### PR TITLE
[codex] Fix V2 link name sync

### DIFF
--- a/apps/main/src/server/api/routers/dashboard-db/listing.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/listing.ts
@@ -3,6 +3,11 @@ import { TRPCError } from "@trpc/server";
 import { protectedProcedure, createTRPCRouter } from "@/server/api/trpc";
 import { generateUniqueSlug } from "@/lib/utils/slugify-server";
 import {
+  ahsDisplayAhsListingSelect,
+  getDisplayAhsListing,
+  v2AhsCultivarDisplaySelect,
+} from "@/lib/utils/ahs-display";
+import {
   dashboardSyncInputSchema,
   parseDashboardSyncSince,
 } from "./dashboard-db-router-helpers";
@@ -142,7 +147,8 @@ export const dashboardDbListingRouter = createTRPCRouter({
         where: { id: input.cultivarReferenceId },
         select: {
           id: true,
-          ahsListing: { select: { name: true } },
+          ahsListing: { select: ahsDisplayAhsListingSelect },
+          v2AhsCultivar: { select: v2AhsCultivarDisplaySelect },
         },
       });
       if (!cultivarReference) {
@@ -153,7 +159,7 @@ export const dashboardDbListingRouter = createTRPCRouter({
       }
 
       const nextTitle = input.syncName
-        ? cultivarReference.ahsListing?.name
+        ? getDisplayAhsListing(cultivarReference)?.name
         : undefined;
       if (input.syncName && !nextTitle) {
         throw new TRPCError({

--- a/apps/main/tests/dashboard-db-collections.test.tsx
+++ b/apps/main/tests/dashboard-db-collections.test.tsx
@@ -1062,64 +1062,85 @@ describe("dashboardDb TanStack DB collections", () => {
   });
 
   it("cultivar refs: linking updates live joined AHS fields", async () => {
-    await withTempAppDb(async () => {
-      const { db } = await import("@/server/db");
+    const previousV2DisplayFlag =
+      process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA;
+    process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA = "true";
 
-      const ahs = await db.ahsListing.create({
-        data: { name: "AHS-Alpha" },
-      });
-      const cultivarRef = await db.cultivarReference.create({
-        data: {
-          ahsId: ahs.id,
-          normalizedName: "ahs-alpha",
-        },
-      });
+    try {
+      await withTempAppDb(async () => {
+        const { db } = await import("@/server/db");
 
-      const {
-        listingsCollection,
-        insertListing,
-        linkAhs,
-        initializeListingsCollection,
-      } = await import("@/app/dashboard/_lib/dashboard-db/listings-collection");
-      const {
-        cultivarReferencesCollection,
-        initializeCultivarReferencesCollection,
-      } = await import(
-        "@/app/dashboard/_lib/dashboard-db/cultivar-references-collection"
-      );
+        const v2AhsCultivar = await db.v2AhsCultivar.create({
+          data: {
+            id: "v2-alpha",
+            post_title: "AHS-Alpha",
+            link_normalized_name: "ahs-alpha",
+          },
+        });
+        const cultivarRef = await db.cultivarReference.create({
+          data: {
+            v2AhsCultivarId: v2AhsCultivar.id,
+            normalizedName: "ahs-alpha",
+          },
+        });
 
-      await act(async () => {
-        await initializeListingsCollection("test-user");
-        await initializeCultivarReferencesCollection("test-user");
-        render(
-          <CultivarJoinViewer
-            listingsCollection={listingsCollection}
-            cultivarReferencesCollection={cultivarReferencesCollection}
-          />,
+        const {
+          listingsCollection,
+          insertListing,
+          linkAhs,
+          initializeListingsCollection,
+        } = await import(
+          "@/app/dashboard/_lib/dashboard-db/listings-collection"
         );
-      });
+        const {
+          cultivarReferencesCollection,
+          initializeCultivarReferencesCollection,
+        } = await import(
+          "@/app/dashboard/_lib/dashboard-db/cultivar-references-collection"
+        );
 
-      let listingId = "";
-      await act(async () => {
-        const created = await insertListing({ title: "L1" });
-        listingId = created.id;
-      });
+        await act(async () => {
+          await initializeListingsCollection("test-user");
+          await initializeCultivarReferencesCollection("test-user");
+          render(
+            <CultivarJoinViewer
+              listingsCollection={listingsCollection}
+              cultivarReferencesCollection={cultivarReferencesCollection}
+            />,
+          );
+        });
 
-      await waitFor(() => {
-        expect(screen.getByTestId("joined").textContent).toBe("L1:");
-      });
+        let listingId = "";
+        await act(async () => {
+          const created = await insertListing({ title: "L1" });
+          listingId = created.id;
+        });
 
-      await act(async () => {
-        await linkAhs({
-          id: listingId,
-          cultivarReferenceId: cultivarRef.id,
-          syncName: false,
+        await waitFor(() => {
+          expect(screen.getByTestId("joined").textContent).toBe("L1:");
+        });
+
+        await act(async () => {
+          await linkAhs({
+            id: listingId,
+            cultivarReferenceId: cultivarRef.id,
+            syncName: true,
+          });
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId("joined").textContent).toBe(
+            "AHS-Alpha:AHS-Alpha",
+          );
         });
       });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("joined").textContent).toBe("L1:AHS-Alpha");
-      });
-    });
-  });
+    } finally {
+      if (previousV2DisplayFlag === undefined) {
+        delete process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA;
+      } else {
+        process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA =
+          previousV2DisplayFlag;
+      }
+    }
+  }, 15_000);
 });


### PR DESCRIPTION
## What changed

- Updates the dashboard collection regression test to use a V2-only cultivar reference and `syncName: true`.
- Makes `dashboardDb.listing.linkAhs` resolve the synced listing title through `getDisplayAhsListing`, so V2-backed cultivar references can provide the display name.

## Why

`linkAhs(syncName: true)` still read `cultivarReference.ahsListing?.name`. That breaks once a linked cultivar reference is backed only by `V2AhsCultivar`, which is the direction we are moving toward as v1 AHS data is removed.

## Validation

- First ran the updated targeted test before the code fix and confirmed it failed with `AHS listing not found`.
- `pnpm main test -- tests/dashboard-db-collections.test.tsx -t "cultivar refs: linking updates live joined AHS fields"`
- `pnpm main test -- tests/dashboard-db-collections.test.tsx`
- `pnpm lint`
- `pnpm main typecheck`
