### PR TITLE
Add print quantity control to tag sheet dialog

### DIFF
--- a/.codex/napkin.md
+++ b/.codex/napkin.md
@@ -2,6 +2,10 @@
 
 ## Log
 
+- 2026-02-24 - tags print selection source correction - In `/dashboard/tags`, selected items for print/sheet output must be derived from table `rowSelection` IDs (same source as selected badges), not `getFilteredSelectedRowModel`, so selected rows remain printable when filtered/paged out of the current table view.
+- 2026-02-24 - sheet copies-per-label UX - Sheet Creator now needs a `Copies of each label` control that resets to `1` each open, duplicates each selected label contiguously before moving to the next label, and shows an explicit summary line: `X labels selected, X copies of each, X total labels.`
+- 2026-02-24 - sheet copies visibility follow-up - User could miss copies control when it lived among page/grid settings; keep copies control in a dedicated top "Print quantity" section to make multi-copy behavior obvious.
+- 2026-02-24 - sheet quantity placement correction - User wants print quantity placed directly under `Print dashed borders` and collapsed by default; implement as a collapsible section that resets closed when the dialog opens.
 - 2026-02-23 - sheet export parity correction - Sheet Creator download control should match primary export formats; provide a shadcn download menu with `HTML Sheets (.html)`, `PDF (.pdf)`, and `Images (.zip)` from the sheet layout.
 - 2026-02-23 - sheet sizing rule update - User expects sheet tags to always stay at active tag dimensions; rows/columns now define count, and page settings are validated against required sheet area instead of scaling tag size.
 - 2026-02-23 - sheet border styling - Tag cards on sheet output should include a muted dashed border for placement guidance in both preview and exported sheet documents.

--- a/tests/tag-print-table.test.ts
+++ b/tests/tag-print-table.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildSelectedTagListingsForPrint } from "@/app/dashboard/tags/_components/tag-print-table";
+
+const listings = [
+  {
+    id: "listing-1",
+    userId: "user-1",
+    title: "Moonlit Smile",
+    price: 15,
+    privateNote: "note-1",
+    ahsListing: null,
+    lists: [{ id: "list-1", title: "For Sale" }],
+  },
+  {
+    id: "listing-2",
+    userId: "user-1",
+    title: "Solar Echo",
+    price: 22,
+    privateNote: "note-2",
+    ahsListing: null,
+    lists: [{ id: "list-2", title: "Garden Mix" }],
+  },
+  {
+    id: "listing-3",
+    userId: "user-1",
+    title: "Starlit Path",
+    price: 30,
+    privateNote: "note-3",
+    ahsListing: null,
+    lists: [
+      { id: "list-1", title: "For Sale" },
+      { id: "list-3", title: "Featured" },
+    ],
+  },
+];
+
+describe("buildSelectedTagListingsForPrint", () => {
+  it("returns selected listings from rowSelection ids in full-data order", () => {
+    const selected = buildSelectedTagListingsForPrint({
+      listings,
+      rowSelection: {
+        "listing-3": true,
+        "listing-1": true,
+      },
+    });
+
+    expect(selected.map((listing) => listing.id)).toEqual([
+      "listing-1",
+      "listing-3",
+    ]);
+  });
+
+  it("formats list names and ignores ids not present in listings", () => {
+    const selected = buildSelectedTagListingsForPrint({
+      listings,
+      rowSelection: {
+        "listing-3": true,
+        "missing-listing": true,
+      },
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0]).toMatchObject({
+      id: "listing-3",
+      title: "Starlit Path",
+      listName: "For Sale, Featured",
+    });
+  });
+});


### PR DESCRIPTION
Summary
- Persist row-selection-based listings into the sheet flow, show copy counts, and duplicate each label before moving to the next so the total labels and sheets compute correctly.
- Add a collapsed Print quantity section beneath the dashed-border checkbox with per-label copy input, numeric bounds, and descriptive summary text while resetting to one copy every time the dialog opens.
Testing
- Not run (not requested)