### PR TITLE
[codex] Rate limit public inquiries

### DIFF
--- a/apps/main/src/server/api/routers/public.ts
+++ b/apps/main/src/server/api/routers/public.ts
@@ -18,6 +18,23 @@ import {
 import { sendPublicInquiry } from "@/server/services/public-inquiry";
 import { cartItemSchema } from "@/types";
 
+const publicInquiryCartItemSchema = cartItemSchema.extend({
+  id: z.string().min(1).max(128),
+  title: z.string().min(1).max(200),
+  price: z.number().min(0).max(100000).nullable(),
+  quantity: z.number().int().min(1).max(999),
+  listingId: z.string().min(1).max(128),
+  userId: z.string().min(1).max(128),
+});
+
+const publicInquiryInputSchema = z.object({
+  userId: z.string().min(1).max(128),
+  customerEmail: z.string().email().max(254),
+  customerName: z.string().max(120).optional(),
+  message: z.string().max(5000),
+  items: z.array(publicInquiryCartItemSchema).max(25).optional(),
+});
+
 export const publicRouter = createTRPCRouter({
   getPublicProfiles: publicProcedure.query(() => getPublicProfiles()),
 
@@ -78,14 +95,8 @@ export const publicRouter = createTRPCRouter({
   ),
 
   sendMessage: publicProcedure
-    .input(
-      z.object({
-        userId: z.string(),
-        customerEmail: z.string().email(),
-        customerName: z.string().optional(),
-        message: z.string(),
-        items: z.array(cartItemSchema).optional(),
-      }),
-    )
-    .mutation(async ({ input }) => sendPublicInquiry(input)),
+    .input(publicInquiryInputSchema)
+    .mutation(async ({ ctx, input }) =>
+      sendPublicInquiry(input, { headers: ctx.headers }),
+    ),
 });

--- a/apps/main/src/server/services/public-inquiry-rate-limit.ts
+++ b/apps/main/src/server/services/public-inquiry-rate-limit.ts
@@ -44,20 +44,25 @@ export interface PublicInquiryRateLimitInput {
 }
 
 function getHeader(headers: Headers | undefined, name: string) {
-  return headers?.get(name)?.trim() ?? "";
+  const value = headers?.get(name)?.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  return value;
 }
 
 export function getPublicInquiryClientId(headers: Headers | undefined) {
-  const forwardedFor = getHeader(headers, "x-forwarded-for");
+  const forwardedFor = getHeader(headers, "x-forwarded-for") ?? "";
   const forwardedIp = forwardedFor
     .split(",")
     .map((value) => value.trim())
     .find(Boolean);
 
   return (
-    forwardedIp ||
-    getHeader(headers, "x-real-ip") ||
-    getHeader(headers, "cf-connecting-ip") ||
+    forwardedIp ??
+    getHeader(headers, "x-real-ip") ??
+    getHeader(headers, "cf-connecting-ip") ??
     "unknown"
   );
 }

--- a/apps/main/src/server/services/public-inquiry-rate-limit.ts
+++ b/apps/main/src/server/services/public-inquiry-rate-limit.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { TRPCError } from "@trpc/server";
-import { kvStore as appKvStore, type KVStore } from "@/server/db/kvStore";
+import { db as appDb } from "@/server/db";
 
 export const PUBLIC_INQUIRY_RATE_LIMIT = {
   maxRequests: 5,
@@ -9,6 +9,33 @@ export const PUBLIC_INQUIRY_RATE_LIMIT = {
 
 interface RateLimitBucket {
   timestamps: number[];
+}
+
+interface RateLimitKeyValueDelegate {
+  findUnique: (args: {
+    where: { key: string };
+    select: { value: true };
+  }) => Promise<{ value: string } | null>;
+  upsert: (args: {
+    where: { key: string };
+    update: { value: string };
+    create: { key: string; value: string };
+  }) => Promise<unknown>;
+}
+
+interface TransactionalRateLimitDb {
+  $transaction: <T>(
+    callback: (tx: { keyValue: RateLimitKeyValueDelegate }) => Promise<T>,
+  ) => Promise<T>;
+}
+
+export interface PublicInquiryRateLimitStore {
+  consumeBuckets: (args: {
+    keys: string[];
+    maxRequests: number;
+    now: number;
+    windowMs: number;
+  }) => Promise<void>;
 }
 
 export interface PublicInquiryRateLimitInput {
@@ -39,16 +66,35 @@ function hashRateLimitKey(parts: string[]) {
   return createHash("sha256").update(parts.join("\0")).digest("hex");
 }
 
+function parseRateLimitBucket(value: string | null): RateLimitBucket {
+  if (!value) {
+    return { timestamps: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Partial<RateLimitBucket>;
+    return {
+      timestamps: Array.isArray(parsed.timestamps)
+        ? parsed.timestamps.filter((timestamp) => typeof timestamp === "number")
+        : [],
+    };
+  } catch {
+    return { timestamps: [] };
+  }
+}
+
 async function consumeRateLimitBucket(args: {
+  keyValue: RateLimitKeyValueDelegate;
   key: string;
   maxRequests: number;
   now: number;
-  store: KVStore;
   windowMs: number;
 }) {
-  const bucket = (await args.store.get<RateLimitBucket>(args.key)) ?? {
-    timestamps: [],
-  };
+  const record = await args.keyValue.findUnique({
+    where: { key: args.key },
+    select: { value: true },
+  });
+  const bucket = parseRateLimitBucket(record?.value ?? null);
   const windowStart = args.now - args.windowMs;
   const timestamps = bucket.timestamps.filter(
     (timestamp) => timestamp > windowStart,
@@ -62,17 +108,44 @@ async function consumeRateLimitBucket(args: {
   }
 
   timestamps.push(args.now);
-  await args.store.set(args.key, { timestamps });
+  await args.keyValue.upsert({
+    where: { key: args.key },
+    update: { value: JSON.stringify({ timestamps }) },
+    create: { key: args.key, value: JSON.stringify({ timestamps }) },
+  });
 }
+
+export function createTransactionalPublicInquiryRateLimitStore(
+  db: TransactionalRateLimitDb,
+): PublicInquiryRateLimitStore {
+  return {
+    async consumeBuckets(args) {
+      await db.$transaction(async (tx) => {
+        for (const key of args.keys) {
+          await consumeRateLimitBucket({
+            keyValue: tx.keyValue,
+            key,
+            maxRequests: args.maxRequests,
+            now: args.now,
+            windowMs: args.windowMs,
+          });
+        }
+      });
+    },
+  };
+}
+
+const defaultRateLimitStore =
+  createTransactionalPublicInquiryRateLimitStore(appDb);
 
 export async function enforcePublicInquiryRateLimit(args: {
   headers?: Headers;
   input: PublicInquiryRateLimitInput;
   now?: number;
-  store?: KVStore;
+  store?: PublicInquiryRateLimitStore;
 }) {
   const now = args.now ?? Date.now();
-  const store = args.store ?? appKvStore;
+  const store = args.store ?? defaultRateLimitStore;
   const clientId = getPublicInquiryClientId(args.headers);
   const customerEmail = args.input.customerEmail.trim().toLowerCase();
   const bucketInputs = [
@@ -80,13 +153,12 @@ export async function enforcePublicInquiryRateLimit(args: {
     ["email", customerEmail, args.input.userId],
   ];
 
-  for (const bucketInput of bucketInputs) {
-    await consumeRateLimitBucket({
-      key: `public-inquiry:${hashRateLimitKey(bucketInput)}`,
-      maxRequests: PUBLIC_INQUIRY_RATE_LIMIT.maxRequests,
-      now,
-      store,
-      windowMs: PUBLIC_INQUIRY_RATE_LIMIT.windowMs,
-    });
-  }
+  await store.consumeBuckets({
+    keys: bucketInputs.map(
+      (bucketInput) => `public-inquiry:${hashRateLimitKey(bucketInput)}`,
+    ),
+    maxRequests: PUBLIC_INQUIRY_RATE_LIMIT.maxRequests,
+    now,
+    windowMs: PUBLIC_INQUIRY_RATE_LIMIT.windowMs,
+  });
 }

--- a/apps/main/src/server/services/public-inquiry-rate-limit.ts
+++ b/apps/main/src/server/services/public-inquiry-rate-limit.ts
@@ -1,0 +1,92 @@
+import { createHash } from "node:crypto";
+import { TRPCError } from "@trpc/server";
+import { kvStore as appKvStore, type KVStore } from "@/server/db/kvStore";
+
+export const PUBLIC_INQUIRY_RATE_LIMIT = {
+  maxRequests: 5,
+  windowMs: 15 * 60 * 1000,
+} as const;
+
+interface RateLimitBucket {
+  timestamps: number[];
+}
+
+export interface PublicInquiryRateLimitInput {
+  userId: string;
+  customerEmail: string;
+}
+
+function getHeader(headers: Headers | undefined, name: string) {
+  return headers?.get(name)?.trim() ?? "";
+}
+
+export function getPublicInquiryClientId(headers: Headers | undefined) {
+  const forwardedFor = getHeader(headers, "x-forwarded-for");
+  const forwardedIp = forwardedFor
+    .split(",")
+    .map((value) => value.trim())
+    .find(Boolean);
+
+  return (
+    forwardedIp ||
+    getHeader(headers, "x-real-ip") ||
+    getHeader(headers, "cf-connecting-ip") ||
+    "unknown"
+  );
+}
+
+function hashRateLimitKey(parts: string[]) {
+  return createHash("sha256").update(parts.join("\0")).digest("hex");
+}
+
+async function consumeRateLimitBucket(args: {
+  key: string;
+  maxRequests: number;
+  now: number;
+  store: KVStore;
+  windowMs: number;
+}) {
+  const bucket = (await args.store.get<RateLimitBucket>(args.key)) ?? {
+    timestamps: [],
+  };
+  const windowStart = args.now - args.windowMs;
+  const timestamps = bucket.timestamps.filter(
+    (timestamp) => timestamp > windowStart,
+  );
+
+  if (timestamps.length >= args.maxRequests) {
+    throw new TRPCError({
+      code: "TOO_MANY_REQUESTS",
+      message: "Too many inquiries. Please try again later.",
+    });
+  }
+
+  timestamps.push(args.now);
+  await args.store.set(args.key, { timestamps });
+}
+
+export async function enforcePublicInquiryRateLimit(args: {
+  headers?: Headers;
+  input: PublicInquiryRateLimitInput;
+  now?: number;
+  store?: KVStore;
+}) {
+  const now = args.now ?? Date.now();
+  const store = args.store ?? appKvStore;
+  const clientId = getPublicInquiryClientId(args.headers);
+  const customerEmail = args.input.customerEmail.trim().toLowerCase();
+  const bucketInputs = [
+    ["ip", clientId, args.input.userId],
+    ["email", customerEmail, args.input.userId],
+  ];
+
+  for (const bucketInput of bucketInputs) {
+    await consumeRateLimitBucket({
+      key: `public-inquiry:${hashRateLimitKey(bucketInput)}`,
+      maxRequests: PUBLIC_INQUIRY_RATE_LIMIT.maxRequests,
+      now,
+      store,
+      windowMs: PUBLIC_INQUIRY_RATE_LIMIT.windowMs,
+    });
+  }
+}

--- a/apps/main/src/server/services/public-inquiry.ts
+++ b/apps/main/src/server/services/public-inquiry.ts
@@ -5,6 +5,7 @@ import type { CartItem } from "@/types";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { db } from "@/server/db";
 import { getClerkUserData } from "@/server/clerk/sync-user";
+import { enforcePublicInquiryRateLimit } from "@/server/services/public-inquiry-rate-limit";
 
 export interface SendPublicInquiryInput {
   userId: string;
@@ -12,6 +13,10 @@ export interface SendPublicInquiryInput {
   customerName?: string;
   message: string;
   items?: CartItem[];
+}
+
+export interface SendPublicInquiryOptions {
+  headers?: Headers;
 }
 
 interface PublicInquiryContext {
@@ -127,7 +132,9 @@ async function loadPublicInquiryContext(
   }
 
   const customerDisplayName = getCustomerDisplayName(input);
-  const { formattedItems, hasCartItems, subtotal } = formatCartItems(input.items);
+  const { formattedItems, hasCartItems, subtotal } = formatCartItems(
+    input.items,
+  );
   const catalogUrl = `${getCanonicalBaseUrl()}/${user.profile?.slug ?? user.id}`;
 
   return {
@@ -225,8 +232,14 @@ This is an automated confirmation from Daylily Catalog. Please do not reply.
 
 export async function sendPublicInquiry(
   input: SendPublicInquiryInput,
+  options: SendPublicInquiryOptions = {},
 ): Promise<{ success: boolean; message: string }> {
   try {
+    await enforcePublicInquiryRateLimit({
+      headers: options.headers,
+      input,
+    });
+
     const context = await loadPublicInquiryContext(input);
     const cleanedMessage = normalizeInquiryMessage(input.message);
     const formattedMessage =

--- a/apps/main/tests/e2e/utils/seed-manage-list-page.ts
+++ b/apps/main/tests/e2e/utils/seed-manage-list-page.ts
@@ -51,20 +51,43 @@ export async function seedManageListPageData({
     },
   });
 
+  const bulkListings = [];
   for (let i = 1; i <= TOTAL_LINKED_LISTINGS - 3; i++) {
     const number = pad(i);
-    await db.listing.create({
-      data: {
-        userId: user.id,
-        title: `List Listing ${number}`,
-        slug: `list-listing-${number}`,
-        price: i,
-        lists: {
-          connect: [{ id: list.id }],
-        },
-      },
+    bulkListings.push({
+      userId: user.id,
+      title: `List Listing ${number}`,
+      slug: `list-listing-${number}`,
+      price: i,
     });
   }
+
+  await db.listing.createMany({
+    data: bulkListings,
+  });
+
+  const bulkListingIds = await db.listing.findMany({
+    where: {
+      userId: user.id,
+      slug: {
+        in: bulkListings.map((listing) => listing.slug),
+      },
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  await db.list.update({
+    where: {
+      id: list.id,
+    },
+    data: {
+      listings: {
+        connect: bulkListingIds,
+      },
+    },
+  });
 
   const sortToken = "token-manage-sort";
   const sortAlphaTitle = "Sort Alpha token-manage-sort";
@@ -147,7 +170,9 @@ export async function seedManageListPageData({
     },
   });
 
-  const expectedPageCountBeforeAdd = Math.ceil(beforeAddCount / DEFAULT_PAGE_SIZE);
+  const expectedPageCountBeforeAdd = Math.ceil(
+    beforeAddCount / DEFAULT_PAGE_SIZE,
+  );
   const totalListListingsAfterAdd = beforeAddCount + 1;
   const expectedPageCountAfterAdd = Math.ceil(
     totalListListingsAfterAdd / DEFAULT_PAGE_SIZE,

--- a/apps/main/tests/public-inquiry-rate-limit.test.ts
+++ b/apps/main/tests/public-inquiry-rate-limit.test.ts
@@ -1,27 +1,101 @@
 // @vitest-environment node
 
 import { describe, expect, it } from "vitest";
-import type { KVStore } from "@/server/db/kvStore";
 import {
+  createTransactionalPublicInquiryRateLimitStore,
   enforcePublicInquiryRateLimit,
   getPublicInquiryClientId,
+  type PublicInquiryRateLimitStore,
   PUBLIC_INQUIRY_RATE_LIMIT,
 } from "@/server/services/public-inquiry-rate-limit";
 
-function createMemoryStore(): KVStore {
-  const values = new Map<string, unknown>();
+interface MemoryKeyValueDb {
+  values: Map<string, string>;
+  keyValue: {
+    findUnique: (args: {
+      where: { key: string };
+      select: { value: true };
+    }) => Promise<{ value: string } | null>;
+    upsert: (args: {
+      where: { key: string };
+      update: { value: string };
+      create: { key: string; value: string };
+    }) => Promise<unknown>;
+  };
+  $transaction: <T>(
+    callback: (tx: { keyValue: MemoryKeyValueDb["keyValue"] }) => Promise<T>,
+  ) => Promise<T>;
+}
 
-  return {
-    async get<T>(key: string) {
-      return (values.get(key) as T | undefined) ?? null;
+function createMemoryKeyValueDb(): MemoryKeyValueDb {
+  const db: MemoryKeyValueDb = {
+    values: new Map<string, string>(),
+    keyValue: {
+      async findUnique(args) {
+        const value = db.values.get(args.where.key);
+        return value ? { value } : null;
+      },
+      async upsert(args) {
+        const nextValue = db.values.has(args.where.key)
+          ? args.update.value
+          : args.create.value;
+        db.values.set(args.where.key, nextValue);
+        return {};
+      },
     },
-    async set<T>(key: string, value: T) {
-      values.set(key, value);
-    },
-    async delete(key: string) {
-      values.delete(key);
+    async $transaction(callback) {
+      const committedValues = db.values;
+      const transactionValues = new Map(committedValues);
+      const txKeyValue = {
+        async findUnique(args: {
+          where: { key: string };
+          select: { value: true };
+        }) {
+          const value = transactionValues.get(args.where.key);
+          return value ? { value } : null;
+        },
+        async upsert(args: {
+          where: { key: string };
+          update: { value: string };
+          create: { key: string; value: string };
+        }) {
+          const nextValue = transactionValues.has(args.where.key)
+            ? args.update.value
+            : args.create.value;
+          transactionValues.set(args.where.key, nextValue);
+          return {};
+        },
+      };
+
+      const result = await callback({ keyValue: txKeyValue });
+      db.values = transactionValues;
+      return result;
     },
   };
+
+  return db;
+}
+
+function createMemoryStore(): PublicInquiryRateLimitStore {
+  const db = createMemoryKeyValueDb();
+
+  return createTransactionalPublicInquiryRateLimitStore(db);
+}
+
+function parseBucket(value: string | undefined) {
+  return value
+    ? ((JSON.parse(value) as { timestamps?: number[] }).timestamps ?? [])
+    : [];
+}
+
+async function findBucketKey(db: MemoryKeyValueDb, matchCount: number) {
+  for (const [key, value] of db.values.entries()) {
+    if (parseBucket(value).length === matchCount) {
+      return key;
+    }
+  }
+
+  throw new Error(`No bucket with ${matchCount} entries found`);
 }
 
 describe("public inquiry rate limiting", () => {
@@ -97,5 +171,50 @@ describe("public inquiry rate limiting", () => {
         store,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("rolls back earlier bucket writes when a later bucket is over limit", async () => {
+    const db = createMemoryKeyValueDb();
+    const store = createTransactionalPublicInquiryRateLimitStore(db);
+    const headers = new Headers({ "x-forwarded-for": "203.0.113.10" });
+    const input = {
+      userId: "seller-1",
+      customerEmail: "buyer@example.com",
+    };
+
+    await enforcePublicInquiryRateLimit({
+      headers,
+      input,
+      now: 1_000,
+      store,
+    });
+    const ipBucketKey = await findBucketKey(db, 1);
+
+    for (
+      let index = 1;
+      index < PUBLIC_INQUIRY_RATE_LIMIT.maxRequests;
+      index++
+    ) {
+      await enforcePublicInquiryRateLimit({
+        headers: new Headers({ "x-forwarded-for": `203.0.113.${index + 10}` }),
+        input,
+        now: 1_000,
+        store,
+      });
+    }
+
+    expect(parseBucket(db.values.get(ipBucketKey))).toHaveLength(1);
+
+    await expect(
+      enforcePublicInquiryRateLimit({
+        headers,
+        input,
+        now: 1_000,
+        store,
+      }),
+    ).rejects.toMatchObject({
+      code: "TOO_MANY_REQUESTS",
+    });
+    expect(parseBucket(db.values.get(ipBucketKey))).toHaveLength(1);
   });
 });

--- a/apps/main/tests/public-inquiry-rate-limit.test.ts
+++ b/apps/main/tests/public-inquiry-rate-limit.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import type { KVStore } from "@/server/db/kvStore";
+import {
+  enforcePublicInquiryRateLimit,
+  getPublicInquiryClientId,
+  PUBLIC_INQUIRY_RATE_LIMIT,
+} from "@/server/services/public-inquiry-rate-limit";
+
+function createMemoryStore(): KVStore {
+  const values = new Map<string, unknown>();
+
+  return {
+    async get<T>(key: string) {
+      return (values.get(key) as T | undefined) ?? null;
+    },
+    async set<T>(key: string, value: T) {
+      values.set(key, value);
+    },
+    async delete(key: string) {
+      values.delete(key);
+    },
+  };
+}
+
+describe("public inquiry rate limiting", () => {
+  it("uses the first forwarded IP as the client identity", () => {
+    const headers = new Headers({
+      "x-forwarded-for": "203.0.113.10, 10.0.0.2",
+    });
+
+    expect(getPublicInquiryClientId(headers)).toBe("203.0.113.10");
+  });
+
+  it("rejects repeated inquiries for the same seller and client window", async () => {
+    const store = createMemoryStore();
+    const headers = new Headers({ "x-forwarded-for": "203.0.113.10" });
+    const input = {
+      userId: "seller-1",
+      customerEmail: "buyer@example.com",
+    };
+
+    for (
+      let index = 0;
+      index < PUBLIC_INQUIRY_RATE_LIMIT.maxRequests;
+      index++
+    ) {
+      await expect(
+        enforcePublicInquiryRateLimit({
+          headers,
+          input,
+          now: 1_000,
+          store,
+        }),
+      ).resolves.toBeUndefined();
+    }
+
+    await expect(
+      enforcePublicInquiryRateLimit({
+        headers,
+        input,
+        now: 1_000,
+        store,
+      }),
+    ).rejects.toMatchObject({
+      code: "TOO_MANY_REQUESTS",
+    });
+  });
+
+  it("allows requests after the rate limit window expires", async () => {
+    const store = createMemoryStore();
+    const headers = new Headers({ "x-forwarded-for": "203.0.113.10" });
+    const input = {
+      userId: "seller-1",
+      customerEmail: "buyer@example.com",
+    };
+
+    for (
+      let index = 0;
+      index < PUBLIC_INQUIRY_RATE_LIMIT.maxRequests;
+      index++
+    ) {
+      await enforcePublicInquiryRateLimit({
+        headers,
+        input,
+        now: 1_000,
+        store,
+      });
+    }
+
+    await expect(
+      enforcePublicInquiryRateLimit({
+        headers,
+        input,
+        now: 1_000 + PUBLIC_INQUIRY_RATE_LIMIT.windowMs + 1,
+        store,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/main/tests/public-inquiry-rate-limit.test.ts
+++ b/apps/main/tests/public-inquiry-rate-limit.test.ts
@@ -1,13 +1,39 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
-import {
-  createTransactionalPublicInquiryRateLimitStore,
-  enforcePublicInquiryRateLimit,
-  getPublicInquiryClientId,
-  type PublicInquiryRateLimitStore,
-  PUBLIC_INQUIRY_RATE_LIMIT,
-} from "@/server/services/public-inquiry-rate-limit";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { PublicInquiryRateLimitStore } from "@/server/services/public-inquiry-rate-limit";
+
+type PublicInquiryRateLimitModule =
+  typeof import("@/server/services/public-inquiry-rate-limit");
+
+let createTransactionalPublicInquiryRateLimitStore: PublicInquiryRateLimitModule[
+  "createTransactionalPublicInquiryRateLimitStore"
+];
+let enforcePublicInquiryRateLimit: PublicInquiryRateLimitModule[
+  "enforcePublicInquiryRateLimit"
+];
+let getPublicInquiryClientId: PublicInquiryRateLimitModule[
+  "getPublicInquiryClientId"
+];
+let PUBLIC_INQUIRY_RATE_LIMIT: PublicInquiryRateLimitModule[
+  "PUBLIC_INQUIRY_RATE_LIMIT"
+];
+
+beforeAll(async () => {
+  process.env.SKIP_ENV_VALIDATION = "1";
+  process.env.DATABASE_URL ??=
+    "file:./tests/.tmp/public-inquiry-rate-limit.sqlite";
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ??= "pk_test_placeholder";
+  process.env.NEXT_PUBLIC_CLOUDFLARE_URL ??=
+    "https://placeholder.cloudflare.com";
+
+  ({
+    createTransactionalPublicInquiryRateLimitStore,
+    enforcePublicInquiryRateLimit,
+    getPublicInquiryClientId,
+    PUBLIC_INQUIRY_RATE_LIMIT,
+  } = await import("@/server/services/public-inquiry-rate-limit"));
+});
 
 interface MemoryKeyValueDb {
   values: Map<string, string>;

--- a/apps/main/tests/public-router-send-message.test.ts
+++ b/apps/main/tests/public-router-send-message.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TRPCInternalContext } from "@/server/api/trpc";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL ??=
+  "file:./tests/.tmp/public-router-send-message.sqlite";
+
+const serviceMocks = vi.hoisted(() => ({
+  sendPublicInquiry: vi.fn(),
+}));
+
+vi.mock("@/server/services/public-inquiry", () => ({
+  sendPublicInquiry: serviceMocks.sendPublicInquiry,
+}));
+
+type RouterModule = typeof import("@/server/api/routers/public");
+let publicRouter: RouterModule["publicRouter"];
+
+beforeAll(async () => {
+  ({ publicRouter } = await import("@/server/api/routers/public"));
+});
+
+function createCaller(headers: Headers) {
+  return publicRouter.createCaller({
+    db: {} as TRPCInternalContext["db"],
+    headers,
+  });
+}
+
+describe("public.sendMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceMocks.sendPublicInquiry.mockResolvedValue({
+      success: true,
+      message: "Message sent successfully",
+    });
+  });
+
+  it("passes request headers to the inquiry service", async () => {
+    const headers = new Headers({ "x-forwarded-for": "203.0.113.10" });
+    const caller = createCaller(headers);
+    const input = {
+      userId: "seller-1",
+      customerEmail: "buyer@example.com",
+      customerName: "Buyer",
+      message: "Do you still have this daylily?",
+      items: [
+        {
+          id: "cart-item-1",
+          title: "Starman",
+          price: 25,
+          quantity: 1,
+          listingId: "listing-1",
+          userId: "seller-1",
+        },
+      ],
+    };
+
+    await caller.sendMessage(input);
+
+    expect(serviceMocks.sendPublicInquiry).toHaveBeenCalledWith(input, {
+      headers,
+    });
+  });
+
+  it("rejects oversized messages before calling the inquiry service", async () => {
+    const caller = createCaller(new Headers());
+
+    await expect(
+      caller.sendMessage({
+        userId: "seller-1",
+        customerEmail: "buyer@example.com",
+        message: "x".repeat(5001),
+      }),
+    ).rejects.toThrow();
+    expect(serviceMocks.sendPublicInquiry).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add server-side bounds for public inquiry payloads, including message length and cart item count
- pass request headers into the inquiry service
- add persistent sliding-window rate limits keyed by client IP plus seller and customer email plus seller
- add tests for header propagation, payload rejection, and rate-limit behavior

## Security impact
The unauthenticated inquiry endpoint now rejects oversized payloads and repeated submissions before doing seller lookup or SES sends, reducing email abuse and cost amplification.

## Validation
- `pnpm main test -- tests/public-inquiry-rate-limit.test.ts tests/public-router-send-message.test.ts`
- `SKIP_ENV_VALIDATION=1 pnpm main typecheck`
- `git diff --check`