### PR TITLE
Add contact seller CTA to catalog header

### DIFF
--- a/.codex/napkin.md
+++ b/.codex/napkin.md
@@ -2,6 +2,9 @@
 
 ## Log
 
+- 2026-02-09 - conversion UX - Reused `FloatingCartButton` dialog state for a new top-of-profile `Contact Seller` CTA while keeping the bottom-right floating button.
+- 2026-02-09 - product review correction - Public listing has a bottom-right floating contact/cart action; it was easy to miss in snapshots because icon-only controls lacked clear labels in the accessibility tree.
+- 2026-02-09 - product review - When asked for customer-value feedback, run Playwright on public flows (home -> catalogs -> catalog -> listing -> auth modal) and prioritize activation, conversion, and retention gaps with concrete examples.
 - 2026-02-09 - e2e observability - Force `NEXT_PUBLIC_SENTRY_ENABLED=false` in Playwright local config and `webServer.env` so local E2E never initializes Sentry.
 - 2026-02-07 - e2e cleanup - Full suite stabilized after removing most custom timeout/retry/poll code and validating with repeats.
 - 2026-02-07 - e2e issue - Profile content sometimes disappeared after reload due autosave race; fixed by waiting for `userProfile.updateContent` response after blur.
@@ -17,6 +20,7 @@
 
 - Use the term `napkin` (not `codex napkin`).
 - Keep E2E tests UI-only; if UI behavior fails, test should fail (don't hide with non-UI shortcuts).
+- For product-feedback asks, return prioritized recommendations tied to activation, conversion, and retention.
 
 ## Patterns That Work
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ node_modules/
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/src/app/(public)/[userSlugOrId]/_components/profile-section.tsx
+++ b/src/app/(public)/[userSlugOrId]/_components/profile-section.tsx
@@ -8,6 +8,7 @@ import {
   LastUpdatedBadge,
   MemberSince,
 } from "@/components/profile/profile-badges";
+import { FloatingCartButton } from "@/components/floating-cart-button";
 import { type RouterOutputs } from "@/trpc/react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { H1, P } from "@/components/typography";
@@ -45,6 +46,12 @@ export function ProfileSection({ profile }: ProfileSectionProps) {
         <ListingCountBadge count={profile._count.listings} />
         <ListCountBadge count={profile.lists.length} lists={profile.lists} />
       </div>
+
+      <FloatingCartButton
+        userId={profile.id}
+        userName={profile.title ?? undefined}
+        showTopButton
+      />
     </div>
   );
 }

--- a/src/app/(public)/[userSlugOrId]/page.tsx
+++ b/src/app/(public)/[userSlugOrId]/page.tsx
@@ -12,7 +12,6 @@ import { getErrorCode, tryCatch } from "@/lib/utils";
 import { generateProfileMetadata } from "./_seo/metadata";
 import { CatalogContent } from "./_components/catalog-content";
 import { ProfilePageSEO } from "./_components/profile-seo";
-import { FloatingCartButton } from "@/components/floating-cart-button";
 
 export const revalidate = 3600;
 export const dynamicParams = true;
@@ -114,12 +113,6 @@ export default async function Page({ params }: PageProps) {
             />
           </Suspense>
         </div>
-
-        {/* Add Floating Cart Button */}
-        <FloatingCartButton
-          userId={initialProfile.id}
-          userName={initialProfile.title ?? undefined}
-        />
       </MainContent>
     </>
   );

--- a/src/components/floating-cart-button.tsx
+++ b/src/components/floating-cart-button.tsx
@@ -15,21 +15,44 @@ import { useState } from "react";
 interface FloatingCartButtonProps {
   userId: string;
   userName?: string;
+  showTopButton?: boolean;
 }
 
 export function FloatingCartButton({
   userId,
   userName,
+  showTopButton = false,
 }: FloatingCartButtonProps) {
   const { itemCount } = useCart(userId);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      {showTopButton && (
+        <Button
+          type="button"
+          className="w-full sm:w-auto"
+          onClick={() => setIsDialogOpen(true)}
+        >
+          <MessageCircle className="h-4 w-4" />
+          <span>
+            Contact Seller
+            {itemCount > 0 &&
+              ` (${itemCount} ${itemCount === 1 ? "item" : "items"})`}
+          </span>
+        </Button>
+      )}
+
       <DialogTrigger asChild>
         <Button
+          type="button"
           className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full shadow-md"
           variant="default"
+          aria-label={
+            itemCount > 0
+              ? `Contact seller and view cart (${itemCount} ${itemCount === 1 ? "item" : "items"})`
+              : "Contact seller"
+          }
         >
           {itemCount > 0 ? (
             <>


### PR DESCRIPTION
Summary
- add a top-page Contact Seller button by reusing `FloatingCartButton` and expose a `showTopButton` flag so the profile header mirrors the floating dialog trigger
- record the recent UX/product feedback notes in `.codex/napkin.md` to preserve context from the latest review

Testing
- Not run (not requested)