### PR TITLE
[codex] Use canonical origins for redirects

### DIFF
--- a/apps/main/src/app/api/legacy-redirect/route.ts
+++ b/apps/main/src/app/api/legacy-redirect/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { getListingOwnerWithSlugs } from "@/server/db/getLegacyMappings";
-import { getRequestBaseUrl } from "@/lib/utils/getBaseUrl";
+import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { buildLegacyListingRedirectPath } from "@/lib/legacy-route-redirects";
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const listingId = searchParams.get("listingId");
-  const baseUrl = getRequestBaseUrl(request.headers);
+  const baseUrl = getCanonicalBaseUrl();
 
   if (!listingId) {
     return NextResponse.redirect(new URL("/catalogs", baseUrl));

--- a/apps/main/src/app/subscribe/success/page.tsx
+++ b/apps/main/src/app/subscribe/success/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { auth } from "@clerk/nextjs/server";
 import { getUserByClerkId } from "@/server/api/trpc";
 import { syncStripeSubscriptionToKV } from "@/server/stripe/sync-subscription";
+import { getSafeSubscribeSuccessRedirect } from "@/lib/utils/safe-redirect";
 
 export default async function SubscribeSuccessPage({
   searchParams,
@@ -27,10 +28,5 @@ export default async function SubscribeSuccessPage({
   // Sync the subscription data
   await syncStripeSubscriptionToKV(user.stripeCustomerId);
 
-  // If there's a redirect URL, go there, otherwise go to dashboard
-  if (params.redirect) {
-    redirect(params.redirect);
-  }
-
-  redirect("/dashboard");
+  redirect(getSafeSubscribeSuccessRedirect(params.redirect));
 }

--- a/apps/main/src/lib/utils/safe-redirect.ts
+++ b/apps/main/src/lib/utils/safe-redirect.ts
@@ -1,0 +1,34 @@
+const SUBSCRIBE_SUCCESS_EXTERNAL_REDIRECT_HOSTS = new Set([
+  "billing.stripe.com",
+]);
+
+export function getSafeSubscribeSuccessRedirect(
+  redirectValue: string | undefined,
+) {
+  if (!redirectValue) {
+    return "/dashboard";
+  }
+
+  if (redirectValue.startsWith("/") && !redirectValue.startsWith("//")) {
+    try {
+      const parsed = new URL(redirectValue, "https://daylilycatalog.local");
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    } catch {
+      return "/dashboard";
+    }
+  }
+
+  try {
+    const parsed = new URL(redirectValue);
+    if (
+      parsed.protocol === "https:" &&
+      SUBSCRIBE_SUCCESS_EXTERNAL_REDIRECT_HOSTS.has(parsed.hostname)
+    ) {
+      return parsed.toString();
+    }
+  } catch {
+    return "/dashboard";
+  }
+
+  return "/dashboard";
+}

--- a/apps/main/src/server/api/routers/stripe.ts
+++ b/apps/main/src/server/api/routers/stripe.ts
@@ -1,10 +1,8 @@
 import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { env, requireEnv } from "@/env";
-import {
-  getStripeSubscription,
-} from "@/server/stripe/sync-subscription";
-import { getRequestBaseUrl } from "@/lib/utils/getBaseUrl";
+import { getStripeSubscription } from "@/server/stripe/sync-subscription";
+import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { hasActiveSubscription } from "@/server/stripe/subscription-utils";
 import { SUBSCRIPTION_CONFIG } from "@/config/subscription-config";
 import { getStripeClient } from "@/server/stripe/client";
@@ -17,7 +15,7 @@ export const stripeRouter = createTRPCRouter({
 
   generateCheckout: protectedProcedure.mutation(async ({ ctx }) => {
     const { user } = ctx;
-    const baseUrl = getRequestBaseUrl(ctx.headers);
+    const baseUrl = getCanonicalBaseUrl();
     const stripe = getStripeClient();
 
     let stripeCustomerId = user.stripeCustomerId;
@@ -79,7 +77,7 @@ export const stripeRouter = createTRPCRouter({
 
   getPortalSession: protectedProcedure.mutation(async ({ ctx }) => {
     const { user } = ctx;
-    const baseUrl = getRequestBaseUrl(ctx.headers);
+    const baseUrl = getCanonicalBaseUrl();
     const stripe = getStripeClient();
 
     if (!user.stripeCustomerId) {

--- a/apps/main/tests/legacy-redirect-route.test.ts
+++ b/apps/main/tests/legacy-redirect-route.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getListingOwnerWithSlugsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/server/db/getLegacyMappings", () => ({
+  getListingOwnerWithSlugs: getListingOwnerWithSlugsMock,
+}));
+
+vi.mock("@/lib/utils/getBaseUrl", () => ({
+  getCanonicalBaseUrl: () => "https://daylilycatalog.com",
+}));
+
+describe("legacy redirect API route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the canonical origin instead of the request host", async () => {
+    getListingOwnerWithSlugsMock.mockResolvedValue({
+      userId: "user-1",
+      userSlug: "garden",
+      listingSlug: "happy-returns",
+    });
+
+    const { GET } = await import("@/app/api/legacy-redirect/route");
+    const response = await GET(
+      new NextRequest(
+        "https://evil.example/api/legacy-redirect?listingId=listing-1",
+        {
+          headers: {
+            "x-forwarded-host": "evil.example",
+            "x-forwarded-proto": "https",
+          },
+        },
+      ),
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "https://daylilycatalog.com/garden/happy-returns",
+    );
+  });
+
+  it("uses the canonical origin for unresolved legacy listing ids", async () => {
+    getListingOwnerWithSlugsMock.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/legacy-redirect/route");
+    const response = await GET(
+      new NextRequest("https://evil.example/api/legacy-redirect"),
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "https://daylilycatalog.com/catalogs",
+    );
+  });
+});

--- a/apps/main/tests/safe-redirect.test.ts
+++ b/apps/main/tests/safe-redirect.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getSafeSubscribeSuccessRedirect } from "@/lib/utils/safe-redirect";
+
+describe("getSafeSubscribeSuccessRedirect", () => {
+  it("allows local redirect paths", () => {
+    expect(getSafeSubscribeSuccessRedirect("/dashboard?tab=billing")).toBe(
+      "/dashboard?tab=billing",
+    );
+  });
+
+  it("allows Stripe billing portal redirects", () => {
+    const stripeUrl = "https://billing.stripe.com/p/session/test_123";
+
+    expect(getSafeSubscribeSuccessRedirect(stripeUrl)).toBe(stripeUrl);
+  });
+
+  it("rejects protocol-relative and untrusted external redirects", () => {
+    expect(getSafeSubscribeSuccessRedirect("//evil.example/path")).toBe(
+      "/dashboard",
+    );
+    expect(getSafeSubscribeSuccessRedirect("https://evil.example/path")).toBe(
+      "/dashboard",
+    );
+    expect(getSafeSubscribeSuccessRedirect("javascript:alert(1)")).toBe(
+      "/dashboard",
+    );
+  });
+});

--- a/apps/main/tests/stripe-router-generate-checkout.test.ts
+++ b/apps/main/tests/stripe-router-generate-checkout.test.ts
@@ -21,6 +21,7 @@ process.env.NEXT_PUBLIC_CLOUDFLARE_URL ??= "https://example.com";
 const stripeMocks = vi.hoisted(() => ({
   customersCreate: vi.fn(),
   checkoutCreate: vi.fn(),
+  billingPortalCreate: vi.fn(),
 }));
 
 const subscriptionMocks = vi.hoisted(() => ({
@@ -37,6 +38,11 @@ vi.mock("@/server/stripe/client", () => ({
         create: stripeMocks.checkoutCreate,
       },
     },
+    billingPortal: {
+      sessions: {
+        create: stripeMocks.billingPortalCreate,
+      },
+    },
   }),
 }));
 
@@ -45,7 +51,7 @@ vi.mock("@/server/stripe/sync-subscription", () => ({
 }));
 
 vi.mock("@/lib/utils/getBaseUrl", () => ({
-  getRequestBaseUrl: () => "https://prod.daylilycatalog.com",
+  getCanonicalBaseUrl: () => "https://daylilycatalog.com",
 }));
 
 type StripeRouterModule = typeof import("@/server/api/routers/stripe");
@@ -76,6 +82,7 @@ function createCaller(
     stripeCustomerId: string | null;
     clerkEmail?: string;
   },
+  headers = new Headers(),
 ) {
   return stripeRouter.createCaller({
     db: db as unknown as TRPCInternalContext["db"],
@@ -86,14 +93,16 @@ function createCaller(
         email: user.clerkEmail ?? "test@example.com",
       },
     } as unknown as TRPCInternalContext["_authUser"],
-    headers: new Headers(),
+    headers,
   });
 }
 
 describe("stripe.generateCheckout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    subscriptionMocks.getStripeSubscription.mockResolvedValue({ status: "none" });
+    subscriptionMocks.getStripeSubscription.mockResolvedValue({
+      status: "none",
+    });
     stripeMocks.checkoutCreate.mockResolvedValue({
       url: "https://checkout.stripe.com/c/pay/test",
     });
@@ -122,8 +131,8 @@ describe("stripe.generateCheckout", () => {
         subscription_data: {
           trial_period_days: SUBSCRIPTION_CONFIG.FREE_TRIAL_DAYS,
         },
-        success_url: "https://prod.daylilycatalog.com/subscribe/success",
-        cancel_url: "https://prod.daylilycatalog.com/dashboard",
+        success_url: "https://daylilycatalog.com/subscribe/success",
+        cancel_url: "https://daylilycatalog.com/dashboard",
       }),
     );
   });
@@ -157,9 +166,64 @@ describe("stripe.generateCheckout", () => {
         subscription_data: {
           trial_period_days: SUBSCRIPTION_CONFIG.FREE_TRIAL_DAYS,
         },
-        success_url: "https://prod.daylilycatalog.com/subscribe/success",
-        cancel_url: "https://prod.daylilycatalog.com/dashboard",
+        success_url: "https://daylilycatalog.com/subscribe/success",
+        cancel_url: "https://daylilycatalog.com/dashboard",
       }),
     );
+  });
+
+  it("ignores untrusted request hosts when generating checkout URLs", async () => {
+    const db = createMockDb();
+    const caller = createCaller(
+      db,
+      {
+        id: "user-3",
+        stripeCustomerId: "cus_existing",
+      },
+      new Headers({
+        "x-forwarded-host": "evil.example",
+        "x-forwarded-proto": "https",
+      }),
+    );
+
+    await caller.generateCheckout();
+
+    expect(stripeMocks.checkoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url: "https://daylilycatalog.com/subscribe/success",
+        cancel_url: "https://daylilycatalog.com/dashboard",
+      }),
+    );
+  });
+});
+
+describe("stripe.getPortalSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stripeMocks.billingPortalCreate.mockResolvedValue({
+      url: "https://billing.stripe.com/p/session/test",
+    });
+  });
+
+  it("uses the canonical dashboard URL for Stripe portal return URLs", async () => {
+    const db = createMockDb();
+    const caller = createCaller(
+      db,
+      {
+        id: "user-1",
+        stripeCustomerId: "cus_existing",
+      },
+      new Headers({
+        "x-forwarded-host": "evil.example",
+        "x-forwarded-proto": "https",
+      }),
+    );
+
+    await caller.getPortalSession();
+
+    expect(stripeMocks.billingPortalCreate).toHaveBeenCalledWith({
+      customer: "cus_existing",
+      return_url: "https://daylilycatalog.com/dashboard",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- build Stripe checkout and billing portal return URLs from the canonical site origin instead of request headers
- build legacy API redirect locations from the canonical site origin
- restrict `/subscribe/success?redirect=` to same-site paths plus Stripe billing portal URLs
- add regression coverage for untrusted request hosts and unsafe redirect values

## Security impact
Host header manipulation can no longer influence Stripe return URLs or legacy redirect locations, and subscribe-success no longer acts as an arbitrary open redirect while preserving the Stripe billing portal flow.

## Validation
- `pnpm main test -- tests/stripe-router-generate-checkout.test.ts tests/safe-redirect.test.ts tests/legacy-redirect-route.test.ts`
- `SKIP_ENV_VALIDATION=1 pnpm main typecheck`
- `git diff --check`