### PR TITLE
[codex] Fix JSON-LD script serialization

### DIFF
--- a/apps/main/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/_components/listing-seo.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/_components/listing-seo.tsx
@@ -3,6 +3,7 @@ import {
   createBreadcrumbListSchema,
   createListingBreadcrumbs,
 } from "@/lib/utils/breadcrumbs";
+import { serializeJsonLd } from "@/lib/utils/json-ld";
 
 // Define types using types from the functions directly
 type Listing = Parameters<typeof generateJsonLd>[0];
@@ -38,11 +39,11 @@ export async function ListingPageSEO({
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbSchema) }}
       />
     </>
   );

--- a/apps/main/src/app/(public)/[userSlugOrId]/_components/profile-seo.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_components/profile-seo.tsx
@@ -3,6 +3,7 @@ import {
   createBreadcrumbListSchema,
   createUserProfileBreadcrumbs,
 } from "@/lib/utils/breadcrumbs";
+import { serializeJsonLd } from "@/lib/utils/json-ld";
 
 // Define types using types from the functions directly
 type Profile = Parameters<typeof generateProfilePageJsonLd>[0];
@@ -50,11 +51,11 @@ export async function ProfilePageSEO({
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbSchema) }}
       />
     </>
   );

--- a/apps/main/src/app/(public)/_components/home-seo.tsx
+++ b/apps/main/src/app/(public)/_components/home-seo.tsx
@@ -1,5 +1,6 @@
 import { generateSoftwareApplicationJsonLd } from "../_seo/json-ld";
 import type { PublicPageMetadata } from "../_seo/public-seo";
+import { serializeJsonLd } from "@/lib/utils/json-ld";
 
 interface HomePageSEOProps {
   metadata: PublicPageMetadata;
@@ -14,7 +15,7 @@ export async function HomePageSEO({ metadata }: HomePageSEOProps) {
         <script
           key={index}
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(schema) }}
         />
       ))}
     </>

--- a/apps/main/src/app/(public)/catalogs/page.tsx
+++ b/apps/main/src/app/(public)/catalogs/page.tsx
@@ -15,6 +15,7 @@ import {
   createBreadcrumbListSchema,
   createCatalogsBreadcrumbs,
 } from "@/lib/utils/breadcrumbs";
+import { serializeJsonLd } from "@/lib/utils/json-ld";
 
 export const revalidate = 1800;
 
@@ -98,15 +99,15 @@ export default async function CatalogsPage() {
       {/* Add breadcrumb schema - keeping only what works for rich results */}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbSchema) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionSchema) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(collectionSchema) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(catalogsFaqSchema) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(catalogsFaqSchema) }}
       />
 
       <PageHeader

--- a/apps/main/src/app/(public)/cultivar/[cultivarNormalizedName]/page.tsx
+++ b/apps/main/src/app/(public)/cultivar/[cultivarNormalizedName]/page.tsx
@@ -3,6 +3,7 @@ import { type Metadata } from "next";
 import { MainContent } from "@/app/(public)/_components/main-content";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
+import { serializeJsonLd } from "@/lib/utils/json-ld";
 import { IsrWrittenAt } from "@/app/(public)/_components/isr-written-at";
 import { SellerIntentLink } from "@/components/seller-intent-link";
 import { buttonVariants } from "@/components/ui/button";
@@ -58,7 +59,7 @@ export default async function CultivarPage({ params }: PageProps) {
     <MainContent>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">

--- a/apps/main/src/app/start-membership/page.tsx
+++ b/apps/main/src/app/start-membership/page.tsx
@@ -10,6 +10,7 @@ import { PRO_FEATURES, METADATA_CONFIG } from "@/config/constants";
 import { SUBSCRIPTION_CONFIG } from "@/config/subscription-config";
 import { IMAGES } from "@/lib/constants/images";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
+import { serializeJsonLd } from "@/lib/utils/json-ld";
 import { UsedByWave } from "@/components/used-by-wave";
 import { LaurelRatingBadge } from "@/components/laurel-rating-badge";
 
@@ -148,7 +149,7 @@ export default async function StartMembershipPage() {
 
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(faqSchema) }}
       />
 
       <section className="relative isolate overflow-hidden bg-[#07120e] px-4 pt-24 pb-36 text-white lg:px-8 lg:pt-20 lg:pb-32">

--- a/apps/main/src/lib/utils/json-ld.ts
+++ b/apps/main/src/lib/utils/json-ld.ts
@@ -1,0 +1,8 @@
+export function serializeJsonLd(value: unknown) {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}

--- a/apps/main/tests/json-ld-serialization.test.ts
+++ b/apps/main/tests/json-ld-serialization.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { serializeJsonLd } from "@/lib/utils/json-ld";
+
+describe("serializeJsonLd", () => {
+  it("escapes script-breaking characters while preserving JSON values", () => {
+    const payload = {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      name: `Evil </script><script>alert("xss")</script>`,
+      description: "A & B > C",
+      separator: "\u2028\u2029",
+    };
+
+    const serialized = serializeJsonLd(payload);
+
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).not.toContain("<script");
+    expect(serialized).not.toContain("<");
+    expect(serialized).not.toContain(">");
+    expect(serialized).not.toContain("&");
+    expect(JSON.parse(serialized)).toEqual(payload);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared JSON-LD serializer that escapes script-breaking characters before inserting schema data into `dangerouslySetInnerHTML`
- route public JSON-LD script tags through the serializer
- add regression coverage for `</script><script>` payloads while preserving JSON parseability

## Security impact
Attacker-controlled profile, listing, or cultivar strings can no longer break out of `application/ld+json` script tags and execute script in public pages.

## Validation
- `pnpm main test -- tests/json-ld-serialization.test.ts tests/profile-json-ld.test.ts tests/cultivar-json-ld.test.ts`
- `git diff --check`
- re-scanned JSON-LD script sinks for raw `JSON.stringify(...)` insertion