### PR TITLE
Simplify browser test setup and scripts

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -36,6 +36,32 @@ jobs:
       - name: Unit Tests
         run: pnpm test
 
+  browser:
+    name: Browser Tests (Vitest)
+    runs-on: ubuntu-latest
+    env:
+      SKIP_ENV_VALIDATION: "1"
+    steps:
+      - name: Enable corepack
+        run: corepack enable
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm fetch
+      - run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Browser Tests
+        run: pnpm test:browser
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:browser": "vitest --config vitest.browser.config.ts run",
-    "test:browser:watch": "vitest --config vitest.browser.config.ts",
+    "test:browser:headed": "vitest --config vitest.browser.config.ts --browser.headless=false run",
     "test:e2e": "playwright test",
     "test:e2e:attach": "BASE_URL=http://localhost:3000 playwright test"
   },
@@ -149,6 +149,7 @@
     "eslint": "^9.35.0",
     "eslint-config-next": "^15.5.2",
     "jsdom": "^26.1.0",
+    "msw": "^2.12.9",
     "playwright": "^1.58.2",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
@@ -163,5 +164,8 @@
   "ct3aMetadata": {
     "initVersion": "7.37.0"
   },
-  "packageManager": "pnpm@9.12.0"
+  "packageManager": "pnpm@9.12.0",
+  "msw": {
+    "workerDirectory": "public"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,7 +350,7 @@ importers:
         version: 5.1.2(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(playwright@1.58.2)(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(vitest@3.2.4)
+        version: 3.2.4(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(playwright@1.58.2)(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(vitest@3.2.4)
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -366,6 +366,9 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      msw:
+        specifier: ^2.12.9
+        version: 2.12.9(@types/node@24.3.1)(typescript@5.9.2)
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
@@ -395,7 +398,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.3.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.44.0)
+        version: 3.2.4(@types/node@24.3.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.0)
 
 packages:
 
@@ -1238,6 +1241,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -1311,6 +1349,10 @@ packages:
     resolution: {integrity: sha512-ay1X9AobE4BpzG0XPw1gplyLZPGHIgJOovvW23gUrukRegiUP62uzhpRbKNogLlUOynyXeq//prHgPXiebUfWg==}
     cpu: [x64]
     os: [win32]
+
+  '@mswjs/interceptors@0.41.2':
+    resolution: {integrity: sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==}
+    engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1387,6 +1429,15 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@opentelemetry/api-logs@0.203.0':
     resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
@@ -3061,6 +3112,9 @@ packages:
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
@@ -3356,6 +3410,11 @@ packages:
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/ui@3.2.4':
+    resolution: {integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==}
+    peerDependencies:
+      vitest: 3.2.4
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
@@ -3637,6 +3696,10 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -4159,6 +4222,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -4281,6 +4347,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql@16.12.0:
+    resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -4311,6 +4381,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -4441,6 +4514,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -4812,6 +4888,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.12.9:
+    resolution: {integrity: sha512-NYbi51C6M3dujGmcmuGemu68jy12KqQPoVWGeroKToLGsBgrwG5ErM8WctoIIg49/EV49SEvYM9WSqO4G7kNeQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4928,6 +5018,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -4961,6 +5054,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -5320,6 +5416,9 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
+  rettime@0.10.1:
+    resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -5432,6 +5531,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
@@ -5480,12 +5583,19 @@ packages:
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5590,6 +5700,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
 
@@ -5662,8 +5776,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
+  tldts-core@7.0.22:
+    resolution: {integrity: sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==}
+
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tldts@7.0.22:
+    resolution: {integrity: sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==}
     hasBin: true
 
   to-regex-range@5.0.1:
@@ -5676,6 +5797,10 @@ packages:
 
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
   tr46@0.0.3:
@@ -5718,6 +5843,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-fest@5.4.3:
+    resolution: {integrity: sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -5765,6 +5894,9 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
@@ -6018,6 +6150,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -6067,6 +6203,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zod@4.1.5:
     resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
@@ -7262,6 +7402,34 @@ snapshots:
   '@img/sharp-win32-x64@0.34.3':
     optional: true
 
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/confirm@5.1.21(@types/node@24.3.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.3.1)
+      '@inquirer/type': 3.0.10(@types/node@24.3.1)
+    optionalDependencies:
+      '@types/node': 24.3.1
+
+  '@inquirer/core@10.3.2(@types/node@24.3.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.3.1)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.3.1
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/type@3.0.10(@types/node@24.3.1)':
+    optionalDependencies:
+      '@types/node': 24.3.1
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
@@ -7346,6 +7514,15 @@ snapshots:
   '@libsql/win32-x64-msvc@0.3.19':
     optional: true
 
+  '@mswjs/interceptors@0.41.2':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.5.0
@@ -7398,6 +7575,15 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api-logs@0.203.0':
     dependencies:
@@ -9301,6 +9487,8 @@ snapshots:
 
   '@types/shimmer@1.2.0': {}
 
+  '@types/statuses@2.0.6': {}
+
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 24.3.1
@@ -9575,16 +9763,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(playwright@1.58.2)(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(playwright@1.58.2)(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))
+      '@vitest/mocker': 3.2.4(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.21
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.3.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.44.0)
+      vitest: 3.2.4(@types/node@24.3.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.0)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.58.2
@@ -9602,12 +9790,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))':
+  '@vitest/mocker@3.2.4(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.12.9(@types/node@24.3.1)(typescript@5.9.2)
       vite: 7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)
 
   '@vitest/pretty-format@3.2.4':
@@ -9629,6 +9818,18 @@ snapshots:
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/ui@3.2.4(vitest@3.2.4)':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@24.3.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.0)
+    optional: true
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9967,6 +10168,8 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
 
@@ -10635,6 +10838,9 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.8.2:
+    optional: true
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -10758,6 +10964,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.12.0: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -10781,6 +10989,8 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  headers-polyfill@4.0.3: {}
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -10921,6 +11131,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -11255,6 +11467,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@24.3.1)
+      '@mswjs/interceptors': 0.41.2
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.0.2
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.4.3
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@2.0.0: {}
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.3: {}
@@ -11376,6 +11615,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  outvariant@1.4.3: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -11408,6 +11649,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -11703,6 +11946,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  rettime@0.10.1: {}
+
   reusify@1.1.0: {}
 
   rollup@4.50.0:
@@ -11880,6 +12125,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
@@ -11931,12 +12178,16 @@ snapshots:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
 
+  statuses@2.0.2: {}
+
   std-env@3.9.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -12062,6 +12313,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@3.3.1: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.1.13):
@@ -12121,9 +12374,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
+  tldts-core@7.0.22: {}
+
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
+
+  tldts@7.0.22:
+    dependencies:
+      tldts-core: 7.0.22
 
   to-regex-range@5.0.1:
     dependencies:
@@ -12134,6 +12393,10 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.22
 
   tr46@0.0.3: {}
 
@@ -12167,6 +12430,10 @@ snapshots:
   type-fest@0.7.1: {}
 
   type-fest@4.41.0: {}
+
+  type-fest@5.4.3:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -12257,6 +12524,8 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  until-async@3.0.2: {}
 
   update-browserslist-db@1.1.3(browserslist@4.25.4):
     dependencies:
@@ -12388,11 +12657,11 @@ snapshots:
       lightningcss: 1.30.1
       terser: 5.44.0
 
-  vitest@3.2.4(@types/node@24.3.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.44.0):
+  vitest@3.2.4(@types/node@24.3.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))
+      '@vitest/mocker': 3.2.4(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -12415,7 +12684,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.3.1
-      '@vitest/browser': 3.2.4(playwright@1.58.2)(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.12.9(@types/node@24.3.1)(typescript@5.9.2))(playwright@1.58.2)(vite@7.3.1(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(vitest@3.2.4)
+      '@vitest/ui': 3.2.4(vitest@3.2.4)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
@@ -12550,6 +12820,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -12583,5 +12859,7 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   zod@4.1.5: {}

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.12.9'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,3 @@
+import { setupWorker } from "msw/browser";
+
+export const worker = setupWorker();

--- a/tests/browser/example-counter.browser.test.tsx
+++ b/tests/browser/example-counter.browser.test.tsx
@@ -2,28 +2,22 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
 
 function ExampleCounter() {
-  const [value, setValue] = useState(0);
+  const [count, setCount] = useState(0);
 
   return (
     <div>
-      <p>Count: {value}</p>
-
-      <button type="button" onClick={() => setValue((current) => current + 1)}>
+      <p>Count: {count}</p>
+      <button type="button" onClick={() => setCount((value) => value + 1)}>
         Increment
       </button>
     </div>
   );
 }
 
-describe("ExampleCounter (browser mode)", () => {
-  it("updates rendered state after user interaction", () => {
-    render(<ExampleCounter />);
+test("browser mode canary renders and updates", () => {
+  render(<ExampleCounter />);
 
-    expect(screen.getByText("Count: 0")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Increment" }));
-    fireEvent.click(screen.getByRole("button", { name: "Increment" }));
-
-    expect(screen.getByText("Count: 2")).toBeInTheDocument();
-  });
+  expect(screen.getByText("Count: 0")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "Increment" }));
+  expect(screen.getByText("Count: 1")).toBeInTheDocument();
 });

--- a/tests/browser/image-upload-manager.browser.test.tsx
+++ b/tests/browser/image-upload-manager.browser.test.tsx
@@ -1,0 +1,462 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { httpBatchLink } from "@trpc/client";
+import type { Image } from "@prisma/client";
+import type { ImageUploadResponse } from "@/types/image";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { userEvent } from "@vitest/browser/context";
+import { HttpResponse, http } from "msw";
+import { useState } from "react";
+import SuperJSON from "superjson";
+import { afterEach, beforeEach, expect, vi } from "vitest";
+import { test } from "../test-extend";
+
+let reportErrorMock: ReturnType<typeof vi.fn>;
+
+const SLOW_MOTION_MS = Number(process.env.VITE_TEST_SLOW_MS ?? 0);
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO6p5nQAAAAASUVORK5CYII=";
+const TINY_PNG_BYTES = Uint8Array.from(atob(TINY_PNG_BASE64), (char) =>
+  char.charCodeAt(0),
+);
+
+function getImageStorageKeyFromUrl(urlString: string): string | undefined {
+  const url = new URL(urlString);
+
+  const cloudflarePath = url.pathname.match(/^\/cdn-cgi\/image\/[^/]+\/(.+)$/);
+  if (cloudflarePath?.[1]) {
+    const decodedSourceUrl = decodeURI(cloudflarePath[1]);
+    const sourceUrl = new URL(decodedSourceUrl);
+    return sourceUrl.pathname.replace(/^\/+/, "");
+  }
+
+  const directPath = url.pathname.replace(/^\/+/, "");
+  return directPath.length > 0 ? directPath : undefined;
+}
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: () => "mock-event-id",
+  captureMessage: () => "mock-event-id",
+}));
+
+async function pause() {
+  if (SLOW_MOTION_MS <= 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, SLOW_MOTION_MS));
+}
+
+async function createPngFile({
+  fileName,
+  color,
+}: {
+  fileName: string;
+  color: string;
+}) {
+  const canvas = document.createElement("canvas");
+  canvas.width = 400;
+  canvas.height = 400;
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    throw new Error("Canvas context unavailable");
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, 400, 400);
+
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((result) => {
+      if (!result) {
+        reject(new Error("Failed to create PNG blob"));
+        return;
+      }
+
+      resolve(result);
+    }, "image/png");
+  });
+
+  return new File([blob], fileName, { type: "image/png" });
+}
+
+async function renderImageUploadManagerHarness() {
+  const [{ ImageManager }, { ImageUpload }, { createQueryClient }, { api }] =
+    await Promise.all([
+      import("@/components/image-manager"),
+      import("@/components/image-upload"),
+      import("@/trpc/query-client"),
+      import("@/trpc/react"),
+    ]);
+
+  function TestTrpcProvider({ children }: { children: React.ReactNode }) {
+    const [queryClient] = useState(() => createQueryClient());
+    const [trpcClient] = useState(() =>
+      api.createClient({
+        links: [
+          httpBatchLink({
+            transformer: SuperJSON,
+            url: `${window.location.origin}/api/trpc`,
+            headers: () => {
+              const headers = new Headers();
+              headers.set("x-trpc-source", "vitest-browser");
+              return headers;
+            },
+          }),
+        ],
+      }),
+    );
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <api.Provider client={trpcClient} queryClient={queryClient}>
+          {children}
+        </api.Provider>
+      </QueryClientProvider>
+    );
+  }
+
+  function ImageUploadManagerHarness() {
+    const [images, setImages] = useState<Image[]>([]);
+
+    const handleUploadComplete = (result: ImageUploadResponse) => {
+      if (!result.success) {
+        return;
+      }
+
+      setImages((prev) => [...prev, result.image]);
+    };
+
+    return (
+      <div>
+        <ImageManager
+          images={images}
+          onImagesChange={setImages}
+          referenceId="listing-1"
+          type="listing"
+        />
+
+        <ImageUpload
+          type="listing"
+          referenceId="listing-1"
+          onUploadComplete={handleUploadComplete}
+        />
+      </div>
+    );
+  }
+
+  render(
+    <TestTrpcProvider>
+      <ImageUploadManagerHarness />
+    </TestTrpcProvider>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  reportErrorMock = vi.fn();
+  vi.stubGlobal("reportError", reportErrorMock);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+test("uploads, crops/saves, previews, reorders, and deletes images with network-level mocks", async ({
+  worker,
+}) => {
+  const callCounts = {
+    getPresignedUrl: 0,
+    s3Upload: 0,
+    createImage: 0,
+    reorderImages: 0,
+    deleteImage: 0,
+  };
+
+  const createdImageIds: string[] = [];
+  let lastReorderInput: Record<string, unknown> | undefined;
+  let lastDeleteInput: Record<string, unknown> | undefined;
+  const uploadedImageBytesByKey = new Map<
+    string,
+    { bytes: Uint8Array; contentType: string }
+  >();
+
+  worker.use(
+    http.post("/api/trpc/:procedure", async ({ params, request }) => {
+      const procedure = String(params.procedure);
+      const payload = (await request.json()) as Record<string, unknown>;
+      const input =
+        ((payload["0"] as { json?: Record<string, unknown> } | undefined)
+          ?.json as Record<string, unknown> | undefined) ??
+        (payload as Record<string, unknown>);
+
+      if (procedure.includes("image.getPresignedUrl")) {
+        callCounts.getPresignedUrl += 1;
+
+        const sequence = callCounts.getPresignedUrl;
+        return HttpResponse.json([
+          {
+            result: {
+              data: {
+                json: {
+                  presignedUrl: `https://s3-upload.test/listing-1/mock-key-${sequence}.jpg`,
+                  key: `listing-1/mock-key-${sequence}.jpg`,
+                  url: `https://cdn.test/listing-1/mock-key-${sequence}.jpg`,
+                },
+              },
+            },
+          },
+        ]);
+      }
+
+      if (procedure.includes("image.createImage")) {
+        callCounts.createImage += 1;
+
+        const imageId = `img-${callCounts.createImage}`;
+        createdImageIds.push(imageId);
+
+        return HttpResponse.json([
+          {
+            result: {
+              data: {
+                json: {
+                  id: imageId,
+                  url: input?.url,
+                  order: callCounts.createImage - 1,
+                  createdAt: new Date().toISOString(),
+                  updatedAt: new Date().toISOString(),
+                  status: null,
+                  userProfileId: null,
+                  listingId: "listing-1",
+                },
+              },
+            },
+          },
+        ]);
+      }
+
+      if (procedure.includes("image.reorderImages")) {
+        callCounts.reorderImages += 1;
+        lastReorderInput = input;
+
+        return HttpResponse.json([
+          {
+            result: {
+              data: {
+                json: { success: true },
+              },
+            },
+          },
+        ]);
+      }
+
+      if (procedure.includes("image.deleteImage")) {
+        callCounts.deleteImage += 1;
+        lastDeleteInput = input;
+
+        return HttpResponse.json([
+          {
+            result: {
+              data: {
+                json: { success: true },
+              },
+            },
+          },
+        ]);
+      }
+
+      return HttpResponse.json(
+        [
+          {
+            error: {
+              code: -32601,
+              message: `Unhandled test procedure: ${procedure}`,
+              data: {
+                code: "NOT_FOUND",
+                httpStatus: 404,
+                path: procedure,
+              },
+            },
+          },
+        ],
+        { status: 404 },
+      );
+    }),
+    http.put("https://s3-upload.test/:path*", async ({ request }) => {
+      callCounts.s3Upload += 1;
+      expect(request.headers.get("content-type")).toBe("image/jpeg");
+
+      const storageKey = getImageStorageKeyFromUrl(request.url);
+      if (storageKey) {
+        const bytes = new Uint8Array(await request.arrayBuffer());
+        uploadedImageBytesByKey.set(storageKey, {
+          bytes,
+          contentType: request.headers.get("content-type") ?? "image/jpeg",
+        });
+      }
+
+      return new HttpResponse(null, { status: 200 });
+    }),
+    http.get("https://cdn.test/:path*", ({ request }) => {
+      const storageKey = getImageStorageKeyFromUrl(request.url);
+      const uploadedImage = storageKey
+        ? uploadedImageBytesByKey.get(storageKey)
+        : undefined;
+
+      return new HttpResponse(uploadedImage?.bytes ?? TINY_PNG_BYTES, {
+        headers: {
+          "content-type": uploadedImage?.contentType ?? "image/png",
+        },
+      });
+    }),
+  );
+
+  await renderImageUploadManagerHarness();
+
+  const getUploadInput = () =>
+    document.getElementById("image-upload-input") as HTMLInputElement | null;
+
+  expect(getUploadInput()).toBeTruthy();
+
+  const getImageOrder = () =>
+    screen
+      .getAllByTestId("image-item")
+      .map((item) => item.getAttribute("data-image-id"))
+      .filter((id): id is string => Boolean(id));
+
+  const waitForManagedImagesToSettle = async (expectedCount: number) => {
+    await waitFor(() => {
+      const items = screen.getAllByTestId("image-item");
+      expect(items).toHaveLength(expectedCount);
+
+      for (const item of items) {
+        const img = item.querySelector("img") as HTMLImageElement | null;
+        expect(img).toBeTruthy();
+        expect(img?.complete).toBe(true);
+      }
+    }, { timeout: 10_000 });
+  };
+
+  const uploadOneImage = async (file: File, expectedImageCount: number) => {
+    const input = getUploadInput();
+    expect(input).toBeTruthy();
+
+    await pause();
+    fireEvent.change(input!, {
+      target: {
+        files: [file],
+      },
+    });
+
+    const uploadButton = await screen.findByRole("button", { name: "Upload" });
+    await waitFor(() => {
+      expect(uploadButton).toBeEnabled();
+    }, { timeout: 10_000 });
+
+    await pause();
+    await userEvent.click(uploadButton);
+
+    await waitFor(() => {
+      expect(reportErrorMock).not.toHaveBeenCalled();
+    }, { timeout: 10_000 });
+
+    await waitFor(() => {
+      expect(callCounts.createImage).toBe(expectedImageCount);
+    }, { timeout: 10_000 });
+
+    await waitForManagedImagesToSettle(expectedImageCount);
+
+    await pause();
+  };
+
+  await uploadOneImage(
+    await createPngFile({ fileName: "flower-red.png", color: "#ff4d4f" }),
+    1,
+  );
+  await uploadOneImage(
+    await createPngFile({ fileName: "flower-blue.png", color: "#4f7cff" }),
+    2,
+  );
+
+  await waitForManagedImagesToSettle(2);
+
+  await pause();
+  await userEvent.click(screen.getAllByRole("button", { name: /view 1 image/i })[0]!);
+  expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+  await pause();
+  await userEvent.keyboard("{Escape}");
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  const initialOrder = getImageOrder();
+  const firstId = initialOrder[0];
+  const secondId = initialOrder[1];
+
+  if (!firstId || !secondId) {
+    throw new Error("Expected at least two images to reorder");
+  }
+
+  await pause();
+  const firstHandle = document.querySelector(
+    `[data-testid="image-drag-handle"][data-image-id="${firstId}"]`,
+  ) as HTMLElement | null;
+  expect(firstHandle).toBeTruthy();
+  await userEvent.click(firstHandle!);
+
+  let reorderTriggered = false;
+  const directions = ["{ArrowRight}", "{ArrowDown}", "{ArrowLeft}", "{ArrowUp}"];
+  for (const direction of directions) {
+    const reorderCallsBefore = callCounts.reorderImages;
+
+    await userEvent.keyboard("{Space}");
+    await userEvent.keyboard(direction);
+    await userEvent.keyboard("{Space}");
+
+    try {
+      await waitFor(() => {
+        expect(callCounts.reorderImages).toBeGreaterThan(reorderCallsBefore);
+      }, { timeout: 1_500 });
+      reorderTriggered = true;
+      break;
+    } catch {
+      await userEvent.keyboard("{Escape}");
+    }
+  }
+
+  expect(reorderTriggered).toBe(true);
+
+  const reordered = getImageOrder();
+  expect(reordered).not.toEqual(initialOrder);
+
+  await pause();
+  const deleteButton = screen.getAllByTestId("image-delete-button")[0] as HTMLButtonElement;
+  await userEvent.click(deleteButton);
+  const confirmDeleteButton = await screen.findByRole("button", {
+    name: /^Delete$/,
+  });
+  expect(confirmDeleteButton).toBeInTheDocument();
+
+  await pause();
+  await userEvent.click(confirmDeleteButton);
+
+  await waitForManagedImagesToSettle(1);
+
+  expect(callCounts.getPresignedUrl).toBe(2);
+  expect(callCounts.s3Upload).toBe(2);
+  expect(callCounts.createImage).toBe(2);
+  expect(callCounts.reorderImages).toBe(1);
+  expect(callCounts.deleteImage).toBe(1);
+  expect(createdImageIds).toEqual(["img-1", "img-2"]);
+  expect(lastReorderInput?.type).toBe("listing");
+  expect(lastReorderInput?.referenceId).toBe("listing-1");
+  expect(lastDeleteInput?.type).toBe("listing");
+  expect(lastDeleteInput?.referenceId).toBe("listing-1");
+});

--- a/tests/browser/mocks/next-image.tsx
+++ b/tests/browser/mocks/next-image.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface NextImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src: string;
+  alt: string;
+  unoptimized?: boolean;
+  priority?: boolean;
+}
+
+const NextImage = React.forwardRef<HTMLImageElement, NextImageProps>(
+  function NextImage(
+    { src, alt, unoptimized: _unoptimized, priority: _priority, ...props },
+    ref,
+  ) {
+    return <img ref={ref} src={src} alt={alt} {...props} />;
+  },
+);
+
+export default NextImage;

