### PR TITLE
[codex] Harden presigned image uploads

### DIFF
--- a/apps/main/src/app/start-onboarding/start-onboarding-page-client.tsx
+++ b/apps/main/src/app/start-onboarding/start-onboarding-page-client.tsx
@@ -855,6 +855,9 @@ async function uploadOnboardingImageBlob({
   const fileNamePrefix = type === "profile" ? "profile" : "listing";
   const fileName = `onboarding-${fileNamePrefix}-${Date.now()}.jpg`;
   const contentType = getSupportedImageContentType(blob.type);
+  if (!contentType) {
+    throw new Error("Only JPEG, PNG, and WebP images are supported");
+  }
 
   const { presignedUrl, key, url } = await getPresignedUrl({
     type,

--- a/apps/main/src/app/start-onboarding/start-onboarding-page-client.tsx
+++ b/apps/main/src/app/start-onboarding/start-onboarding-page-client.tsx
@@ -37,6 +37,10 @@ import { useOnboardingProfileImageFlow } from "./use-onboarding-profile-image-fl
 import { useOnboardingPreviewState } from "./use-onboarding-preview-state";
 import { useOnboardingSaveFlow } from "./use-onboarding-save-flow";
 import { useOnboardingStepFlow } from "./use-onboarding-step-flow";
+import {
+  getSupportedImageContentType,
+  type ImageContentType,
+} from "@/types/image";
 
 const DEFAULT_STARTER_IMAGE_URL = STARTER_PROFILE_IMAGES[0]?.url ?? null;
 
@@ -839,7 +843,7 @@ async function uploadOnboardingImageBlob({
   getPresignedUrl: (input: {
     type: "profile" | "listing";
     fileName: string;
-    contentType: string;
+    contentType: ImageContentType;
     size: number;
     referenceId: string;
   }) => Promise<{
@@ -850,7 +854,7 @@ async function uploadOnboardingImageBlob({
 }) {
   const fileNamePrefix = type === "profile" ? "profile" : "listing";
   const fileName = `onboarding-${fileNamePrefix}-${Date.now()}.jpg`;
-  const contentType = blob.type || "image/jpeg";
+  const contentType = getSupportedImageContentType(blob.type);
 
   const { presignedUrl, key, url } = await getPresignedUrl({
     type,
@@ -862,6 +866,7 @@ async function uploadOnboardingImageBlob({
 
   await uploadFileWithProgress({
     presignedUrl,
+    contentType,
     file: blob,
     onProgress: () => undefined,
   });

--- a/apps/main/src/hooks/use-image-upload.ts
+++ b/apps/main/src/hooks/use-image-upload.ts
@@ -2,9 +2,13 @@ import { useCallback, useState } from "react";
 import { api } from "@/trpc/react";
 import { toast } from "sonner";
 import { uploadFileWithProgress } from "@/lib/utils";
-import { type ImageType } from "@/types/image";
+import { getSupportedImageContentType, type ImageType } from "@/types/image";
 import { type Image } from "@prisma/client";
-import { getErrorMessage, normalizeError, reportError } from "@/lib/error-utils";
+import {
+  getErrorMessage,
+  normalizeError,
+  reportError,
+} from "@/lib/error-utils";
 import { createImage } from "@/app/dashboard/_lib/dashboard-db/images-collection";
 
 interface UseImageUploadOptions {
@@ -32,11 +36,12 @@ export function useImageUpload({
         setIsUploading(true);
         setProgress(0);
 
+        const contentType = getSupportedImageContentType(file.type);
         const { presignedUrl, key, url } =
           await getPresignedUrlMutation.mutateAsync({
             type,
             fileName: `${Date.now()}.jpg`,
-            contentType: file.type,
+            contentType,
             size: file.size,
             referenceId,
           });
@@ -44,6 +49,7 @@ export function useImageUpload({
         step = "upload";
         await uploadFileWithProgress({
           presignedUrl,
+          contentType,
           file,
           onProgress: setProgress,
         });
@@ -89,4 +95,3 @@ export function useImageUpload({
     isUploading,
   };
 }
-

--- a/apps/main/src/hooks/use-image-upload.ts
+++ b/apps/main/src/hooks/use-image-upload.ts
@@ -37,6 +37,10 @@ export function useImageUpload({
         setProgress(0);
 
         const contentType = getSupportedImageContentType(file.type);
+        if (!contentType) {
+          throw new Error("Only JPEG, PNG, and WebP images are supported");
+        }
+
         const { presignedUrl, key, url } =
           await getPresignedUrlMutation.mutateAsync({
             type,

--- a/apps/main/src/lib/test-utils/app-test-db.ts
+++ b/apps/main/src/lib/test-utils/app-test-db.ts
@@ -189,7 +189,13 @@ export async function withTempAppDb<T>(
 
   await previousRun;
 
-  const envKeys = ["DATABASE_URL", "SKIP_ENV_VALIDATION", "STRIPE_SECRET_KEY"] as const;
+  const envKeys = [
+    "DATABASE_URL",
+    "SKIP_ENV_VALIDATION",
+    "STRIPE_SECRET_KEY",
+    "AWS_REGION",
+    "AWS_BUCKET_NAME",
+  ] as const;
   const prevEnv = Object.fromEntries(
     envKeys.map((key) => [key, process.env[key]]),
   );
@@ -199,6 +205,8 @@ export async function withTempAppDb<T>(
   process.env.DATABASE_URL = url;
   process.env.SKIP_ENV_VALIDATION = "1";
   process.env.STRIPE_SECRET_KEY ??= "sk_test_unit";
+  process.env.AWS_REGION ??= "us-east-1";
+  process.env.AWS_BUCKET_NAME ??= "daylily-catalog-images-test";
 
   try {
     (globalThis as unknown as { prisma?: unknown }).prisma = undefined;

--- a/apps/main/src/lib/utils.ts
+++ b/apps/main/src/lib/utils.ts
@@ -91,10 +91,12 @@ export async function tryCatch<T, E = Error>(
 
 export async function uploadFileWithProgress({
   presignedUrl,
+  contentType,
   file,
   onProgress,
 }: {
   presignedUrl: string;
+  contentType?: string;
   file: Blob;
   onProgress: (pct: number) => void;
 }) {
@@ -111,7 +113,7 @@ export async function uploadFileWithProgress({
     });
     xhr.addEventListener("error", () => reject(new Error("Upload failed")));
     xhr.open("PUT", presignedUrl);
-    xhr.setRequestHeader("Content-Type", file.type);
+    xhr.setRequestHeader("Content-Type", contentType ?? file.type);
     xhr.send(file);
   });
 }

--- a/apps/main/src/server/api/routers/dashboard-db/image.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/image.ts
@@ -7,8 +7,7 @@ import { APP_CONFIG } from "@/config/constants";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import crypto from "node:crypto";
-import path from "node:path";
-import { imageTypeSchema } from "@/types/image";
+import { imageContentTypeSchema, imageTypeSchema } from "@/types/image";
 import type { db } from "@/server/db";
 import {
   assertOwnedListing,
@@ -29,6 +28,15 @@ const imageSelect = {
 } as const;
 
 type DbClient = typeof db;
+const imageExtensionByContentType: Record<
+  z.infer<typeof imageContentTypeSchema>,
+  string
+> = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+};
+
 type ImageRow = {
   id: string;
   url: string;
@@ -68,6 +76,90 @@ function sortImagesForDashboard(
   );
 }
 
+function getUploadBucketName() {
+  return requireEnv("AWS_BUCKET_NAME", env.AWS_BUCKET_NAME);
+}
+
+function getUploadRegion() {
+  return requireEnv("AWS_REGION", env.AWS_REGION);
+}
+
+function getS3ImageUrl(key: string) {
+  return `https://${getUploadBucketName()}.s3.${getUploadRegion()}.amazonaws.com/${key}`;
+}
+
+function assertUploadKeyMatchesTarget(args: {
+  key: string;
+  referenceId: string;
+  userId: string;
+}) {
+  const prefix = `${args.userId}/${args.referenceId}/`;
+  const hasAllowedExtension = Object.values(imageExtensionByContentType).some(
+    (extension) => args.key.endsWith(extension),
+  );
+
+  if (!args.key.startsWith(prefix) || !hasAllowedExtension) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid image upload key",
+    });
+  }
+}
+
+function parseS3ImageKey(url: string) {
+  try {
+    const parsed = new URL(url);
+    const expectedHost = `${getUploadBucketName()}.s3.${getUploadRegion()}.amazonaws.com`;
+
+    if (parsed.protocol !== "https:" || parsed.host !== expectedHost) {
+      return null;
+    }
+
+    return decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
+  } catch {
+    return null;
+  }
+}
+
+function getValidatedImageUrl(args: {
+  key: string;
+  referenceId: string;
+  url: string;
+  userId: string;
+}) {
+  assertUploadKeyMatchesTarget({
+    key: args.key,
+    referenceId: args.referenceId,
+    userId: args.userId,
+  });
+
+  const parsedKey = parseS3ImageKey(args.url);
+  if (parsedKey !== args.key || args.url !== getS3ImageUrl(args.key)) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid image upload URL",
+    });
+  }
+
+  return getS3ImageUrl(args.key);
+}
+
+function getValidatedImageUrlFromUrl(args: {
+  referenceId: string;
+  url: string;
+  userId: string;
+}) {
+  const key = parseS3ImageKey(args.url);
+  if (!key) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid image upload URL",
+    });
+  }
+
+  return getValidatedImageUrl({ ...args, key });
+}
+
 async function getOwnedImageWhere(args: { db: DbClient; userId: string }) {
   const [listingRows, profile] = await Promise.all([
     args.db.listing.findMany({
@@ -94,9 +186,9 @@ export const dashboardDbImageRouter = createTRPCRouter({
     .input(
       z.object({
         type: imageTypeSchema,
-        fileName: z.string(),
-        contentType: z.string(),
-        size: z.number().max(APP_CONFIG.UPLOAD.MAX_FILE_SIZE),
+        fileName: z.string().min(1).max(255),
+        contentType: imageContentTypeSchema,
+        size: z.number().int().positive().max(APP_CONFIG.UPLOAD.MAX_FILE_SIZE),
         referenceId: z.string(),
       }),
     )
@@ -126,24 +218,23 @@ export const dashboardDbImageRouter = createTRPCRouter({
         },
       });
 
-      const ext = path.extname(input.fileName);
-      const fileId = crypto.randomBytes(4).toString("hex");
+      const ext = imageExtensionByContentType[input.contentType];
+      const fileId = crypto.randomBytes(16).toString("hex");
       const key = `${ctx.user.id}/${input.referenceId}/${fileId}${ext}`;
 
       const command = new PutObjectCommand({
-        Bucket: requireEnv("AWS_BUCKET_NAME", env.AWS_BUCKET_NAME),
+        Bucket: getUploadBucketName(),
         Key: key,
         ContentType: input.contentType,
+        ContentLength: input.size,
       });
 
-      const bucketName = requireEnv("AWS_BUCKET_NAME", env.AWS_BUCKET_NAME);
-      const region = requireEnv("AWS_REGION", env.AWS_REGION);
       const url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
 
       return {
         presignedUrl: url,
         key,
-        url: `https://${bucketName}.s3.${region}.amazonaws.com/${key}`,
+        url: getS3ImageUrl(key),
       } as const;
     }),
 
@@ -243,7 +334,7 @@ export const dashboardDbImageRouter = createTRPCRouter({
       z.object({
         type: imageTypeSchema,
         referenceId: z.string(),
-        url: z.string().min(1),
+        url: z.url(),
         key: z.string().min(1),
       }),
     )
@@ -262,6 +353,13 @@ export const dashboardDbImageRouter = createTRPCRouter({
         });
       }
 
+      const imageUrl = getValidatedImageUrl({
+        key: input.key,
+        referenceId: input.referenceId,
+        url: input.url,
+        userId: ctx.user.id,
+      });
+
       const whereClause =
         input.type === "listing"
           ? { listingId: input.referenceId }
@@ -271,7 +369,7 @@ export const dashboardDbImageRouter = createTRPCRouter({
 
       const image = await ctx.db.image.create({
         data: {
-          url: input.url,
+          url: imageUrl,
           order: currentCount,
           ...(input.type === "listing"
             ? { listingId: input.referenceId }
@@ -289,7 +387,7 @@ export const dashboardDbImageRouter = createTRPCRouter({
         type: imageTypeSchema,
         referenceId: z.string(),
         imageId: z.string(),
-        url: z.string().min(1),
+        url: z.url(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -328,9 +426,15 @@ export const dashboardDbImageRouter = createTRPCRouter({
         });
       }
 
+      const imageUrl = getValidatedImageUrlFromUrl({
+        referenceId: input.referenceId,
+        url: input.url,
+        userId: ctx.user.id,
+      });
+
       const image = await ctx.db.image.update({
         where: { id: input.imageId },
-        data: { url: input.url },
+        data: { url: imageUrl },
         select: imageSelect,
       });
 

--- a/apps/main/src/types/image.ts
+++ b/apps/main/src/types/image.ts
@@ -113,13 +113,30 @@ export interface ImageError {
 // Zod schemas for validation
 export const imageTypeSchema = z.enum(["listing", "profile"]);
 export type ImageType = z.infer<typeof imageTypeSchema>;
+export const imageContentTypeSchema = z.enum([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+export type ImageContentType = z.infer<typeof imageContentTypeSchema>;
+
+export function getSupportedImageContentType(
+  contentType: string | undefined,
+): ImageContentType {
+  const parsed = imageContentTypeSchema.safeParse(contentType);
+  return parsed.success ? parsed.data : "image/jpeg";
+}
 
 export const presignedUrlSchema = z.object({
   type: imageTypeSchema,
   userId: z.string(),
   fileName: z.string(),
-  contentType: z.string(),
-  size: z.number().max(5 * 1024 * 1024), // 5MB
+  contentType: imageContentTypeSchema,
+  size: z
+    .number()
+    .int()
+    .positive()
+    .max(5 * 1024 * 1024), // 5MB
   listingId: z.string().optional(),
   userProfileId: z.string().optional(),
 });

--- a/apps/main/src/types/image.ts
+++ b/apps/main/src/types/image.ts
@@ -122,9 +122,13 @@ export type ImageContentType = z.infer<typeof imageContentTypeSchema>;
 
 export function getSupportedImageContentType(
   contentType: string | undefined,
-): ImageContentType {
+): ImageContentType | undefined {
+  if (!contentType) {
+    return "image/jpeg";
+  }
+
   const parsed = imageContentTypeSchema.safeParse(contentType);
-  return parsed.success ? parsed.data : "image/jpeg";
+  return parsed.success ? parsed.data : undefined;
 }
 
 export const presignedUrlSchema = z.object({

--- a/apps/main/tests/dashboard-db-collections.test.tsx
+++ b/apps/main/tests/dashboard-db-collections.test.tsx
@@ -965,7 +965,7 @@ describe("dashboardDb TanStack DB collections", () => {
   });
 
   it("images: create -> reorder -> delete renumbers", async () => {
-    await withTempAppDb(async () => {
+    await withTempAppDb(async ({ user }) => {
       const { insertListing, initializeListingsCollection } = await import(
         "@/app/dashboard/_lib/dashboard-db/listings-collection"
       );
@@ -999,18 +999,24 @@ describe("dashboardDb TanStack DB collections", () => {
 
       let u1Id = "";
       let u2Id = "";
+      let url1 = "";
+      let url2 = "";
       await act(async () => {
+        const key1 = `${user.id}/${listingId}/u1.jpg`;
+        const key2 = `${user.id}/${listingId}/u2.jpg`;
+        url1 = `https://daylily-catalog-images-test.s3.us-east-1.amazonaws.com/${key1}`;
+        url2 = `https://daylily-catalog-images-test.s3.us-east-1.amazonaws.com/${key2}`;
         const u1 = await createImage({
           type: "listing",
           referenceId: listingId,
-          url: "u1",
-          key: "k1",
+          url: url1,
+          key: key1,
         });
         const u2 = await createImage({
           type: "listing",
           referenceId: listingId,
-          url: "u2",
-          key: "k2",
+          url: url2,
+          key: key2,
         });
         u1Id = u1.id;
         u2Id = u2.id;
@@ -1018,7 +1024,7 @@ describe("dashboardDb TanStack DB collections", () => {
 
       await waitFor(() => {
         expect(screen.getByTestId("count").textContent).toBe("2");
-        expect(screen.getByTestId("urls").textContent).toBe("u1,u2");
+        expect(screen.getByTestId("urls").textContent).toBe(`${url1},${url2}`);
         expect(screen.getByTestId("orders").textContent).toBe("0,1");
       });
 
@@ -1034,7 +1040,7 @@ describe("dashboardDb TanStack DB collections", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId("urls").textContent).toBe("u2,u1");
+        expect(screen.getByTestId("urls").textContent).toBe(`${url2},${url1}`);
         expect(screen.getByTestId("orders").textContent).toBe("0,1");
       });
 
@@ -1048,7 +1054,7 @@ describe("dashboardDb TanStack DB collections", () => {
 
       await waitFor(() => {
         expect(screen.getByTestId("count").textContent).toBe("1");
-        expect(screen.getByTestId("urls").textContent).toBe("u1");
+        expect(screen.getByTestId("urls").textContent).toBe(url1);
         expect(screen.getByTestId("orders").textContent).toBe("0");
       });
     });

--- a/apps/main/tests/dashboard-db-image-router.test.ts
+++ b/apps/main/tests/dashboard-db-image-router.test.ts
@@ -5,6 +5,24 @@ import type { TRPCInternalContext } from "@/server/api/trpc";
 
 process.env.SKIP_ENV_VALIDATION = "1";
 process.env.DATABASE_URL ??= "file:./tests/.tmp/dashboard-db-image.sqlite";
+process.env.AWS_ACCESS_KEY_ID ??= "test-access-key";
+process.env.AWS_SECRET_ACCESS_KEY ??= "test-secret-key";
+process.env.AWS_REGION ??= "us-east-1";
+process.env.AWS_BUCKET_NAME ??= "daylily-catalog-images-test";
+
+const s3Mocks = vi.hoisted(() => ({
+  putObjectCommand: vi.fn((input: unknown) => ({ input })),
+  getSignedUrl: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: vi.fn(),
+  PutObjectCommand: s3Mocks.putObjectCommand,
+}));
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: s3Mocks.getSignedUrl,
+}));
 
 type RouterModule = typeof import("@/server/api/routers/dashboard-db/image");
 let dashboardDbImageRouter: RouterModule["dashboardDbImageRouter"];
@@ -18,12 +36,18 @@ beforeAll(async () => {
 interface MockDb {
   $queryRaw: ReturnType<typeof vi.fn>;
   image: {
+    count: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
   };
   listing: {
+    findFirst: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
   };
   userProfile: {
+    findFirst: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
   };
 }
@@ -32,12 +56,18 @@ function createMockDb(): MockDb {
   return {
     $queryRaw: vi.fn(),
     image: {
+      count: vi.fn(),
+      create: vi.fn(),
+      findUnique: vi.fn(),
       findMany: vi.fn(),
+      update: vi.fn(),
     },
     listing: {
+      findFirst: vi.fn(),
       findMany: vi.fn(),
     },
     userProfile: {
+      findFirst: vi.fn(),
       findUnique: vi.fn(),
     },
   };
@@ -54,6 +84,128 @@ function createCaller(db: MockDb) {
 describe("dashboardDb.image", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    s3Mocks.getSignedUrl.mockResolvedValue("https://upload-url.example");
+  });
+
+  it("presigns only allowed image types with a server-derived extension and content length", async () => {
+    const db = createMockDb();
+    db.listing.findFirst.mockResolvedValue({ id: "listing-1" });
+
+    const caller = createCaller(db);
+    const result = await caller.getPresignedUrl({
+      type: "listing",
+      referenceId: "listing-1",
+      fileName: "payload.svg",
+      contentType: "image/jpeg",
+      size: 1234,
+    });
+
+    expect(result.presignedUrl).toBe("https://upload-url.example");
+    expect(result.key).toMatch(/^user-1\/listing-1\/[a-f0-9]{32}\.jpg$/);
+    expect(result.url).toBe(
+      `https://${process.env.AWS_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${result.key}`,
+    );
+    expect(s3Mocks.putObjectCommand).toHaveBeenCalledWith({
+      Bucket: process.env.AWS_BUCKET_NAME,
+      Key: result.key,
+      ContentType: "image/jpeg",
+      ContentLength: 1234,
+    });
+  });
+
+  it("rejects unsupported image content types before presigning", async () => {
+    const db = createMockDb();
+    const caller = createCaller(db);
+
+    await expect(
+      caller.getPresignedUrl({
+        type: "listing",
+        referenceId: "listing-1",
+        fileName: "payload.svg",
+        contentType: "image/svg+xml" as never,
+        size: 1234,
+      }),
+    ).rejects.toThrow();
+    expect(db.listing.findFirst).not.toHaveBeenCalled();
+    expect(s3Mocks.getSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("saves only owned upload keys that match the expected S3 URL", async () => {
+    const db = createMockDb();
+    db.listing.findFirst.mockResolvedValue({ id: "listing-1" });
+    db.image.count.mockResolvedValue(0);
+    db.image.create.mockImplementation(async (args) => ({
+      id: "image-1",
+      url: args.data.url,
+      order: args.data.order,
+      listingId: args.data.listingId,
+      userProfileId: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+      status: null,
+    }));
+
+    const key = "user-1/listing-1/uploaded.jpg";
+    const url = `https://${process.env.AWS_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
+    const caller = createCaller(db);
+
+    const result = await caller.create({
+      type: "listing",
+      referenceId: "listing-1",
+      key,
+      url,
+    });
+
+    expect(result.url).toBe(url);
+    expect(db.image.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          url,
+          order: 0,
+          listingId: "listing-1",
+        }),
+      }),
+    );
+  });
+
+  it("rejects image records when the key does not belong to the current target", async () => {
+    const db = createMockDb();
+    db.listing.findFirst.mockResolvedValue({ id: "listing-1" });
+
+    const key = "user-2/listing-1/uploaded.jpg";
+    const url = `https://${process.env.AWS_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
+    const caller = createCaller(db);
+
+    await expect(
+      caller.create({
+        type: "listing",
+        referenceId: "listing-1",
+        key,
+        url,
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+    expect(db.image.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects image records when the URL does not match the upload key", async () => {
+    const db = createMockDb();
+    db.listing.findFirst.mockResolvedValue({ id: "listing-1" });
+
+    const caller = createCaller(db);
+
+    await expect(
+      caller.create({
+        type: "listing",
+        referenceId: "listing-1",
+        key: "user-1/listing-1/uploaded.jpg",
+        url: "https://evil.example/uploaded.jpg",
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+    expect(db.image.create).not.toHaveBeenCalled();
   });
 
   it("sync filters images through direct owner foreign keys", async () => {

--- a/apps/main/tests/use-image-upload.test.ts
+++ b/apps/main/tests/use-image-upload.test.ts
@@ -162,6 +162,30 @@ describe("useImageUpload", () => {
     );
   });
 
+  it("rejects unsupported typed blobs before presigning", async () => {
+    const { result } = renderHook(() =>
+      useImageUpload({
+        type: "listing",
+        referenceId: "listing-1",
+      }),
+    );
+
+    const file = new Blob(["image-bytes"], { type: "image/gif" });
+
+    let returned: unknown;
+    await act(async () => {
+      returned = await result.current.upload(file);
+    });
+
+    expect(returned).toBeUndefined();
+    expect(getPresignedUrlMutateAsyncMock).not.toHaveBeenCalled();
+    expect(uploadFileWithProgressMock).not.toHaveBeenCalled();
+    expect(createImageMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith("Failed to get upload URL", {
+      description: "Only JPEG, PNG, and WebP images are supported",
+    });
+  });
+
   it("handles presigned-url failure and resets state", async () => {
     getPresignedUrlMutateAsyncMock.mockRejectedValue(
       new Error("Presign failed"),

--- a/apps/main/tests/use-image-upload.test.ts
+++ b/apps/main/tests/use-image-upload.test.ts
@@ -67,11 +67,7 @@ describe("useImageUpload", () => {
       url: uploadedImage.url,
     });
     uploadFileWithProgressMock.mockImplementation(
-      async ({
-        onProgress,
-      }: {
-        onProgress: (value: number) => void;
-      }) => {
+      async ({ onProgress }: { onProgress: (value: number) => void }) => {
         onProgress(25);
         onProgress(100);
       },
@@ -116,7 +112,9 @@ describe("useImageUpload", () => {
       key: "abc123.jpg",
     });
     expect(onSuccess).toHaveBeenCalledWith(uploadedImage);
-    expect(toastSuccessMock).toHaveBeenCalledWith("Image uploaded successfully");
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Image uploaded successfully",
+    );
     expect(returned).toEqual(uploadedImage);
 
     await waitFor(() => {
@@ -125,8 +123,49 @@ describe("useImageUpload", () => {
     });
   });
 
+  it("uses a supported signed content type for untyped blobs", async () => {
+    const uploadedImage = {
+      id: "img-1",
+      url: "https://example.com/images/img-1.jpg",
+    };
+
+    getPresignedUrlMutateAsyncMock.mockResolvedValue({
+      presignedUrl: "https://upload-url.example",
+      key: "abc123.jpg",
+      url: uploadedImage.url,
+    });
+    uploadFileWithProgressMock.mockResolvedValue(undefined);
+    createImageMock.mockResolvedValue(uploadedImage);
+
+    const { result } = renderHook(() =>
+      useImageUpload({
+        type: "listing",
+        referenceId: "listing-1",
+      }),
+    );
+
+    const file = new Blob(["image-bytes"]);
+
+    await act(async () => {
+      await result.current.upload(file);
+    });
+
+    expect(getPresignedUrlMutateAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentType: "image/jpeg",
+      }),
+    );
+    expect(uploadFileWithProgressMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentType: "image/jpeg",
+      }),
+    );
+  });
+
   it("handles presigned-url failure and resets state", async () => {
-    getPresignedUrlMutateAsyncMock.mockRejectedValue(new Error("Presign failed"));
+    getPresignedUrlMutateAsyncMock.mockRejectedValue(
+      new Error("Presign failed"),
+    );
 
     const { result } = renderHook(() =>
       useImageUpload({


### PR DESCRIPTION
## Summary
- restrict presigned image uploads to JPEG, PNG, and WebP content types
- derive the object extension from the allowed MIME type instead of the client filename
- include the expected content length in the signed PUT command
- validate uploaded image keys and S3 URLs before creating or updating image records
- ensure client upload code sends the same supported content type that was signed

## Security impact
Authenticated users can no longer obtain upload URLs for arbitrary MIME types, spoof object extensions through filenames, or save image records pointing at arbitrary external URLs or another user's upload prefix.

## Validation
- `pnpm main test -- tests/dashboard-db-image-router.test.ts tests/use-image-upload.test.ts`
- `SKIP_ENV_VALIDATION=1 pnpm main typecheck`
- `git diff --check`