### PR TITLE
[codex] Use ownership-anchored joins for dashboard image list

### DIFF
--- a/apps/main/src/server/api/routers/dashboard-db/image.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/image.ts
@@ -256,20 +256,22 @@ export const dashboardDbImageRouter = createTRPCRouter({
         i."createdAt",
         i."updatedAt",
         i."status"
-      FROM "Image" i
-      WHERE
-        EXISTS (
-          SELECT 1
-          FROM "Listing" l
-          WHERE l."id" = i."listingId"
-            AND l."userId" = ${ctx.user.id}
-        )
-        OR EXISTS (
-          SELECT 1
-          FROM "UserProfile" up
-          WHERE up."id" = i."userProfileId"
-            AND up."userId" = ${ctx.user.id}
-        )
+      FROM "Listing" l
+      INNER JOIN "Image" i ON i."listingId" = l."id"
+      WHERE l."userId" = ${ctx.user.id}
+      UNION
+      SELECT
+        i."id",
+        i."url",
+        i."order",
+        i."listingId",
+        i."userProfileId",
+        i."createdAt",
+        i."updatedAt",
+        i."status"
+      FROM "UserProfile" up
+      INNER JOIN "Image" i ON i."userProfileId" = up."id"
+      WHERE up."userId" = ${ctx.user.id}
     `);
 
     return rows.map(mapImageRow).sort(sortImagesForDashboard);


### PR DESCRIPTION
## Summary

- updates `dashboardDb.image.list` to read images through ownership-anchored listing/profile joins
- keeps the existing parameter-limit fix while avoiding a global `Image` table scan

## Root Cause

The merged dashboard image-list fix avoided Prisma `IN (...)` parameter limits, but the follow-up review change that drives the query from owned rows was not included before merge.

## Validation

- `pnpm main test -- dashboard-db-image-router.test.ts`
- `pnpm main typecheck`
- `pnpm main lint`
- `git diff --check origin/main..HEAD`
