### PR TITLE
Update numeric inputs to commit on blur

### DIFF
--- a/.codex/napkin.md
+++ b/.codex/napkin.md
@@ -2,6 +2,9 @@
 
 ## Log
 
+- 2026-02-24 - self-miss hook deps lint - Wrapping simple local input-commit handlers in `useCallback` around a non-memoized `patch` helper triggered `react-hooks/exhaustive-deps`; simplest fix is plain inline functions when memoization is unnecessary.
+- 2026-02-24 - tags effects simplification preference - User prefers avoiding derived-state `useEffect` syncing for `/dashboard/tags` numeric inputs; use uncontrolled number inputs (`defaultValue`) with blur-time commit/reset handlers instead.
+- 2026-02-24 - self-miss TagCell key field - `TagCell` has no `id`; when forcing input remount keys, derive from existing stable fields (for example `fieldId` + value) instead of assuming an ID.
 - 2026-02-24 - tags numeric spinner preference - User wants native number input arrows preserved on `/dashboard/tags`; keep `type="number"` while still using draft-state + blur-only commit to allow clear-then-type editing.
 - 2026-02-24 - tags custom size blur validation - Main `/dashboard/tags` custom size inputs (`Width (in)`, `Height (in)`) must follow the same draft + blur-commit pattern as other numeric controls; eager parse on `onChange` blocks clear-then-type editing.
 - 2026-02-24 - tags numeric verification pattern - For `/dashboard/tags`, one integration sweep test over all `SheetNumberField` labels plus print-quantity copies gives reliable coverage that every sheet numeric field allows empty drafts and commits on blur.

--- a/tests/tag-designer-panel.test.tsx
+++ b/tests/tag-designer-panel.test.tsx
@@ -266,7 +266,7 @@ describe("TagDesignerPanel", () => {
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Increase Rows" }));
-    expect(rowsInput).toHaveValue(2);
+    expect(screen.getByLabelText("Rows")).toHaveValue(2);
     expect(
       screen.queryByText(/Enter a whole number between 1 and 20/i),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
Summary
- keep the tag designer cell options and custom-size inputs on `/dashboard/tags` in draft state until blur so users can clear and type values without eager clamping; this preserves native number-input spinners
- align the Sheet Creator fields with the same blur-only commit flow, including an integration test that bumps every `SheetNumberField` plus the copies control so each field can stay empty until blur
Testing
- Not run (not requested)