--- a/tests/browser/setup-browser.ts
+++ b/tests/browser/setup-browser.ts
@@ -1,0 +1,12 @@
+import "@/styles/globals.css";
+
+if (typeof globalThis.process === "undefined") {
+  Object.defineProperty(globalThis, "process", {
+    value: { env: { NODE_ENV: "test" } },
+    writable: true,
+  });
+}
+
+const env = process.env as Record<string, string | undefined>;
+env.NODE_ENV = "test";
+env.NEXT_PUBLIC_CLOUDFLARE_URL = "https://cdn.test";

--- a/tests/test-extend.ts
+++ b/tests/test-extend.ts
@@ -1,0 +1,30 @@
+import { worker } from "../src/mocks/browser";
+import { test as testBase } from "vitest";
+
+export const test = testBase.extend<{ worker: typeof worker }>({
+  worker: [
+    async ({}, use) => {
+      await worker.start({
+        quiet: true,
+        serviceWorker: { url: "/mockServiceWorker.js" },
+        onUnhandledRequest(request, print) {
+          const url = new URL(request.url);
+
+          if (
+            url.origin === location.origin &&
+            url.pathname.startsWith("/api")
+          ) {
+            print.error();
+            throw new Error(
+              `Unhandled API request: ${request.method} ${request.url}`,
+            );
+          }
+        },
+      });
+      await use(worker);
+      worker.resetHandlers();
+      worker.stop();
+    },
+    { auto: true },
+  ],
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,7 @@
     "prisma/generated/**/*",
     "prisma/schema.postgres.prisma",
     "playwright-report",
+    "public/mockServiceWorker.js",
     "src/components/ui/**/*"
   ]
 }

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
-    setupFiles: ["./vitest.setup.ts"],
+    setupFiles: ["./vitest.setup.ts", "./tests/browser/setup-browser.ts"],
     include: ["tests/browser/**/*.browser.test.tsx"],
     exclude: ["**/node_modules/**", "**/dist/**"],
     browser: {
@@ -24,6 +24,7 @@ export default defineConfig({
         "prisma/generated/sqlite-client",
       ),
       "@/env": path.resolve(__dirname, "src/env.js"),
+      "next/image": path.resolve(__dirname, "tests/browser/mocks/next-image.tsx"),
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
       // Exclude Playwright e2e specs by pattern
       "tests/**/*.e2e.ts",
       "tests/**/*.e2e.tsx",
+      // Exclude browser-mode specs (run via vitest.browser.config.ts)
+      "tests/**/*.browser.test.ts",
+      "tests/**/*.browser.test.tsx",
+      "tests/browser/**",
     ],
   },
   resolve: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,2 +1,1 @@
-// Basic test environment setup for jsdom
 import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
Summary
- streamline the vitest configs and setup files so only `test:browser` and `test:browser:headed` remain while keeping the new browser helpers tidy
- adjust MSW/browser mocks and related assets to match the simplified flow and avoid duplicated fixtures
- clean up the browser tests themselves (handlers, image mocks, setup) so they align with the leaner infrastructure

Testing
- `pnpm test` *(fails: browser-specific suites still hit MSW/browser context errors when run in the Node pool)*