### PR TITLE
Add Playwright fixtures and dashboard listing tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,17 +2,11 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
+  workers: 1,
   use: {
     baseURL: "http://localhost:3000",
     screenshot: "only-on-failure",
     bypassCSP: true,
     ...devices["Desktop Chrome"],
-  },
-
-  /* Run your local dev server before starting the tests */
-  webServer: {
-    command: "npm run dev",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
   },
 });

--- a/prisma/test-seed.ts
+++ b/prisma/test-seed.ts
@@ -1,0 +1,54 @@
+import { PrismaClient } from "./generated/sqlite-client";
+
+const db = new PrismaClient();
+
+async function main() {
+  const user = await db.user.create({
+    data: {
+      clerkUserId: "user_2tNBvfz00pi17Kavs9M6wurk1VP",
+    },
+  });
+
+  await db.userProfile.create({
+    data: {
+      userId: user.id,
+      title: "Test User",
+      slug: "test-user",
+      description: "Test profile",
+    },
+  });
+
+  const list = await db.list.create({
+    data: {
+      userId: user.id,
+      title: "Test List",
+      description: "List for testing",
+    },
+  });
+
+  const createListing = async (i: number) => {
+    await db.listing.create({
+      data: {
+        userId: user.id,
+        title: `Seed Listing ${i}`,
+        slug: `seed-listing-${i}`,
+        price: i,
+        description: `Listing number ${i}`,
+        lists: { connect: { id: list.id } },
+      },
+    });
+  };
+
+  for (let i = 1; i <= 105; i++) {
+    await createListing(i);
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 
 test("should sign in and navigate to listings", async ({ page }) => {
   const formValues = {

--- a/tests/dashboard-listings.test.ts
+++ b/tests/dashboard-listings.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from './fixtures';
+
+const userEmail = 'test_playwright+clerk_test@gmail.com';
+
+async function signIn(page) {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.getByLabel('Email address').fill(userEmail);
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.waitForTimeout(1000);
+  await page.waitForSelector('#digit-0-field');
+  await page.keyboard.type('424242');
+  await page.waitForURL('/');
+}
+
+test('create, edit listing and paginate', async ({ page, db }) => {
+  await signIn(page);
+  await page.goto('/dashboard/listings');
+
+  // check pagination shows two pages
+  await expect(page.getByText('Page 1 of 2')).toBeVisible();
+
+  // create listing
+  await page.getByRole('button', { name: 'Create Listing' }).click();
+  await page.getByLabel('Listing Title').fill('Playwright Listing');
+  await page.getByRole('button', { name: 'Create Listing' }).click();
+
+  // edit dialog should open automatically
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await page.getByLabel('Name').fill('Updated Listing');
+  await page.getByLabel('Price').fill('99');
+  await page.getByLabel('Public Note').fill('Updated note');
+  await page.getByLabel('Private Note').fill('Private');
+  await page.getByLabel('Private Note').blur();
+  await page.getByRole('button', { name: 'Close' }).click();
+  await expect(page.getByRole('dialog').locator('text=Edit Listing')).not.toBeVisible();
+
+  const listing = await db.listing.findFirst({ where: { title: 'Updated Listing' } });
+  expect(listing?.price).toBe(99);
+
+  // pagination: go to next page and back
+  await page.getByRole('button', { name: 'Go to next page' }).click();
+  await expect(page.getByText('Page 2 of 2')).toBeVisible();
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,60 @@
+import { test as base, expect } from '@playwright/test';
+import { execSync, spawn } from 'child_process';
+import path from 'path';
+import fs from 'fs/promises';
+import http from 'http';
+import { PrismaClient } from '@prisma/client';
+import { randomUUID } from 'crypto';
+
+async function waitForServer(url: string, timeout = 30000) {
+  const start = Date.now();
+  while (true) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const req = http.get(url, (res) => {
+          res.resume();
+          resolve();
+        });
+        req.on('error', reject);
+      });
+      return;
+    } catch {
+      if (Date.now() - start > timeout) throw new Error('Server start timeout');
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+}
+
+export const test = base.extend<{ db: PrismaClient }>({
+  db: async ({}, use, testInfo) => {
+    const dbFile = path.join(testInfo.outputDir, `test-${randomUUID()}.sqlite`);
+    const databaseUrl = `file:${dbFile}`;
+
+    execSync('npx prisma db push --schema=prisma/schema.prisma', {
+      env: { ...process.env, LOCAL_DATABASE_URL: databaseUrl },
+      stdio: 'inherit',
+    });
+
+    execSync('npx tsx prisma/test-seed.ts', {
+      env: { ...process.env, LOCAL_DATABASE_URL: databaseUrl },
+      stdio: 'inherit',
+    });
+
+    const server = spawn('npm', ['run', 'start'], {
+      env: { ...process.env, LOCAL_DATABASE_URL: databaseUrl, PORT: '3000' },
+      stdio: 'inherit',
+    });
+
+    await waitForServer('http://localhost:3000');
+
+    const prisma = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
+
+    await use(prisma);
+
+    server.kill();
+    await prisma.$disconnect();
+    await fs.unlink(dbFile);
+  },
+});
+
+export { expect } from '@playwright/test';


### PR DESCRIPTION
## Summary
- add a Prisma seed script for Playwright tests
- create test fixtures that spin up a new SQLite DB per test and start the app
- update existing test to use the new fixtures
- add end‑to‑end test for dashboard listings page
- simplify Playwright config for custom server handling

## Testing
- `npx playwright test --list` *(fails: Cannot find package '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_6842174ef4248320a5cf57d1ccb35059