### PR TITLE
[codex] Filter merchant feed to public listings

### DIFF
--- a/apps/main/src/app/api/google-merchant-feed/route.ts
+++ b/apps/main/src/app/api/google-merchant-feed/route.ts
@@ -6,6 +6,8 @@ import {
   withResolvedDisplayAhsListing,
   v2AhsCultivarDisplaySelect,
 } from "@/lib/utils/ahs-display";
+import { getProUserIds } from "@/server/db/getProUserIds";
+import { shouldShowToPublic } from "@/server/db/public-visibility/filters";
 
 // Constants for merchant feed configuration
 const SHIPPING_WEIGHT = "0.5 lb";
@@ -15,8 +17,11 @@ export async function GET(_request: Request) {
   try {
     const baseUrl = getCanonicalBaseUrl();
 
-    // Query all listings with prices
-    const where = { price: { not: null } };
+    const proUserIds = await getProUserIds();
+    const where = {
+      price: { not: null },
+      ...shouldShowToPublic(proUserIds),
+    };
     const include = {
       images: {
         take: 4, // Get up to 4 images (1 main + 3 additional)

--- a/apps/main/tests/google-merchant-feed-route.test.ts
+++ b/apps/main/tests/google-merchant-feed-route.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const dbMocks = vi.hoisted(() => ({
   listingFindMany: vi.fn(),
+  getProUserIds: vi.fn(),
 }));
 
 vi.mock("@/server/db", () => ({
@@ -17,6 +18,10 @@ vi.mock("@/server/db", () => ({
       findMany: dbMocks.listingFindMany,
     },
   },
+}));
+
+vi.mock("@/server/db/getProUserIds", () => ({
+  getProUserIds: dbMocks.getProUserIds,
 }));
 
 function createFeedListing(index: number) {
@@ -106,6 +111,7 @@ describe("google merchant feed route", () => {
     vi.clearAllMocks();
     process.env.APP_BASE_URL = "https://daylilycatalog.com";
     delete process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA;
+    dbMocks.getProUserIds.mockResolvedValue(["user-1"]);
   });
 
   it("paginates listing queries to stay below database parameter limits", async () => {
@@ -125,10 +131,16 @@ describe("google merchant feed route", () => {
 
     expect(response.status).toBe(200);
     expect(body.match(/<item>/g)).toHaveLength(201);
+    expect(dbMocks.getProUserIds).toHaveBeenCalledTimes(1);
     expect(dbMocks.listingFindMany).toHaveBeenCalledTimes(2);
     expect(dbMocks.listingFindMany).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
+        where: {
+          price: { not: null },
+          OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
+          userId: { in: ["user-1"] },
+        },
         orderBy: { id: "asc" },
         take: 200,
       }),


### PR DESCRIPTION
## Summary
- require Google Merchant feed listings to pass the public visibility rule
- keep the existing priced-listing requirement
- update the route test to assert hidden listings and non-Pro sellers are filtered at the query boundary

## Security impact
The feed no longer exposes priced listings that are hidden or owned by sellers without an active Pro subscription.

## Validation
- `pnpm main test -- tests/google-merchant-feed-route.test.ts`
- `git diff --check`