### PR TITLE
[codex] Fix tag raster downloads

### DIFF
--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-downloads.ts
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-downloads.ts
@@ -176,7 +176,7 @@ async function renderSingleTagCanvas(args: {
     const tagElement = frameDocument.querySelector<HTMLElement>(".tag");
     if (!tagElement) return null;
 
-    return args.html2canvas(tagElement, {
+    return await args.html2canvas(tagElement, {
       backgroundColor: "#ffffff",
       scale: 3,
       foreignObjectRendering: true,
@@ -261,7 +261,7 @@ async function renderSingleSheetCanvas(args: {
       frameDocument.querySelector<HTMLElement>(".sheet-page");
     if (!sheetElement) return null;
 
-    return args.html2canvas(sheetElement, {
+    return await args.html2canvas(sheetElement, {
       backgroundColor: "#ffffff",
       scale: 2,
       foreignObjectRendering: true,

--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-model.ts
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-model.ts
@@ -994,7 +994,7 @@ export function buildResolvedRowsForListing(
   for (const row of rows) {
     const resolved: ResolvedCell[] = [];
 
-    for (const cell of row.cells) {
+    for (const [cellIndex, cell] of row.cells.entries()) {
       let text: string;
       if (cell.fieldId === "customText") {
         text = cell.label ?? "";
@@ -1004,7 +1004,7 @@ export function buildResolvedRowsForListing(
       }
 
       resolved.push({
-        id: `${listing.id}-${row.id}-${cell.fieldId}`,
+        id: `${listing.id}-${row.id}-${cellIndex}-${cell.fieldId}`,
         text,
         width: cell.width,
         textAlign: cell.textAlign,

--- a/apps/main/tests/tag-designer-downloads.test.ts
+++ b/apps/main/tests/tag-designer-downloads.test.ts
@@ -1,7 +1,112 @@
-import { describe, expect, it } from "vitest";
-import { mapWithConcurrency } from "@/app/dashboard/tags/_components/tag-designer-downloads";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  downloadTagImagesZip,
+  downloadTagDocumentPdf,
+  mapWithConcurrency,
+} from "@/app/dashboard/tags/_components/tag-designer-downloads";
+import type { TagPreviewData } from "@/app/dashboard/tags/_components/tag-designer-model";
+
+const {
+  html2canvasMock,
+  pdfAddImageMock,
+  pdfSaveMock,
+  zipFileMock,
+  zipGenerateAsyncMock,
+} = vi.hoisted(() => ({
+  html2canvasMock: vi.fn(),
+  pdfAddImageMock: vi.fn(),
+  pdfSaveMock: vi.fn(),
+  zipFileMock: vi.fn(),
+  zipGenerateAsyncMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("html2canvas", () => ({
+  default: html2canvasMock,
+}));
+
+vi.mock("jspdf", () => ({
+  jsPDF: vi.fn().mockImplementation(() => ({
+    addImage: pdfAddImageMock,
+    addPage: vi.fn(),
+    save: pdfSaveMock,
+  })),
+}));
+
+vi.mock("jszip", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    folder: vi.fn(() => ({
+      file: zipFileMock,
+    })),
+    generateAsync: zipGenerateAsyncMock,
+  })),
+}));
+
+const tag: TagPreviewData = {
+  id: "tag-1",
+  qrCodeUrl: null,
+  rows: [
+    {
+      id: "row-1",
+      cells: [
+        {
+          id: "cell-1",
+          text: "Little Miss Sunshine",
+          width: 100,
+          textAlign: "left",
+          fontSize: 12,
+          bold: false,
+          italic: false,
+          underline: false,
+        },
+      ],
+    },
+  ],
+};
+
+function mockHtml2CanvasWithDelayedFrameCheck() {
+  html2canvasMock.mockImplementation(async (element: HTMLElement) => {
+    const frameElement = element.ownerDocument.defaultView
+      ?.frameElement as HTMLIFrameElement | null;
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    if (!frameElement?.isConnected) {
+      throw new Error("raster frame was removed before rendering completed");
+    }
+
+    const canvas = document.createElement("canvas");
+    Object.defineProperty(canvas, "toDataURL", {
+      value: () => "data:image/png;base64,tag",
+    });
+    Object.defineProperty(canvas, "toBlob", {
+      value: (callback: BlobCallback) => {
+        callback(new Blob(["png"], { type: "image/png" }));
+      },
+    });
+    return canvas;
+  });
+}
 
 describe("tag designer downloads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    URL.createObjectURL = vi.fn();
+    URL.revokeObjectURL = vi.fn();
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:tag-download");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+      () => undefined,
+    );
+    zipGenerateAsyncMock.mockResolvedValue(new Blob(["zip"]));
+  });
+
   it("limits concurrent raster render work while preserving result order", async () => {
     let active = 0;
     let maxActive = 0;
@@ -17,5 +122,35 @@ describe("tag designer downloads", () => {
 
     expect(maxActive).toBeLessThanOrEqual(2);
     expect(results).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it("keeps the hidden raster iframe mounted until html2canvas finishes", async () => {
+    mockHtml2CanvasWithDelayedFrameCheck();
+
+    const didDownload = await downloadTagDocumentPdf({
+      tags: [tag],
+      widthInches: 3,
+      heightInches: 1,
+    });
+
+    expect(didDownload).toBe(true);
+    expect(html2canvasMock).toHaveBeenCalledOnce();
+    expect(pdfAddImageMock).toHaveBeenCalledOnce();
+    expect(pdfSaveMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the hidden raster iframe mounted until image ZIP rendering finishes", async () => {
+    mockHtml2CanvasWithDelayedFrameCheck();
+
+    const didDownload = await downloadTagImagesZip({
+      tags: [tag],
+      widthInches: 3,
+      heightInches: 1,
+    });
+
+    expect(didDownload).toBe(true);
+    expect(html2canvasMock).toHaveBeenCalledOnce();
+    expect(zipFileMock).toHaveBeenCalledOnce();
+    expect(zipGenerateAsyncMock).toHaveBeenCalledOnce();
   });
 });

--- a/apps/main/tests/tag-designer-model.test.ts
+++ b/apps/main/tests/tag-designer-model.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildResolvedRowsForListing } from "@/app/dashboard/tags/_components/tag-designer-model";
+import type {
+  TagListingData,
+  TagRow,
+} from "@/app/dashboard/tags/_components/tag-designer-model";
+
+const listing: TagListingData = {
+  id: "listing-1",
+  title: "Moonlit Smile",
+  price: 18.5,
+  ahsListing: null,
+};
+
+function customTextCell(label: string): TagRow["cells"][number] {
+  return {
+    fieldId: "customText",
+    width: 1,
+    textAlign: "left",
+    fontSize: 12,
+    overflow: false,
+    fit: true,
+    wrap: false,
+    bold: false,
+    italic: false,
+    underline: false,
+    label,
+  };
+}
+
+describe("tag designer model", () => {
+  it("keeps resolved cell ids unique for repeated free-text cells", () => {
+    const rows = buildResolvedRowsForListing(listing, [
+      {
+        id: "row-1",
+        cells: [customTextCell("A"), customTextCell("B")],
+      },
+    ]);
+
+    expect(rows[0]?.cells.map((cell) => cell.id)).toEqual([
+      "listing-1-row-1-0-customText",
+      "listing-1-row-1-1-customText",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- keep hidden tag export iframes mounted until html2canvas finishes rendering
- add regression coverage for PDF and image ZIP export paths

## Tests
- pnpm main test -- tests/tag-designer-downloads.test.ts
- pnpm main test -- tests/tag-designer-downloads.test.ts tests/tag-designer-panel.test.tsx
- pnpm lint
- pnpm main typecheck
