### PR TITLE
[codex] Limit tag export render concurrency

### DIFF
--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-downloads.ts
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-downloads.ts
@@ -123,6 +123,31 @@ type Html2CanvasRenderer = (
   },
 ) => Promise<HTMLCanvasElement>;
 
+const RASTER_RENDER_CONCURRENCY = 2;
+
+export async function mapWithConcurrency<TInput, TOutput>(
+  inputs: TInput[],
+  concurrency: number,
+  mapper: (input: TInput) => Promise<TOutput>,
+) {
+  const results = new Array<TOutput>(inputs.length);
+  let nextIndex = 0;
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, inputs.length) },
+    async () => {
+      while (nextIndex < inputs.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await mapper(inputs[index]!);
+      }
+    },
+  );
+
+  await Promise.all(workers);
+  return results;
+}
+
 async function renderSingleTagCanvas(args: {
   tag: TagPreviewData;
   widthInches: number;
@@ -176,15 +201,16 @@ async function renderTagCanvasesForExport(args: {
     const { default: html2canvas } = await import("html2canvas");
     const canvases: HTMLCanvasElement[] = [];
 
-    const renderedCanvases = await Promise.all(
-      args.tags.map((tag) =>
+    const renderedCanvases = await mapWithConcurrency(
+      args.tags,
+      RASTER_RENDER_CONCURRENCY,
+      (tag) =>
         renderSingleTagCanvas({
           tag,
           widthInches: args.widthInches,
           heightInches: args.heightInches,
           html2canvas,
         }),
-      ),
     );
 
     for (const canvas of renderedCanvases) {
@@ -268,8 +294,10 @@ async function renderSheetCanvasesForExport(args: {
     const canvases: HTMLCanvasElement[] = [];
     const sheets = chunkTags(args.tags, metrics.tagsPerSheet);
 
-    const renderedCanvases = await Promise.all(
-      sheets.map((sheetTags) =>
+    const renderedCanvases = await mapWithConcurrency(
+      sheets,
+      RASTER_RENDER_CONCURRENCY,
+      (sheetTags) =>
         renderSingleSheetCanvas({
           sheetTags,
           sheetState: args.sheetState,
@@ -277,7 +305,6 @@ async function renderSheetCanvasesForExport(args: {
           tagHeightInches: args.tagHeightInches,
           html2canvas,
         }),
-      ),
     );
 
     for (const canvas of renderedCanvases) {

--- a/apps/main/tests/tag-designer-downloads.test.ts
+++ b/apps/main/tests/tag-designer-downloads.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "@/app/dashboard/tags/_components/tag-designer-downloads";
+
+describe("tag designer downloads", () => {
+  it("limits concurrent raster render work while preserving result order", async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    const results = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (item) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      active -= 1;
+
+      return item * 10;
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(results).toEqual([10, 20, 30, 40, 50]);
+  });
+});


### PR DESCRIPTION
## What changed

- Adds a small concurrency-limited mapper for tag designer raster exports.
- Uses it for individual tag image/PDF rendering and sheet image/PDF rendering.
- Adds a unit test proving the helper preserves result order while capping concurrent work.

## Why

The React Doctor cleanup left tag raster exports using `Promise.all` across every selected tag or sheet. For large selections that can launch many hidden iframe and `html2canvas` renders at once, increasing the chance of browser hangs or memory pressure.

## Validation

- `pnpm main test -- tests/tag-designer-downloads.test.ts tests/tag-designer-panel.test.tsx`
- `pnpm lint`
- `pnpm main typecheck`
