### PR TITLE
[codex] Fix image ownership checks

### DIFF
--- a/apps/main/src/server/api/routers/dashboard-db/image.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/image.ts
@@ -374,6 +374,17 @@ export const dashboardDbImageRouter = createTRPCRouter({
       });
 
       const inputIds = new Set(input.images.map((img) => img.id));
+      const ownedImageIds = new Set(allImages.map((img) => img.id));
+      const hasUnownedImage = input.images.some(
+        (img) => !ownedImageIds.has(img.id),
+      );
+      if (hasUnownedImage) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Image not found",
+        });
+      }
+
       const mergedOrder = [
         ...input.images,
         ...allImages
@@ -425,7 +436,15 @@ export const dashboardDbImageRouter = createTRPCRouter({
           : { userProfileId: input.referenceId };
 
       await ctx.db.$transaction(async (tx) => {
-        await tx.image.delete({ where: { id: input.imageId } });
+        const deleted = await tx.image.deleteMany({
+          where: { id: input.imageId, ...whereClause },
+        });
+        if (deleted.count === 0) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Image not found",
+          });
+        }
 
         const remaining = await tx.image.findMany({
           where: whereClause,

--- a/apps/main/tests/dashboard-db-image-router.test.ts
+++ b/apps/main/tests/dashboard-db-image-router.test.ts
@@ -17,27 +17,40 @@ beforeAll(async () => {
 
 interface MockDb {
   $queryRaw: ReturnType<typeof vi.fn>;
+  $transaction: ReturnType<typeof vi.fn>;
   image: {
+    deleteMany: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
   };
   listing: {
+    findFirst: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
   };
   userProfile: {
+    findFirst: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
   };
 }
 
 function createMockDb(): MockDb {
+  const image = {
+    deleteMany: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+  };
   return {
     $queryRaw: vi.fn(),
-    image: {
-      findMany: vi.fn(),
-    },
+    $transaction: vi.fn(async (arg) =>
+      typeof arg === "function" ? await arg({ image }) : await Promise.all(arg),
+    ),
+    image,
     listing: {
+      findFirst: vi.fn(),
       findMany: vi.fn(),
     },
     userProfile: {
+      findFirst: vi.fn(),
       findUnique: vi.fn(),
     },
   };
@@ -146,5 +159,113 @@ describe("dashboardDb.image", () => {
     expect(db.listing.findMany).not.toHaveBeenCalled();
     expect(db.userProfile.findUnique).not.toHaveBeenCalled();
     expect(db.image.findMany).not.toHaveBeenCalled();
+  });
+
+  it("delete only removes an image that belongs to the owned target", async () => {
+    const db = createMockDb();
+    db.listing.findFirst.mockResolvedValueOnce({ id: "listing-1" });
+    db.image.deleteMany.mockResolvedValueOnce({ count: 0 });
+
+    const caller = createCaller(db);
+
+    await expect(
+      caller.delete({
+        type: "listing",
+        referenceId: "listing-1",
+        imageId: "victim-image",
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(db.image.deleteMany).toHaveBeenCalledWith({
+      where: { id: "victim-image", listingId: "listing-1" },
+    });
+    expect(db.image.findMany).not.toHaveBeenCalled();
+  });
+
+  it("delete renumbers remaining images after deleting an owned image", async () => {
+    const db = createMockDb();
+    db.listing.findFirst.mockResolvedValueOnce({ id: "listing-1" });
+    db.image.deleteMany.mockResolvedValueOnce({ count: 1 });
+    db.image.findMany.mockResolvedValueOnce([
+      { id: "image-2" },
+      { id: "image-3" },
+    ]);
+    db.image.update.mockResolvedValue({});
+
+    const caller = createCaller(db);
+    const result = await caller.delete({
+      type: "listing",
+      referenceId: "listing-1",
+      imageId: "image-1",
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(db.image.update).toHaveBeenCalledTimes(2);
+    expect(db.image.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "image-2" },
+      data: { order: 0 },
+    });
+    expect(db.image.update).toHaveBeenNthCalledWith(2, {
+      where: { id: "image-3" },
+      data: { order: 1 },
+    });
+  });
+
+  it("reorder rejects image ids outside the owned target set", async () => {
+    const db = createMockDb();
+    db.listing.findFirst.mockResolvedValueOnce({ id: "listing-1" });
+    db.image.findMany.mockResolvedValueOnce([{ id: "image-1" }]);
+
+    const caller = createCaller(db);
+
+    await expect(
+      caller.reorder({
+        type: "listing",
+        referenceId: "listing-1",
+        images: [
+          { id: "image-1", order: 0 },
+          { id: "victim-image", order: 1 },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(db.image.update).not.toHaveBeenCalled();
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("reorder updates only images from the owned target set", async () => {
+    const db = createMockDb();
+    db.userProfile.findFirst.mockResolvedValueOnce({ id: "profile-1" });
+    db.image.findMany.mockResolvedValueOnce([
+      { id: "image-1" },
+      { id: "image-2" },
+      { id: "image-3" },
+    ]);
+    db.image.update.mockResolvedValue({});
+
+    const caller = createCaller(db);
+    const result = await caller.reorder({
+      type: "profile",
+      referenceId: "profile-1",
+      images: [
+        { id: "image-3", order: 0 },
+        { id: "image-1", order: 1 },
+      ],
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(db.image.update).toHaveBeenCalledTimes(3);
+    expect(db.image.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "image-3" },
+      data: { order: 0 },
+    });
+    expect(db.image.update).toHaveBeenNthCalledWith(2, {
+      where: { id: "image-1" },
+      data: { order: 1 },
+    });
+    expect(db.image.update).toHaveBeenNthCalledWith(3, {
+      where: { id: "image-2" },
+      data: { order: 2 },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Constrain dashboard image deletion to the owned listing/profile target instead of deleting by image id alone.
- Reject reorder payloads that include image ids outside the owned target image set.
- Add focused router regression tests for cross-tenant delete/reorder attempts and legitimate renumbering behavior.

## Security impact

This fixes a BOLA path where an authenticated seller could supply another seller's public image id while using any owned `referenceId`, then delete that image row or tamper with its display order.

## Validation

- `pnpm main test -- tests/dashboard-db-image-router.test.ts`
- `git diff --check`