### PR TITLE
Paginate Google merchant feed queries to avoid Prisma parameter limits

### DIFF
--- a/apps/main/src/app/api/google-merchant-feed/route.ts
+++ b/apps/main/src/app/api/google-merchant-feed/route.ts
@@ -9,6 +9,7 @@ import {
 
 // Constants for merchant feed configuration
 const SHIPPING_WEIGHT = "0.5 lb";
+const FEED_BATCH_SIZE = 200;
 
 export async function GET(_request: Request) {
   try {
@@ -37,11 +38,6 @@ export async function GET(_request: Request) {
       },
     };
 
-    const listings = await db.listing.findMany({
-      where,
-      include,
-    });
-
     // Generate the XML feed
     let xml = `<?xml version="1.0" encoding="UTF-8"?>
 <rss xmlns:g="http://base.google.com/ns/1.0" version="2.0">
@@ -53,44 +49,60 @@ export async function GET(_request: Request) {
 
     const errors: string[] = []; // Collect errors during processing
 
-    // Process listings
-    listings.forEach((listing) => {
-      try {
-        const displayListing = withResolvedDisplayAhsListing(listing);
-        const displayAhsListing = displayListing.ahsListing;
-        const listingName =
-          displayListing.title ?? displayAhsListing?.name ?? "Unnamed Daylily";
-        // Combine descriptions
-        const userDescription = displayListing.description;
-        const ahsDescription = formatAhsListingSummary(displayAhsListing);
-        let combinedDescription = "";
-        if (userDescription && ahsDescription) {
-          combinedDescription = `${userDescription}\n\n---\n\n${ahsDescription}`;
-        } else {
-          combinedDescription =
-            userDescription ?? ahsDescription ?? `${listingName} daylily`;
-        }
+    let cursor: string | undefined;
+    while (true) {
+      const listings = await db.listing.findMany({
+        where,
+        include,
+        orderBy: { id: "asc" },
+        take: FEED_BATCH_SIZE,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      });
 
-        const imageUrl =
-          displayListing.images?.[0]?.url ?? displayAhsListing?.ahsImageUrl;
-        const additionalImages = displayListing.images?.slice(1, 4) ?? [];
-        const productUrl = `${baseUrl}/${displayListing.userId}/${displayListing.id}`;
-        const catalogName =
-          displayListing.user.profile?.title ??
-          `Daylily Catalog #${displayListing.userId}`;
-        const mpn = displayListing.id;
-        const enhancedTitle = `${listingName} Daylily`;
+      if (listings.length === 0) {
+        break;
+      }
 
-        // Clean and prepare text
-        const cleanTitle = cleanTextForXml(enhancedTitle);
-        const cleanCatalogName = cleanTextForXml(catalogName);
-        const cleanCombinedDescription = cleanTextForXml(combinedDescription);
-        // Append seller info to the end
-        const fullDescription = `${cleanCombinedDescription}\n\n Available from ${cleanCatalogName} on Daylily Catalog.`;
-        const priceFormatted = listing.price?.toFixed(2) ?? "0.00";
+      // Process listings
+      listings.forEach((listing) => {
+        try {
+          const displayListing = withResolvedDisplayAhsListing(listing);
+          const displayAhsListing = displayListing.ahsListing;
+          const listingName =
+            displayListing.title ??
+            displayAhsListing?.name ??
+            "Unnamed Daylily";
+          // Combine descriptions
+          const userDescription = displayListing.description;
+          const ahsDescription = formatAhsListingSummary(displayAhsListing);
+          let combinedDescription = "";
+          if (userDescription && ahsDescription) {
+            combinedDescription = `${userDescription}\n\n---\n\n${ahsDescription}`;
+          } else {
+            combinedDescription =
+              userDescription ?? ahsDescription ?? `${listingName} daylily`;
+          }
 
-        // Build the item XML with all required Google Merchant fields
-        const itemXml = `<item>
+          const imageUrl =
+            displayListing.images?.[0]?.url ?? displayAhsListing?.ahsImageUrl;
+          const additionalImages = displayListing.images?.slice(1, 4) ?? [];
+          const productUrl = `${baseUrl}/${displayListing.userId}/${displayListing.id}`;
+          const catalogName =
+            displayListing.user.profile?.title ??
+            `Daylily Catalog #${displayListing.userId}`;
+          const mpn = displayListing.id;
+          const enhancedTitle = `${listingName} Daylily`;
+
+          // Clean and prepare text
+          const cleanTitle = cleanTextForXml(enhancedTitle);
+          const cleanCatalogName = cleanTextForXml(catalogName);
+          const cleanCombinedDescription = cleanTextForXml(combinedDescription);
+          // Append seller info to the end
+          const fullDescription = `${cleanCombinedDescription}\n\n Available from ${cleanCatalogName} on Daylily Catalog.`;
+          const priceFormatted = listing.price?.toFixed(2) ?? "0.00";
+
+          // Build the item XML with all required Google Merchant fields
+          const itemXml = `<item>
 <title>${escapeXml(cleanTitle)}</title>
 <g:title>${escapeXml(cleanTitle)}</g:title>
 <link>${escapeXml(productUrl)}</link>
@@ -104,27 +116,33 @@ export async function GET(_request: Request) {
 <g:product_type>Daylily</g:product_type>
 <g:mpn>${escapeXml(mpn)}</g:mpn>
 <g:shipping_weight>${SHIPPING_WEIGHT}</g:shipping_weight>${
-          imageUrl
-            ? `
+            imageUrl
+              ? `
 <g:image_link>${escapeXml(imageUrl)}</g:image_link>`
-            : ""
-        }${additionalImages
-          .map(
-            (img) => `
+              : ""
+          }${additionalImages
+            .map(
+              (img) => `
 <g:additional_image_link>${escapeXml(img.url)}</g:additional_image_link>`,
-          )
-          .join("")}
+            )
+            .join("")}
 <g:custom_label_0>${escapeXml(cleanCatalogName)}</g:custom_label_0>
 </item>
 `;
 
-        xml += itemXml;
-      } catch (error) {
-        const errorMessage = `Error processing listing ${listing.id}: ${String(error)}`;
-        console.error(errorMessage);
-        errors.push(errorMessage);
+          xml += itemXml;
+        } catch (error) {
+          const errorMessage = `Error processing listing ${listing.id}: ${String(error)}`;
+          console.error(errorMessage);
+          errors.push(errorMessage);
+        }
+      });
+
+      cursor = listings.at(-1)?.id;
+      if (listings.length < FEED_BATCH_SIZE || !cursor) {
+        break;
       }
-    });
+    }
 
     // If we encountered errors, add a comment in the XML
     if (errors.length > 0) {

--- a/apps/main/tests/google-merchant-feed-route.test.ts
+++ b/apps/main/tests/google-merchant-feed-route.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  listingFindMany: vi.fn(),
+}));
+
+vi.mock("@/server/db", () => ({
+  db: {
+    listing: {
+      findMany: dbMocks.listingFindMany,
+    },
+  },
+}));
+
+function createFeedListing(index: number) {
+  const id = `listing-${index.toString().padStart(3, "0")}`;
+
+  return {
+    id,
+    userId: "user-1",
+    title: `Listing ${index}`,
+    slug: id,
+    price: 25,
+    description: `Listing ${index} description`,
+    privateNote: null,
+    ahsId: null,
+    cultivarReferenceId: `cultivar-reference-${index}`,
+    status: "PUBLISHED",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    images: [
+      {
+        id: `image-${index}`,
+        url: `https://example.com/listing-${index}.jpg`,
+        order: 0,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        status: null,
+        userProfileId: null,
+        listingId: id,
+      },
+    ],
+    cultivarReference: {
+      id: `cultivar-reference-${index}`,
+      ahsId: `ahs-${index}`,
+      v2AhsCultivarId: null,
+      normalizedName: `listing ${index}`,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      ahsListing: {
+        id: `ahs-${index}`,
+        name: `AHS Listing ${index}`,
+        ahsImageUrl: null,
+        hybridizer: null,
+        year: null,
+        scapeHeight: null,
+        bloomSize: null,
+        bloomSeason: null,
+        ploidy: null,
+        foliageType: null,
+        bloomHabit: null,
+        color: null,
+        form: null,
+        parentage: null,
+        fragrance: null,
+        budcount: null,
+        branches: null,
+        sculpting: null,
+        foliage: null,
+        flower: null,
+      },
+      v2AhsCultivar: null,
+    },
+    user: {
+      id: "user-1",
+      clerkUserId: null,
+      stripeCustomerId: null,
+      role: "USER",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      profile: {
+        id: "profile-1",
+        userId: "user-1",
+        title: "Test Garden",
+        slug: "test-garden",
+        logoUrl: null,
+        description: null,
+        content: null,
+        location: null,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  };
+}
+
+describe("google merchant feed route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.APP_BASE_URL = "https://daylilycatalog.com";
+    delete process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA;
+  });
+
+  it("paginates listing queries to stay below database parameter limits", async () => {
+    const firstPage = Array.from({ length: 200 }, (_, index) =>
+      createFeedListing(index + 1),
+    );
+    const secondPage = [createFeedListing(201)];
+    dbMocks.listingFindMany
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(secondPage);
+
+    const { GET } = await import("@/app/api/google-merchant-feed/route");
+    const response = await GET(
+      new Request("https://daylilycatalog.com/api/google-merchant-feed"),
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body.match(/<item>/g)).toHaveLength(201);
+    expect(dbMocks.listingFindMany).toHaveBeenCalledTimes(2);
+    expect(dbMocks.listingFindMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        orderBy: { id: "asc" },
+        take: 200,
+      }),
+    );
+    expect(dbMocks.listingFindMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        cursor: { id: "listing-200" },
+        skip: 1,
+        orderBy: { id: "asc" },
+        take: 200,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Split the Google merchant feed listing read into 200-row cursor batches so nested Prisma includes stay under SQLite/Turso parameter limits.
- Added a regression test that verifies the feed advances with `cursor`/`skip` instead of one unbounded `findMany`.

## Testing
- `pnpm main test -- tests/google-merchant-feed-route.test.ts`
- `pnpm main lint`
- `pnpm main typecheck`
- Prettier check passed
- Reproduced locally against the production snapshot and confirmed the route now returns `200 application/xml` instead of `500`.