### PR TITLE
Force static cultivar routes and canonicalize middleware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,40 @@ seed script for e2e, QA, or demos.
 Playwright local runs auto-provision a temp DB and start `pnpm dev` unless
 `BASE_URL` is set. Local E2E uses `E2E_PORT` (default `3100`).
 
+## Local "Prod" Build Workflow (with Production Data Snapshot)
+
+Use this when you need production-mode behavior locally with a local copy of
+production data.
+
+```sh
+# Pull local copy of prod DB to file
+pnpm env:dev bash scripts/db-backup.sh
+
+# Build in production mode against local prod DB copy
+LOCAL_DATABASE_URL="file:./local-prod-copy-daylily-catalog.db" USE_TURSO_DB=false NODE_ENV=production pnpm env:dev pnpm build
+
+# Run production server locally against local prod DB copy
+LOCAL_DATABASE_URL="file:./local-prod-copy-daylily-catalog.db" USE_TURSO_DB=false NODE_ENV=production pnpm env:dev pnpm start
+```
+
+## Static Public Pages + Search Params
+
+For SEO-focused public routes, keep the server render static and treat query
+params as client-only UI state.
+
+- Public SEO pages should render as static/ISR (not request-time dynamic).
+- Do not read `searchParams` in server `page.tsx`, `layout.tsx`, or
+  `generateMetadata` for static public routes.
+- Canonical URLs should be query-free (base path only).
+- Parse and apply query params in client components only (for sort/filter/toggle
+  UX via `useSearchParams` + `router.replace`).
+- Query params should not change server data fetching, metadata, or structured
+  data for static public pages.
+- For routes that should only serve build-known slugs, use
+  `dynamic = "force-static"` and `dynamicParams = false`.
+- Verify behavior with the local prod workflow and check headers for static
+  pages (`x-nextjs-cache: HIT` and `Cache-Control: s-maxage=...`).
+
 ## Repo Structure (High-Level)
 
 - `src/app/` Next.js App Router (routes + route-level `_components`)

--- a/src/app/(public)/cultivar/[cultivarNormalizedName]/page.tsx
+++ b/src/app/(public)/cultivar/[cultivarNormalizedName]/page.tsx
@@ -20,7 +20,8 @@ import { CultivarRelatedSection } from "./_components/cultivar-related-section";
 import { Muted } from "@/components/typography";
 
 export const revalidate = 86400;
-export const dynamicParams = true;
+export const dynamic = "force-static";
+export const dynamicParams = false;
 
 const getCultivarRouteSegmentsCached = cache(getCultivarRouteSegments);
 const getPublicCultivarPageCached = cache(getPublicCultivarPage);
@@ -29,7 +30,6 @@ interface PageProps {
   params: Promise<{
     cultivarNormalizedName: string;
   }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 function getCultivarJsonLd(
@@ -155,9 +155,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-export default async function CultivarPage({ params, searchParams }: PageProps) {
+export default async function CultivarPage({ params }: PageProps) {
   const { cultivarNormalizedName } = await params;
-  const queryParams = await searchParams;
 
   const cultivarPage = await getPublicCultivarPageCached(cultivarNormalizedName);
 
@@ -168,25 +167,7 @@ export default async function CultivarPage({ params, searchParams }: PageProps) 
   const canonicalSegment = toCultivarRouteSegment(cultivarPage.cultivar.normalizedName);
 
   if (canonicalSegment && cultivarNormalizedName !== canonicalSegment) {
-    const query = new URLSearchParams();
-
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (typeof value === "string") {
-        query.append(key, value);
-        return;
-      }
-
-      if (Array.isArray(value)) {
-        value.forEach((entry) => query.append(key, entry));
-      }
-    });
-
-    const queryString = query.toString();
-    permanentRedirect(
-      queryString
-        ? `/cultivar/${canonicalSegment}?${queryString}`
-        : `/cultivar/${canonicalSegment}`,
-    );
+    permanentRedirect(`/cultivar/${canonicalSegment}`);
   }
 
   const baseUrl = getBaseUrl();


### PR DESCRIPTION
Summary
- Document the local prod build workflow and static-public route expectations in `AGENTS.md`.
- Make the public cultivar page fully static, drop dynamic params, and simplify canonical redirects since middleware now enforces normalized segments.
- Let the middleware decode cultivar URLs, compute canonical slugs, and redirect stale paths before the page renders.

Testing
- Not run (not requested)