### PR TITLE
E2e test failures

### DIFF
--- a/tests/e2e/public-profile-first-response.e2e.ts
+++ b/tests/e2e/public-profile-first-response.e2e.ts
@@ -1,10 +1,12 @@
 import { createAuthedUser } from "../../src/lib/test-utils/e2e-users";
 import { withTempE2EDb } from "../../src/lib/test-utils/e2e-db";
+import { PUBLIC_PROFILE_LISTINGS_PAGE_SIZE } from "../../src/config/constants";
 import { test, expect } from "./fixtures/app-fixtures";
 
 const PROFILE_SLUG = "static-first-response-farm";
 const PROFILE_TITLE = "Static First Response Farm";
 const LISTING_TITLE_PREFIX = "Static First Listing";
+const LISTING_COUNT_FOR_TWO_PAGES = PUBLIC_PROFILE_LISTINGS_PAGE_SIZE + 1;
 
 function pad(value: number) {
   return String(value).padStart(3, "0");
@@ -25,7 +27,7 @@ test.describe("public profile first-response content @local", () => {
         },
       });
 
-      for (let i = 1; i <= 13; i++) {
+      for (let i = 1; i <= LISTING_COUNT_FOR_TWO_PAGES; i++) {
         const suffix = pad(i);
         await db.listing.create({
           data: {
@@ -57,6 +59,8 @@ test.describe("public profile first-response content @local", () => {
   test("first HTML response contains profile and listing content for page 1 and page 2", async ({
     request,
   }) => {
+    const page2FirstListingTitle = `${LISTING_TITLE_PREFIX} ${pad(LISTING_COUNT_FOR_TWO_PAGES)}`;
+
     const page1Response = await request.get(`/${PROFILE_SLUG}`);
     expect(page1Response.status()).toBe(200);
     const page1Html = await page1Response.text();
@@ -65,7 +69,7 @@ test.describe("public profile first-response content @local", () => {
     const page2Response = await request.get(`/${PROFILE_SLUG}?page=2`);
     expect(page2Response.status()).toBe(200);
     const page2Html = await page2Response.text();
-    await assertFirstDocumentContent(page2Html, `${LISTING_TITLE_PREFIX} 013`);
+    await assertFirstDocumentContent(page2Html, page2FirstListingTitle);
 
     const page1Prerender = page1Response.headers()["x-nextjs-prerender"];
     const page2Prerender = page2Response.headers()["x-nextjs-prerender"];


### PR DESCRIPTION
Update `public-profile-first-response.e2e.ts` to use the current `PUBLIC_PROFILE_LISTINGS_PAGE_SIZE` for seeding data, fixing a pagination test failure.

The E2E test `public-profile-first-response.e2e.ts` was failing because it seeded only 13 listings and expected a second page. However, the `PUBLIC_PROFILE_LISTINGS_PAGE_SIZE` is now 50, meaning 13 listings only constitute a single page, leading to a 404 when requesting `?page=2`. This PR updates the test to seed `PUBLIC_PROFILE_LISTINGS_PAGE_SIZE + 1` listings and dynamically assert content, making it resilient to pagination configuration changes.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-60aa0994-073d-4efc-ae9f-5dd591291979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-60aa0994-073d-4efc-ae9f-5dd591291979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

