### PR TITLE
Cancel dependent workflows on gate failure

### DIFF
--- a/.codex/napkin.md
+++ b/.codex/napkin.md
@@ -71,6 +71,7 @@
 ## Preferences
 
 - Write tests, not too many, mostly integration, hapy path e2e.
+- CI preference: if lint/unit or Vercel deploy fails, cancel other in-progress GitHub Actions workflows for that commit.
 - TanStack DB dashboard migration: keep procedures under new `dashboardDb` router, migrate main `/dashboard` page-by-page, and run `pnpm lint`, `npx tsc --noEmit`, `pnpm test`, `pnpm test:e2e` before each incremental commit.
 - Cultivar pages should be catalog-centric (catalog cards with nested cultivar listing rows), not listing-card grids.
 - Use composition patterns for new UI components (prefer explicit composed sections over boolean-mode props).

--- a/.github/workflows/cancel-on-gate-failure.yml
+++ b/.github/workflows/cancel-on-gate-failure.yml
@@ -1,0 +1,147 @@
+name: Cancel Remaining Workflows
+
+on:
+  workflow_run:
+    workflows:
+      - PR Tests
+    types:
+      - completed
+  deployment_status:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel-on-pr-gate-failure:
+    name: Cancel on lint/unit failure
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel in-progress/queued runs for this commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const failedRunId = context.payload.workflow_run.id;
+            const headSha = context.payload.workflow_run.head_sha;
+
+            if (!headSha) {
+              core.info("No head SHA on workflow_run payload; skipping.");
+              return;
+            }
+
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner,
+                repo,
+                run_id: failedRunId,
+                per_page: 100,
+              },
+            );
+
+            const gateJob = jobs.find((job) => job.name === "Lint, Typecheck, Unit Tests");
+            if (!gateJob || gateJob.conclusion !== "failure") {
+              core.info("Lint/typecheck/unit gate did not fail; skipping cancellation.");
+              return;
+            }
+
+            const [inProgressRuns, queuedRuns] = await Promise.all([
+              github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                owner,
+                repo,
+                head_sha: headSha,
+                status: "in_progress",
+                per_page: 100,
+              }),
+              github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                owner,
+                repo,
+                head_sha: headSha,
+                status: "queued",
+                per_page: 100,
+              }),
+            ]);
+
+            const runsById = new Map();
+            for (const run of [...inProgressRuns, ...queuedRuns]) {
+              runsById.set(run.id, run);
+            }
+
+            const targets = [...runsById.values()].filter((run) => run.id !== context.runId);
+
+            if (targets.length === 0) {
+              core.info(`No active runs to cancel for ${headSha}.`);
+              return;
+            }
+
+            for (const run of targets) {
+              core.info(`Canceling run ${run.id} (${run.name}) for ${headSha}.`);
+              await github.rest.actions.cancelWorkflowRun({
+                owner,
+                repo,
+                run_id: run.id,
+              });
+            }
+
+  cancel-on-vercel-deploy-failure:
+    name: Cancel on Vercel deploy failure
+    if: >
+      github.event_name == 'deployment_status' &&
+      github.event.deployment_status.state == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel in-progress/queued runs for this commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headSha = context.payload.deployment?.sha;
+
+            if (!headSha) {
+              core.info("No deployment SHA on payload; skipping.");
+              return;
+            }
+
+            const [inProgressRuns, queuedRuns] = await Promise.all([
+              github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                owner,
+                repo,
+                head_sha: headSha,
+                status: "in_progress",
+                per_page: 100,
+              }),
+              github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                owner,
+                repo,
+                head_sha: headSha,
+                status: "queued",
+                per_page: 100,
+              }),
+            ]);
+
+            const runsById = new Map();
+            for (const run of [...inProgressRuns, ...queuedRuns]) {
+              runsById.set(run.id, run);
+            }
+
+            const targets = [...runsById.values()].filter((run) => run.id !== context.runId);
+
+            if (targets.length === 0) {
+              core.info(`No active runs to cancel for ${headSha}.`);
+              return;
+            }
+
+            for (const run of targets) {
+              core.info(`Canceling run ${run.id} (${run.name}) for ${headSha}.`);
+              await github.rest.actions.cancelWorkflowRun({
+                owner,
+                repo,
+                run_id: run.id,
+              });
+            }

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -38,6 +38,7 @@ jobs:
 
   e2e:
     name: E2E Tests
+    needs: lint-typecheck-unit
     runs-on: ubuntu-latest
     # Skip E2E on forked PRs (secrets not available)
     if: github.event.pull_request.head.repo.fork != true


### PR DESCRIPTION
Summary
- Documented the CI preference about canceling remaining workflows when lint/typecheck/unit or Vercel deploy fails in `.codex/napkin.md`.
- Updated `.github/workflows/pr-tests.yml` so the E2E job waits for the lint/typecheck/unit gate before running.
- Added `.github/workflows/cancel-on-gate-failure.yml` to cancel any in-progress or queued runs for the same commit if the lint/unit gate or a Vercel deployment fails.

Testing
- Not run (not requested)