### PR TITLE
Clarify robots rules for SEO bots

### DIFF
--- a/.codex/napkin.md
+++ b/.codex/napkin.md
@@ -11,6 +11,8 @@
 - 2026-02-08 - e2e issue - `scrollIntoViewIfNeeded()` on row-action trigger can throw `Element is not attached to the DOM` during table re-render; direct locator `.click()` was more stable for this trigger.
 - 2026-02-08 - e2e issue - URL-param assertions (`expect.poll` on `page.url()`) were flaky in CI/act despite correct UI behavior; replacing with table/page-indicator assertions removed false negatives.
 - 2026-02-08 - e2e issue - `page.locator("table").first()` is brittle when pages render multiple tables; scope all row locators to container test ids (`list-table`, `manage-list-table`) to avoid wrong-table clicks and detach.
+- 2026-02-09 - seo/public routes - Avoid `as const` on Prisma `where` filter objects (`OR` arrays become readonly and break Prisma + no-unsafe typing across route outputs).
+- 2026-02-09 - tooling - `pnpm install` runs `prisma generate` and may rewrite generated client paths/binary targets to local machine values; revert generated noise before finalizing changes.
 
 ## Preferences
 

--- a/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/_seo/metadata.ts
+++ b/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/_seo/metadata.ts
@@ -22,6 +22,7 @@ async function createListingMetadata(listing: Listing | null, url: string) {
       pageUrl: url,
       title: "Listing Not Found",
       description: "The daylily listing you are looking for does not exist.",
+      robots: "noindex, nofollow",
       openGraph: {
         title: "Listing Not Found",
         description: "The daylily listing you are looking for does not exist.",
@@ -99,6 +100,7 @@ async function createListingMetadata(listing: Listing | null, url: string) {
       pageUrl: `${url}/${listing.userId}/${listing.id}`,
       title: "Daylily | Daylily Catalog",
       description: "View this daylily from our catalog",
+      robots: "noindex, nofollow",
       openGraph: {
         title: "Daylily | Daylily Catalog",
         description: "View this daylily from our catalog",

--- a/src/app/(public)/[userSlugOrId]/_seo/metadata.ts
+++ b/src/app/(public)/[userSlugOrId]/_seo/metadata.ts
@@ -32,6 +32,7 @@ async function createProfileMetadata(
       description: "The daylily catalog you are looking for does not exist.",
       imageUrl: IMAGES.DEFAULT_CATALOG,
       pageUrl: url,
+      robots: "noindex, nofollow",
       openGraph: {
         title: "Catalog Not Found",
         description: "The daylily catalog you are looking for does not exist.",
@@ -130,8 +131,8 @@ async function createProfileMetadata(
       description: "Browse our collection of beautiful daylilies.",
       imageUrl: IMAGES.DEFAULT_CATALOG,
       pageUrl: `${url}/${profile.id}`,
-      // Let Google show big thumbnails in Search/Discover.
-      robots: "index, follow, max-image-preview:large",
+      // Avoid indexing metadata generated from fallback errors.
+      robots: "noindex, nofollow",
       openGraph: {
         title: "Daylily Catalog",
         description: "Browse our collection of beautiful daylilies.",

--- a/src/app/(public)/_seo/json-ld.ts
+++ b/src/app/(public)/_seo/json-ld.ts
@@ -9,11 +9,49 @@ type MetadataInput = {
   [key: string]: unknown;
 };
 
+const HOME_PAGE_FAQ = [
+  {
+    question: "What is Daylily Catalog?",
+    answer:
+      "Daylily Catalog is a web app for growers to publish searchable daylily catalogs, share photos, and organize listings using trusted cultivar data.",
+  },
+  {
+    question: "How large is the cultivar database?",
+    answer:
+      "Daylily Catalog supports listings powered by a database of more than 100,000 registered cultivars, making it easier to create accurate listings quickly.",
+  },
+  {
+    question: "How do I browse public catalogs?",
+    answer:
+      "You can browse public grower catalogs at /catalogs, then open each catalog to view listings, photos, and additional daylily details.",
+  },
+] as const;
+
 // Function to generate JSON-LD for SoftwareApplication schema
 async function createSoftwareApplicationJsonLd(metadata: MetadataInput) {
   try {
-    // Create both website and application schemas
+    // Create a schema set that covers both classic SEO and GEO use-cases.
     const schemas = [
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        name: METADATA_CONFIG.SITE_NAME,
+        url: metadata.url,
+        description: metadata.description,
+        inLanguage: "en-US",
+      },
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        name: METADATA_CONFIG.SITE_NAME,
+        url: metadata.url,
+        description: metadata.description,
+        isPartOf: {
+          "@type": "WebSite",
+          name: METADATA_CONFIG.SITE_NAME,
+          url: metadata.url,
+        },
+      },
       // SoftwareApplication schema (primary schema for the platform)
       {
         "@context": "https://schema.org",
@@ -23,6 +61,12 @@ async function createSoftwareApplicationJsonLd(metadata: MetadataInput) {
         url: metadata.url,
         applicationCategory: "BusinessApplication",
         operatingSystem: "Web",
+        offers: {
+          "@type": "Offer",
+          price: "0",
+          priceCurrency: "USD",
+          availability: "https://schema.org/InStock",
+        },
       },
       // Organization schema for the company
       {
@@ -30,8 +74,20 @@ async function createSoftwareApplicationJsonLd(metadata: MetadataInput) {
         "@type": "Organization",
         name: METADATA_CONFIG.SITE_NAME,
         url: metadata.url,
-        logo: `${metadata.url}/images/logo.png`,
+        logo: `${metadata.url}/favicon.ico`,
         description: metadata.description,
+      },
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: HOME_PAGE_FAQ.map((faq) => ({
+          "@type": "Question",
+          name: faq.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: faq.answer,
+          },
+        })),
       },
     ];
 
@@ -50,6 +106,12 @@ async function createSoftwareApplicationJsonLd(metadata: MetadataInput) {
 
     // Minimal valid SoftwareApplication JSON-LD as fallback
     return [
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        name: METADATA_CONFIG.SITE_NAME,
+        url: metadata.url,
+      },
       {
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",

--- a/src/app/(public)/_seo/metadata.ts
+++ b/src/app/(public)/_seo/metadata.ts
@@ -14,6 +14,14 @@ async function createHomePageMetadata(url: string) {
     title,
     description,
     imageUrl,
+    robots: "index, follow, max-image-preview:large",
+    keywords: [
+      "daylily catalog",
+      "daylily database",
+      "daylily growers",
+      "daylily listings",
+      "garden catalog",
+    ],
     openGraph: {
       title,
       description,

--- a/src/app/(public)/catalogs/page.tsx
+++ b/src/app/(public)/catalogs/page.tsx
@@ -50,6 +50,10 @@ export async function generateMetadata(): Promise<Metadata> {
       site: METADATA_CONFIG.TWITTER_HANDLE,
       images: [metadata.imageUrl],
     },
+    robots: "index, follow, max-image-preview:large",
+    alternates: {
+      canonical: "/catalogs",
+    },
   };
 }
 
@@ -57,6 +61,7 @@ export default async function CatalogsPage() {
   const catalogs = await getPublicProfiles();
 
   const baseUrl = getBaseUrl();
+  const catalogsUrl = `${baseUrl}/catalogs`;
 
   // Create breadcrumb schema
   const breadcrumbSchema = createBreadcrumbListSchema(
@@ -64,12 +69,78 @@ export default async function CatalogsPage() {
     createCatalogsBreadcrumbs(baseUrl),
   );
 
+  const collectionSchema = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Daylily Catalogs",
+    description:
+      "Browse public daylily grower catalogs and discover unique collections by location, listing count, and catalog details.",
+    url: catalogsUrl,
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: catalogs.length,
+      itemListElement: catalogs.slice(0, 100).map((catalog, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `${baseUrl}/${catalog.id}`,
+        name: catalog.title ?? "Unnamed Garden",
+        ...(catalog.description && {
+          description: catalog.description,
+        }),
+      })),
+    },
+    isPartOf: {
+      "@type": "WebSite",
+      name: METADATA_CONFIG.SITE_NAME,
+      url: baseUrl,
+    },
+  };
+
+  const catalogsFaqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "How do I find a daylily catalog to browse?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Open the catalogs page and use the search box to find growers by catalog title, location, or description.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What can I see in a public daylily catalog?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Each catalog can include listing photos, descriptions, prices, and curated lists that help you explore a grower’s collection.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Are hidden listings shown on public catalogs?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "No. Listings marked as hidden are excluded from public catalog pages and are not included in sitemap entries.",
+        },
+      },
+    ],
+  };
+
   return (
     <MainContent>
       {/* Add breadcrumb schema - keeping only what works for rich results */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(catalogsFaqSchema) }}
       />
 
       <PageHeader

--- a/src/app/auth-error/layout.tsx
+++ b/src/app/auth-error/layout.tsx
@@ -1,0 +1,23 @@
+import { type ReactNode } from "react";
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+    googleBot: {
+      index: false,
+      follow: false,
+      noimageindex: true,
+    },
+  },
+};
+
+export default function AuthErrorLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return children;
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -10,6 +10,7 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { DashboardClientWrapper } from "./_components/dashboard-client-wrapper";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cookies } from "next/headers";
+import { type Metadata } from "next";
 
 // Simple fallback loading state for the Suspense boundary
 function DashboardFallback() {
@@ -31,6 +32,18 @@ function DashboardFallback() {
 }
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+    googleBot: {
+      index: false,
+      follow: false,
+      noimageindex: true,
+    },
+  },
+};
 
 export default async function DashboardLayout({
   children,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,20 +3,37 @@ import { type MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = getBaseUrl();
+  const disallowPrivateRoutes = [
+    "/dashboard/",
+    "/api/",
+    "/trpc/",
+    "/auth-error",
+    "/subscribe/success",
+    "/catalog/",
+  ];
 
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-      disallow: [
-        "/dashboard/",
-        "/api/",
-        "/trpc/",
-        "/auth-error",
-        "/subscribe/success",
-        "/catalog/",
-      ],
-    },
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: disallowPrivateRoutes,
+      },
+      {
+        userAgent: [
+          "Googlebot",
+          "Bingbot",
+          "msnbot",
+          "PerplexityBot",
+          "GPTBot",
+          "ChatGPT-User",
+          "ClaudeBot",
+          "anthropic-ai",
+        ],
+        allow: "/",
+        disallow: disallowPrivateRoutes,
+      },
+    ],
     sitemap: `${baseUrl}/sitemap.xml`,
     host: baseUrl,
   };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,17 @@
 import { db } from "@/server/db";
 import { getBaseUrl } from "@/lib/utils/getBaseUrl";
 import { type MetadataRoute } from "next";
