### PR TITLE
[codex] Sanitize profile editor content

### DIFF
--- a/.github/workflows/preview-alias.yml
+++ b/.github/workflows/preview-alias.yml
@@ -19,7 +19,8 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.deployment_status.state == 'success' &&
-       (github.event.deployment.environment == 'Preview' || github.event.deployment.environment == 'preview'))
+       (github.event.deployment.environment == 'Preview' || github.event.deployment.environment == 'preview') &&
+       (github.event.deployment_status.environment_url != '' || github.event.deployment_status.target_url != ''))
     runs-on: ubuntu-latest
     environment: preview
     steps:
@@ -31,12 +32,13 @@ jobs:
             echo "SHA=${{ github.sha }}" >> $GITHUB_OUTPUT
             echo "HASH=$(echo '${{ github.sha }}' | cut -c1-8)" >> $GITHUB_OUTPUT
           else
-            echo "URL=${{ github.event.deployment_status.environment_url }}" >> $GITHUB_OUTPUT
+            echo "URL=${{ github.event.deployment_status.environment_url || github.event.deployment_status.target_url }}" >> $GITHUB_OUTPUT
             echo "SHA=${{ github.event.deployment.sha }}" >> $GITHUB_OUTPUT
             echo "HASH=$(echo '${{ github.event.deployment.sha }}' | cut -c1-8)" >> $GITHUB_OUTPUT
           fi
 
       - name: Alias to <hash>.deploy-preview.daylilycatalog.com
+        if: steps.vals.outputs.URL != ''
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM: ${{ vars.VERCEL_TEAM }}
@@ -52,6 +54,7 @@ jobs:
           npx vercel alias set "$URL" "$ALIAS" --token "$VERCEL_TOKEN" --scope "$VERCEL_TEAM"
 
       - name: Comment alias URL on PR
+        if: steps.vals.outputs.URL != ''
         uses: mshick/add-pr-comment@v2
         with:
           repo-token: ${{ github.token }}

--- a/.github/workflows/preview-alias.yml
+++ b/.github/workflows/preview-alias.yml
@@ -20,7 +20,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.deployment_status.state == 'success' &&
        (github.event.deployment.environment == 'Preview' || github.event.deployment.environment == 'preview') &&
-       (github.event.deployment_status.environment_url != '' || github.event.deployment_status.target_url != ''))
+       ((github.event.deployment_status.environment_url != '' && contains(github.event.deployment_status.environment_url, 'vercel.app')) ||
+        (github.event.deployment_status.target_url != '' && contains(github.event.deployment_status.target_url, 'vercel.app'))))
     runs-on: ubuntu-latest
     environment: preview
     steps:

--- a/apps/main/src/server/api/routers/dashboard-db/user-profile.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/user-profile.ts
@@ -4,6 +4,7 @@ import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
 import { slugSchema } from "@/types/schemas/profile";
 import { isValidSlug } from "@/lib/utils/slugify";
 import type { PrismaClient } from "@prisma/client";
