### PR TITLE
Improve sheet creator number inputs and border controls

### DIFF
--- a/.codex/napkin.md
+++ b/.codex/napkin.md
@@ -7,6 +7,7 @@
 - 2026-02-23 - sheet border styling - Tag cards on sheet output should include a muted dashed border for placement guidance in both preview and exported sheet documents.
 - 2026-02-23 - sheet border print correction - User wants dashed borders visible in the Sheet Creator preview but not in printed/exported sheet output; keep preview-only dashed outlines and omit border in generated sheet HTML.
 - 2026-02-23 - sheet border toggle preference - User wants an explicit Sheet Creator checkbox to include dashed borders in printed/exported sheets; default must remain off.
+- 2026-02-23 - mobile numeric input usability - In Sheet Creator, eagerly clamping/parsing number inputs on each keystroke blocks backspace/editing on iPad/iPhone; use text input drafts + blur-time validation with explicit +/- step buttons.
 - 2026-02-23 - sheet creator UX follow-up - User expects a live sheet preview in the modal; render a scaled first-sheet preview tied directly to current rows/columns/margins/padding settings.
 - 2026-02-23 - tag sheet creator defaults - For `/dashboard/tags` sheet mode, initialize defaults to current tag dimensions on first modal open when no sheet settings exist; persist subsequent edits in `tag-sheet-creator-state-v1`.
 - 2026-02-23 - self-miss stale callsites - After refactoring export function signatures, I initially left handler calls passing old `html` args; always re-check all call sites after interface changes in large files.

--- a/tests/tag-designer-panel.test.tsx
+++ b/tests/tag-designer-panel.test.tsx
@@ -87,15 +87,37 @@ describe("TagDesignerPanel", () => {
     expect(
       screen.getByRole("heading", { name: "Sheet Creator" }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("Rows")).toHaveValue(1);
-    expect(screen.getByLabelText("Columns")).toHaveValue(1);
-    expect(screen.getByLabelText("Page width (in)")).toHaveValue(3.5);
-    expect(screen.getByLabelText("Page height (in)")).toHaveValue(1);
+    expect(screen.getByLabelText("Rows")).toHaveValue("1");
+    expect(screen.getByLabelText("Columns")).toHaveValue("1");
+    expect(screen.getByLabelText("Page width (in)")).toHaveValue("3.50");
+    expect(screen.getByLabelText("Page height (in)")).toHaveValue("1.00");
     expect(screen.getByLabelText("Print dashed borders")).not.toBeChecked();
     expect(
       screen.getByRole("heading", { name: "Sheet Preview" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Print Sheets" })).toBeEnabled();
+  });
+
+  it("defers numeric validation until blur and supports +/- buttons", () => {
+    render(<TagDesignerPanel listings={sampleListings} />);
+    fireEvent.click(screen.getByRole("button", { name: "Make Sheet" }));
+
+    const rowsInput = screen.getByLabelText("Rows");
+    fireEvent.change(rowsInput, { target: { value: "" } });
+    expect(
+      screen.queryByText(/Enter a whole number between 1 and 20/i),
+    ).not.toBeInTheDocument();
+
+    fireEvent.blur(rowsInput);
+    expect(
+      screen.getByText(/Enter a whole number between 1 and 20/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Increase Rows" }));
+    expect(rowsInput).toHaveValue("2");
+    expect(
+      screen.queryByText(/Enter a whole number between 1 and 20/i),
+    ).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- replace the inline number inputs in the Sheet Creator with a dedicated `SheetNumberField` that uses text drafts, blur-time validation, and custom +/- controls so the form works reliably on mobile while keeping the clamp/decimal rules
- document the new behavior through the existing test covering the Sheet Creator dialog and ensure the validation warning only appears after blur while the buttons move values immediately
- update the Sheet Creator state tests to assert on the new formatted inputs and the dashed-border toggle checkbox state

## Testing
- Not run (not requested)