+import { STATUS } from "@/config/constants";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = getBaseUrl();
   const sitemap: MetadataRoute.Sitemap = [];
+  const publicListingVisibilityFilter = {
+    OR: [{ status: null }, { NOT: { status: STATUS.HIDDEN } }],
+  };
 
   // Add static pages
-  const staticPages = ["", "/catalogs", "/auth-error"];
+  const staticPages = ["", "/catalogs"];
 
   staticPages.forEach((path) => {
     sitemap.push({
@@ -26,6 +30,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         select: {
           updatedAt: true,
         },
+      },
+    },
+    where: {
+      listings: {
+        some: publicListingVisibilityFilter,
       },
     },
   });
@@ -47,6 +56,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       userId: true,
       updatedAt: true,
     },
+    where: publicListingVisibilityFilter,
   });
 
   listings.forEach((listing) => {

--- a/src/server/api/routers/public.ts
+++ b/src/server/api/routers/public.ts
@@ -17,6 +17,7 @@ import {
 import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
 import { env } from "@/env";
 import { cartItemSchema } from "@/types";
+import { STATUS } from "@/config/constants";
 
 // Initialize SES client
 const ses = new SESClient({
@@ -29,8 +30,12 @@ const ses = new SESClient({
 
 // Helper function to get the full listing data with all relations
 async function getFullListingData(listingId: string) {
-  const listing = await db.listing.findUnique({
-    where: { id: listingId },
+  const publicListingVisibilityFilter = {
+    OR: [{ status: null }, { NOT: { status: STATUS.HIDDEN } }],
+  };
+
+  const listing = await db.listing.findFirst({
+    where: { id: listingId, ...publicListingVisibilityFilter },
     select: listingSelect,
   });
 

--- a/src/server/db/getUserAndListingIdsAndSlugs.ts
+++ b/src/server/db/getUserAndListingIdsAndSlugs.ts
@@ -1,6 +1,11 @@
+import { STATUS } from "@/config/constants";
 import { db } from "../db";
 
 export async function getUserAndListingIdsAndSlugs() {
+  const publicListingVisibilityFilter = {
+    OR: [{ status: null }, { NOT: { status: STATUS.HIDDEN } }],
+  };
+
   const users = await db.user.findMany({
     select: {
       id: true,
@@ -10,10 +15,16 @@ export async function getUserAndListingIdsAndSlugs() {
         },
       },
       listings: {
+        where: publicListingVisibilityFilter,
         select: {
           id: true,
           slug: true,
         },
+      },
+    },
+    where: {
+      listings: {
+        some: publicListingVisibilityFilter,
       },
     },
   });


### PR DESCRIPTION
Summary
- keep a single `disallowPrivateRoutes` list and let all crawlers (including Googlebot, Bingbot, GPTBot, ClaudeBot, etc.) reuse it so public pages stay indexable while private routes stay blocked
- keep sitemap/host metadata unchanged so search engines continue discovering the public site map
Testing
- Not run (not requested)