### PR TITLE
[codex] Prevent profile slugs from shadowing user ids

### DIFF
--- a/apps/main/src/server/api/routers/dashboard-db/user-profile.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/user-profile.ts
@@ -32,17 +32,28 @@ async function checkSlugAvailability(
     return false;
   }
 
-  const existingProfile = await db.userProfile.findFirst({
-    where: {
-      slug: normalizedSlug,
-      NOT: {
-        userId,
+  const [existingProfile, existingUser] = await Promise.all([
+    db.userProfile.findFirst({
+      where: {
+        slug: normalizedSlug,
+        NOT: {
+          userId,
+        },
       },
-    },
-    select: { id: true },
-  });
+      select: { id: true },
+    }),
+    db.user.findFirst({
+      where: {
+        id: normalizedSlug,
+        NOT: {
+          id: userId,
+        },
+      },
+      select: { id: true },
+    }),
+  ]);
 
-  return !existingProfile;
+  return !existingProfile && !existingUser;
 }
 
 export const dashboardDbUserProfileRouter = createTRPCRouter({

--- a/apps/main/tests/dashboard-db-user-profile-slug-router.test.ts
+++ b/apps/main/tests/dashboard-db-user-profile-slug-router.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { TRPCError } from "@trpc/server";
+import type { TRPCInternalContext } from "@/server/api/trpc";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL ??=
+  "file:./tests/.tmp/dashboard-db-user-profile-slug.sqlite";
+
+type RouterModule =
+  typeof import("@/server/api/routers/dashboard-db/user-profile");
+let dashboardDbUserProfileRouter: RouterModule["dashboardDbUserProfileRouter"];
+
+beforeAll(async () => {
+  ({ dashboardDbUserProfileRouter } = await import(
+    "@/server/api/routers/dashboard-db/user-profile"
+  ));
+});
+
+interface MockDb {
+  user: {
+    findFirst: ReturnType<typeof vi.fn>;
+  };
+  userProfile: {
+    findFirst: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createMockDb(): MockDb {
+  return {
+    user: {
+      findFirst: vi.fn(),
+    },
+    userProfile: {
+      findFirst: vi.fn(),
+      upsert: vi.fn(),
+    },
+  };
+}
+
+function createCaller(db: MockDb) {
+  return dashboardDbUserProfileRouter.createCaller({
+    db: db as unknown as TRPCInternalContext["db"],
+    _authUser: { id: "user-1" } as unknown as TRPCInternalContext["_authUser"],
+    headers: new Headers(),
+  });
+}
+
+describe("dashboardDb.userProfile slug namespace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects slugs that match another user's raw id", async () => {
+    const db = createMockDb();
+    db.userProfile.findFirst.mockResolvedValue(null);
+    db.user.findFirst.mockResolvedValue({ id: "other-user-id" });
+
+    const caller = createCaller(db);
+
+    await expect(caller.checkSlug({ slug: "other-user-id" })).resolves.toEqual({
+      available: false,
+    });
+    expect(db.user.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "other-user-id",
+        NOT: {
+          id: "user-1",
+        },
+      },
+      select: { id: true },
+    });
+  });
+
+  it("does not allow updates to shadow another user's raw id", async () => {
+    const db = createMockDb();
+    db.userProfile.findFirst.mockResolvedValue(null);
+    db.user.findFirst.mockResolvedValue({ id: "other-user-id" });
+
+    const caller = createCaller(db);
+
+    await expect(
+      caller.update({ data: { slug: "other-user-id" } }),
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(db.userProfile.upsert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- reject profile slugs that match another `User.id`
- keep the existing behavior that allows a user to use their own id as the default slug
- add router regression coverage for `checkSlug` and `update`

## Security impact
A seller can no longer claim a custom slug that shadows another user's raw id on public profile routes.

## Validation
- `pnpm main test -- tests/dashboard-db-user-profile-slug-router.test.ts tests/profile-slug-rules.test.ts`
- `SKIP_ENV_VALIDATION=1 pnpm main typecheck`
- `git diff --check`