### PR TITLE
Fix dashboard image list query to avoid Prisma parameter limits

### DIFF
--- a/apps/main/src/server/api/routers/dashboard-db/image.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/image.ts
@@ -160,27 +160,6 @@ function getValidatedImageUrlFromUrl(args: {
   return getValidatedImageUrl({ ...args, key });
 }
 
-async function getOwnedImageWhere(args: { db: DbClient; userId: string }) {
-  const [listingRows, profile] = await Promise.all([
-    args.db.listing.findMany({
-      where: { userId: args.userId },
-      select: { id: true },
-    }),
-    args.db.userProfile.findUnique({
-      where: { userId: args.userId },
-      select: { id: true },
-    }),
-  ]);
-
-  const listingIds = listingRows.map((listing) => listing.id);
-  const ownerFilters = [
-    ...(listingIds.length ? [{ listingId: { in: listingIds } }] : []),
-    ...(profile ? [{ userProfileId: profile.id }] : []),
-  ];
-
-  return ownerFilters.length ? { OR: ownerFilters } : null;
-}
-
 async function getDashboardImagesByListingIds(args: {
   db: DbClient;
   userId: string;
@@ -267,21 +246,33 @@ export const dashboardDbImageRouter = createTRPCRouter({
     }),
 
   list: protectedProcedure.query(async ({ ctx }) => {
-    const ownedImageWhere = await getOwnedImageWhere({
-      db: ctx.db,
-      userId: ctx.user.id,
-    });
-    if (!ownedImageWhere) return [];
+    const rows = await ctx.db.$queryRaw<ImageRow[]>(Prisma.sql`
+      SELECT
+        i."id",
+        i."url",
+        i."order",
+        i."listingId",
+        i."userProfileId",
+        i."createdAt",
+        i."updatedAt",
+        i."status"
+      FROM "Image" i
+      WHERE
+        EXISTS (
+          SELECT 1
+          FROM "Listing" l
+          WHERE l."id" = i."listingId"
+            AND l."userId" = ${ctx.user.id}
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM "UserProfile" up
+          WHERE up."id" = i."userProfileId"
+            AND up."userId" = ${ctx.user.id}
+        )
+    `);
 
-    return ctx.db.image.findMany({
-      where: ownedImageWhere,
-      orderBy: [
-        { listingId: "asc" },
-        { userProfileId: "asc" },
-        { order: "asc" },
-      ],
-      select: imageSelect,
-    });
+    return rows.map(mapImageRow).sort(sortImagesForDashboard);
   }),
 
   listByListingIds: protectedProcedure

--- a/apps/main/tests/dashboard-db-image-router.test.ts
+++ b/apps/main/tests/dashboard-db-image-router.test.ts
@@ -269,6 +269,50 @@ describe("dashboardDb.image", () => {
     expect(db.image.findMany).not.toHaveBeenCalled();
   });
 
+  it("list fetches images with owner-checked SQL instead of materialized listing ids", async () => {
+    const db = createMockDb();
+    db.listing.findMany.mockResolvedValue(
+      Array.from({ length: 5000 }, (_, index) => ({ id: `listing-${index}` })),
+    );
+    db.$queryRaw.mockResolvedValueOnce([
+      {
+        id: "profile-image",
+        url: "https://example.com/profile.jpg",
+        order: 0,
+        listingId: null,
+        userProfileId: "profile-1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+        status: null,
+      },
+      {
+        id: "listing-image",
+        url: "https://example.com/listing.jpg",
+        order: 1,
+        listingId: "listing-1",
+        userProfileId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+        status: null,
+      },
+    ]);
+
+    const caller = createCaller(db);
+    const result = await caller.list();
+
+    expect(result.map((row) => row.id)).toEqual([
+      "profile-image",
+      "listing-image",
+    ]);
+    expect(result[0]?.updatedAt).toEqual(
+      new Date("2026-01-02T00:00:00.000Z"),
+    );
+    expect(db.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(db.listing.findMany).not.toHaveBeenCalled();
+    expect(db.userProfile.findUnique).not.toHaveBeenCalled();
+    expect(db.image.findMany).not.toHaveBeenCalled();
+  });
+
   it("listByListingIds fetches image chunks with indexed owner-checked queries", async () => {
     const db = createMockDb();
     db.$queryRaw.mockResolvedValueOnce([


### PR DESCRIPTION
## Summary
- Reworked `dashboardDb.image.list` to use owner-checked SQL with `EXISTS` instead of loading owned listing IDs into a Prisma `IN (...)` filter.
- This removes the large-parameter failure path while keeping public listing pages untouched.
- Added a focused regression test to verify `list` uses the SQL path and does not fall back to materialized listing lookups.

## Testing
- `pnpm main test -- dashboard-db-image-router.test.ts`
- `pnpm main typecheck`
- `pnpm main lint`
- `git diff --check`