### PR TITLE
Disable Sentry during E2E runs

### DIFF
--- a/.codex/napkin.md
+++ b/.codex/napkin.md
@@ -2,6 +2,7 @@
 
 ## Log
 
+- 2026-02-09 - e2e observability - Force `NEXT_PUBLIC_SENTRY_ENABLED=false` in Playwright local config and `webServer.env` so local E2E never initializes Sentry.
 - 2026-02-07 - e2e cleanup - Full suite stabilized after removing most custom timeout/retry/poll code and validating with repeats.
 - 2026-02-07 - e2e issue - Profile content sometimes disappeared after reload due autosave race; fixed by waiting for `userProfile.updateContent` response after blur.
 - 2026-02-07 - e2e issue - Clerk modal has variant state: after email click `Continue`; after code entry do not submit again (auto-submit). If warning says code wasn't sent, click `Continue` once.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 const e2ePort = process.env.E2E_PORT ?? "3100";
 const baseURL = process.env.BASE_URL ?? `http://localhost:${e2ePort}`;
+process.env.NEXT_PUBLIC_SENTRY_ENABLED = "false";
 
 // Pre-provision temp DB path when running locally (not attaching to BASE_URL)
 // DB template copy and clearing is handled by global-setup.ts
@@ -66,6 +67,7 @@ export default defineConfig({
         env: {
           ...process.env,
           PORT: e2ePort,
+          NEXT_PUBLIC_SENTRY_ENABLED: "false",
           USE_TURSO_DB: "false",
           LOCAL_DATABASE_URL: process.env.LOCAL_DATABASE_URL!,
           E2E_TEST_DB_URL: process.env.E2E_TEST_DB_URL!,


### PR DESCRIPTION
## Summary
- ensure `NEXT_PUBLIC_SENTRY_ENABLED=false` is set globally so Playwright launches never initialize Sentry
- note the behavior in `.codex/napkin.md` to keep the repo memory aligned with the new config

## Testing
- Not run (not requested)