### PR TITLE
Remove `/api/trpc` from proxy matching

### DIFF
--- a/apps/main/src/proxy.ts
+++ b/apps/main/src/proxy.ts
@@ -29,6 +29,5 @@ export const config = {
     "/dashboard/:path*",
     "/onboarding/:path*",
     "/subscribe/success/:path*",
-    "/api/trpc/:path*",
   ],
 };

--- a/apps/main/tests/proxy-matcher.test.ts
+++ b/apps/main/tests/proxy-matcher.test.ts
@@ -23,6 +23,12 @@ describe("proxy matcher", () => {
     expect(
       unstable_doesMiddlewareMatch({
         config,
+        url: "/api/trpc/dashboardDb.user.getCurrentUser",
+      }),
+    ).toBe(false);
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
         url: "/trpc/public.getProfile",
       }),
     ).toBe(false);
@@ -82,7 +88,7 @@ describe("proxy matcher", () => {
     ).toBe(false);
   });
 
-  it("still runs for protected and auth-backed tRPC routes", async () => {
+  it("still runs for protected routes", async () => {
     const { config } = await import("@/proxy");
 
     expect(
@@ -95,12 +101,6 @@ describe("proxy matcher", () => {
       unstable_doesMiddlewareMatch({
         config,
         url: "/onboarding",
-      }),
-    ).toBe(true);
-    expect(
-      unstable_doesMiddlewareMatch({
-        config,
-        url: "/api/trpc/dashboardDb.user.getCurrentUser",
       }),
     ).toBe(true);
     expect(

--- a/apps/main/tests/trpc-route-auth.test.ts
+++ b/apps/main/tests/trpc-route-auth.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL ??= "file:./tests/.tmp/trpc-route-auth.sqlite";
+
+const authMock = vi.hoisted(() => vi.fn(async () => ({ userId: null })));
+
+vi.mock("@clerk/nextjs/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@clerk/nextjs/server")>();
+  return {
+    ...actual,
+    auth: authMock,
+  };
+});
+
+function createBatchedQueryUrl(path: string) {
+  const input = encodeURIComponent(
+    JSON.stringify({
+      0: {
+        json: null,
+        meta: {
+          values: ["undefined"],
+        },
+      },
+    }),
+  );
+
+  return `http://localhost:3000/api/trpc/${path}?batch=1&input=${input}`;
+}
+
+describe("tRPC route auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.mockResolvedValue({ userId: null });
+  });
+
+  it("rejects protected HTTP tRPC calls without relying on proxy auth", async () => {
+    const { GET } = await import("@/app/api/trpc/[trpc]/route");
+    const request = new NextRequest(createBatchedQueryUrl("user.getCurrentUser"));
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({
+          json: expect.objectContaining({
+            code: -32001,
+            message: "Not authenticated",
+          }),
+        }),
+      }),
+    ]);
+    expect(authMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Stop sending `/api/trpc` requests through Clerk proxy middleware.
- Keep the proxy focused on protected browser routes only.
- Add coverage that the tRPC HTTP route still enforces auth directly.

## Testing
- Added a proxy matcher test that asserts `/api/trpc/...` no longer matches the proxy.
- Added an HTTP route-handler test for `/api/trpc/[trpc]` that verifies unauthenticated calls return `401` without proxy involvement.
- Ran the targeted Vitest files and `eslint src`; both passed.