+import { sanitizeEditorJsContentForStorage } from "@/server/security/editor-js-content";
 
 const profileSelect = {
   id: true,
@@ -140,15 +141,17 @@ export const dashboardDbUserProfileRouter = createTRPCRouter({
   updateContent: protectedProcedure
     .input(z.object({ content: z.string().nullable() }))
     .mutation(async ({ ctx, input }) => {
+      const sanitizedContent = sanitizeEditorJsContentForStorage(input.content);
+
       const profile = await ctx.db.userProfile.upsert({
         where: { userId: ctx.user.id },
         create: {
           userId: ctx.user.id,
           slug: ctx.user.id,
-          content: input.content,
+          content: sanitizedContent,
         },
         update: {
-          content: input.content,
+          content: sanitizedContent,
         },
         select: profileSelect,
       });

--- a/apps/main/src/server/db/public-seller-read-model.ts
+++ b/apps/main/src/server/db/public-seller-read-model.ts
@@ -4,6 +4,7 @@ import { replicaDb } from "@/server/db";
 import { getLatestDate } from "@/server/db/public-date-utils";
 import { getProUserIds } from "@/server/db/getProUserIds";
 import { isPublished } from "@/server/db/public-visibility/filters";
+import { parseAndSanitizeEditorJsContent } from "@/server/security/editor-js-content";
 
 export interface PublicSellerSummary {
   id: string;
@@ -52,16 +53,7 @@ interface PublicSellerSummaryOptions {
 function parseProfileContent(
   content: string | null,
 ): OutputData | string | null {
-  if (!content) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(content) as OutputData;
-  } catch (error) {
-    console.error("Error parsing profile content:", error);
-    return content;
-  }
+  return parseAndSanitizeEditorJsContent(content);
 }
 
 function toActiveUserIdSet(activeUserIds?: readonly string[] | Set<string>) {

--- a/apps/main/src/server/security/editor-js-content.ts
+++ b/apps/main/src/server/security/editor-js-content.ts
@@ -154,7 +154,7 @@ export function sanitizeEditorJsData(data: OutputData): OutputData {
     ...data,
     blocks: data.blocks.map((block) => ({
       ...block,
-      data: sanitizeRichTextData(block.data) as typeof block.data,
+      data: sanitizeRichTextData(block.data),
     })),
   };
 }

--- a/apps/main/src/server/security/editor-js-content.ts
+++ b/apps/main/src/server/security/editor-js-content.ts
@@ -1,0 +1,184 @@
+import type { OutputData } from "@editorjs/editorjs";
+import { HTMLElement, NodeType, parse, type Node } from "node-html-parser";
+
+const ALLOWED_INLINE_TAGS = new Set([
+  "a",
+  "b",
+  "br",
+  "code",
+  "em",
+  "i",
+  "mark",
+  "s",
+  "strong",
+  "u",
+]);
+
+const DROPPED_TAGS = new Set([
+  "audio",
+  "canvas",
+  "embed",
+  "iframe",
+  "img",
+  "math",
+  "object",
+  "script",
+  "source",
+  "style",
+  "svg",
+  "template",
+  "video",
+]);
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(value: string) {
+  return escapeHtml(value).replace(/"/g, "&quot;");
+}
+
+function isSafeHref(href: string) {
+  const trimmed = href.trim();
+  if (trimmed.startsWith("/")) {
+    return !trimmed.startsWith("//");
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return ["http:", "https:", "mailto:", "tel:"].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function serializeSanitizedNode(node: Node): string {
+  if (node.nodeType === NodeType.TEXT_NODE) {
+    return escapeHtml(node.rawText);
+  }
+
+  if (!(node instanceof HTMLElement)) {
+    return "";
+  }
+
+  const tagName = node.rawTagName.toLowerCase();
+  if (DROPPED_TAGS.has(tagName)) {
+    return "";
+  }
+
+  const children = node.childNodes.map(serializeSanitizedNode).join("");
+  if (!ALLOWED_INLINE_TAGS.has(tagName)) {
+    return children;
+  }
+
+  if (tagName === "br") {
+    return "<br>";
+  }
+
+  if (tagName === "a") {
+    const href = node.getAttribute("href");
+    if (!href || !isSafeHref(href)) {
+      return `<a>${children}</a>`;
+    }
+
+    return `<a href="${escapeAttribute(href)}" rel="noopener noreferrer nofollow" target="_blank">${children}</a>`;
+  }
+
+  return `<${tagName}>${children}</${tagName}>`;
+}
+
+export function sanitizeEditorJsHtml(value: string) {
+  const root = parse(`<root>${value}</root>`, {
+    comment: false,
+    lowerCaseTagName: true,
+  });
+  const wrapper = root.querySelector("root");
+
+  if (!wrapper) {
+    return escapeHtml(value);
+  }
+
+  return wrapper.childNodes.map(serializeSanitizedNode).join("");
+}
+
+function sanitizeRichTextData(value: unknown): unknown {
+  if (typeof value === "string") {
+    return sanitizeEditorJsHtml(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sanitizeRichTextData);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        sanitizeRichTextData(nestedValue),
+      ]),
+    );
+  }
+
+  return value;
+}
+
+function isEditorJsData(value: unknown): value is OutputData {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      Array.isArray((value as { blocks?: unknown }).blocks),
+  );
+}
+
+function createLegacyEditorJsData(content: string): OutputData {
+  return {
+    time: Date.now(),
+    blocks: [
+      {
+        id: "legacy",
+        type: "paragraph",
+        data: {
+          text: sanitizeEditorJsHtml(content),
+        },
+      },
+    ],
+    version: "2.30.0",
+  };
+}
+
+export function sanitizeEditorJsData(data: OutputData): OutputData {
+  return {
+    ...data,
+    blocks: data.blocks.map((block) => ({
+      ...block,
+      data: sanitizeRichTextData(block.data) as typeof block.data,
+    })),
+  };
+}
+
+export function parseAndSanitizeEditorJsContent(
+  content: string | null,
+): OutputData | null {
+  if (!content) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (isEditorJsData(parsed)) {
+      return sanitizeEditorJsData(parsed);
+    }
+  } catch {
+    return createLegacyEditorJsData(content);
+  }
+
+  return createLegacyEditorJsData(content);
+}
+
+export function sanitizeEditorJsContentForStorage(content: string | null) {
+  const sanitized = parseAndSanitizeEditorJsContent(content);
+  return sanitized ? JSON.stringify(sanitized) : null;
+}

--- a/apps/main/tests/dashboard-db-user-profile-router.test.ts
+++ b/apps/main/tests/dashboard-db-user-profile-router.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TRPCInternalContext } from "@/server/api/trpc";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL ??=
+  "file:./tests/.tmp/dashboard-db-user-profile.sqlite";
+
+type RouterModule =
+  typeof import("@/server/api/routers/dashboard-db/user-profile");
+let dashboardDbUserProfileRouter: RouterModule["dashboardDbUserProfileRouter"];
+
+beforeAll(async () => {
+  ({ dashboardDbUserProfileRouter } = await import(
+    "@/server/api/routers/dashboard-db/user-profile"
+  ));
+});
+
+interface MockDb {
+  userProfile: {
+    upsert: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createMockDb(): MockDb {
+  return {
+    userProfile: {
+      upsert: vi.fn(),
+    },
+  };
+}
+
+function createCaller(db: MockDb) {
+  return dashboardDbUserProfileRouter.createCaller({
+    db: db as unknown as TRPCInternalContext["db"],
+    _authUser: { id: "user-1" } as unknown as TRPCInternalContext["_authUser"],
+    headers: new Headers(),
+  });
+}
+
+describe("dashboardDb.userProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sanitizes EditorJS content before storing it", async () => {
+    const db = createMockDb();
+    db.userProfile.upsert.mockImplementation(async (args) => ({
+      id: "profile-1",
+      userId: "user-1",
+      title: null,
+      slug: "user-1",
+      logoUrl: null,
+      description: null,
+      content: args.create.content,
+      location: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    }));
+
+    const caller = createCaller(db);
+    const unsafeContent = JSON.stringify({
+      time: 1,
+      blocks: [
+        {
+          id: "paragraph-1",
+          type: "paragraph",
+          data: {
+            text: `<img src=x onerror="alert(1)">Hello <b onclick="alert(1)">world</b>`,
+          },
+        },
+      ],
+      version: "2.30.0",
+    });
+
+    await caller.updateContent({ content: unsafeContent });
+
+    const upsertArgs = db.userProfile.upsert.mock.calls[0]?.[0] as {
+      create: { content: string | null };
+      update: { content: string | null };
+    };
+    expect(upsertArgs.create.content).toBe(upsertArgs.update.content);
+
+    const stored = JSON.parse(upsertArgs.create.content ?? "{}") as {
+      blocks: Array<{ data: { text: string } }>;
+    };
+    expect(stored.blocks[0]?.data.text).toBe("Hello <b>world</b>");
+  });
+});

--- a/apps/main/tests/editor-js-content-sanitizer.test.ts
+++ b/apps/main/tests/editor-js-content-sanitizer.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+  parseAndSanitizeEditorJsContent,
+  sanitizeEditorJsContentForStorage,
+  sanitizeEditorJsHtml,
+} from "@/server/security/editor-js-content";
+
+describe("EditorJS content sanitizer", () => {
+  it("removes scriptable HTML from rich text fields", () => {
+    const content = {
+      time: 1,
+      blocks: [
+        {
+          id: "paragraph-1",
+          type: "paragraph",
+          data: {
+            text: `Hello <b onclick="alert(1)">safe</b><img src=x onerror="alert(1)"><script>alert("xss")</script>`,
+          },
+        },
+        {
+          id: "list-1",
+          type: "list",
+          data: {
+            items: [
+              {
+                content: `<a href="javascript:alert(1)" onclick="alert(1)">bad link</a>`,
+                items: [],
+              },
+            ],
+          },
+        },
+      ],
+      version: "2.30.0",
+    };
+
+    const sanitized = sanitizeEditorJsContentForStorage(
+      JSON.stringify(content),
+    );
+    expect(sanitized).not.toBeNull();
+
+    const parsed = JSON.parse(sanitized ?? "{}") as typeof content;
+
+    expect(parsed.blocks[0]?.data.text).toBe("Hello <b>safe</b>");
+    expect(parsed.blocks[0]?.data.text).not.toContain("onclick");
+    expect(parsed.blocks[0]?.data.text).not.toContain("<img");
+    expect(parsed.blocks[0]?.data.text).not.toContain("<script");
+    expect(parsed.blocks[1]?.data.items?.[0]?.content).toBe(
+      "<a>bad link</a>",
+    );
+  });
+
+  it("preserves safe inline links with defensive attributes", () => {
+    const sanitized = sanitizeEditorJsHtml(
+      `<a href="https://example.com/daylily?a=1&b=2">Example</a>`,
+    );
+
+    expect(sanitized).toBe(
+      `<a href="https://example.com/daylily?a=1&amp;b=2" rel="noopener noreferrer nofollow" target="_blank">Example</a>`,
+    );
+  });
+
+  it("converts legacy plain text into escaped EditorJS content", () => {
+    const parsed = parseAndSanitizeEditorJsContent(
+      `Legacy <img src=x onerror="alert(1)"> text`,
+    );
+
+    expect(parsed?.blocks).toHaveLength(1);
+    expect(parsed?.blocks[0]?.data.text).toBe("Legacy  text");
+  });
+});


### PR DESCRIPTION
## Summary
- add a server-side EditorJS sanitizer for stored profile content
- sanitize `dashboardDb.userProfile.updateContent` before content is stored
- sanitize public profile content as it is parsed, protecting existing stored content too
- add regression coverage for script tags, event handlers, unsafe image tags, and `javascript:` links

## Security impact
Profile content can no longer persist scriptable EditorJS HTML that executes when a public catalog page renders in read-only mode.

## Validation
- `pnpm main test -- tests/editor-js-content-sanitizer.test.ts tests/dashboard-db-user-profile-router.test.ts`
- `SKIP_ENV_VALIDATION=1 pnpm main typecheck`
- `git diff --check`