### PR TITLE
[codex] Fix auth error sign-in redirect

### DIFF
--- a/apps/main/src/app/auth-error/auth-error-page-client.tsx
+++ b/apps/main/src/app/auth-error/auth-error-page-client.tsx
@@ -7,11 +7,11 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { SUBSCRIPTION_CONFIG } from "@/config/subscription-config";
+import { getSafeAuthReturnTo } from "./auth-return-to";
 
 function AuthErrorContent() {
   const searchParams = useSearchParams();
-  const getSearchParam = searchParams.get.bind(searchParams);
-  const returnTo = getSearchParam("returnTo") ?? "/dashboard";
+  const returnTo = getSafeAuthReturnTo(searchParams.get("returnTo"));
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center p-4 text-center">
@@ -31,17 +31,17 @@ function AuthErrorContent() {
             expired.
           </p>
           <div className="flex flex-col gap-4 pt-4 sm:flex-row sm:justify-center">
-            <Button asChild size="lg">
-              <SignInButton
-                mode="modal"
-                forceRedirectUrl={returnTo}
-                signUpForceRedirectUrl={
-                  SUBSCRIPTION_CONFIG.NEW_USER_ONBOARDING_PATH
-                }
-              >
+            <SignInButton
+              mode="redirect"
+              forceRedirectUrl={returnTo}
+              signUpForceRedirectUrl={
+                SUBSCRIPTION_CONFIG.NEW_USER_ONBOARDING_PATH
+              }
+            >
+              <Button size="lg">
                 Sign In
-              </SignInButton>
-            </Button>
+              </Button>
+            </SignInButton>
             <Button variant="outline" asChild size="lg">
               <Link href="/">Return Home</Link>
             </Button>

--- a/apps/main/src/app/auth-error/auth-return-to.ts
+++ b/apps/main/src/app/auth-error/auth-return-to.ts
@@ -1,0 +1,29 @@
+const DEFAULT_AUTH_RETURN_TO = "/dashboard";
+
+export function getSafeAuthReturnTo(returnTo: string | null): string {
+  if (!returnTo) {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+
+  if (!returnTo.startsWith("/") || returnTo.startsWith("//")) {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+
+  try {
+    const parsed = new URL(returnTo, "https://daylilycatalog.local");
+
+    if (parsed.origin !== "https://daylilycatalog.local") {
+      return DEFAULT_AUTH_RETURN_TO;
+    }
+
+    const safePath = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+
+    if (safePath === "/auth-error" || safePath.startsWith("/auth-error?")) {
+      return DEFAULT_AUTH_RETURN_TO;
+    }
+
+    return safePath;
+  } catch {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+}

--- a/apps/main/src/proxy.ts
+++ b/apps/main/src/proxy.ts
@@ -47,7 +47,9 @@ const protectedRouteProxy = clerkMiddleware(async (auth, req) => {
 
   if (!userId) {
     // Redirect to our custom auth error page instead of Clerk's sign-in page
-    const returnTo = encodeURIComponent(req.nextUrl.pathname);
+    const returnTo = encodeURIComponent(
+      `${req.nextUrl.pathname}${req.nextUrl.search}`,
+    );
     return NextResponse.redirect(
       new URL(`/auth-error?returnTo=${returnTo}`, req.url),
     );

--- a/apps/main/tests/auth-return-to.test.ts
+++ b/apps/main/tests/auth-return-to.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getSafeAuthReturnTo } from "@/app/auth-error/auth-return-to";
+
+describe("auth error return target", () => {
+  it("keeps same-origin app paths including query strings", () => {
+    expect(getSafeAuthReturnTo("/dashboard/listings?view=table")).toBe(
+      "/dashboard/listings?view=table",
+    );
+  });
+
+  it("falls back for external or looping targets", () => {
+    expect(getSafeAuthReturnTo("https://example.com/dashboard")).toBe(
+      "/dashboard",
+    );
+    expect(getSafeAuthReturnTo("//example.com/dashboard")).toBe("/dashboard");
+    expect(getSafeAuthReturnTo("/auth-error?returnTo=/dashboard")).toBe(
+      "/dashboard",
+    );
+  });
+});

--- a/apps/main/tests/proxy-seller-funnel.test.ts
+++ b/apps/main/tests/proxy-seller-funnel.test.ts
@@ -63,14 +63,16 @@ describe("seller funnel proxy protection", () => {
   it("redirects unauthenticated onboarding access to auth-error", async () => {
     authMock.mockResolvedValueOnce({ userId: null });
 
-    const request = new NextRequest("http://localhost:3000/onboarding");
+    const request = new NextRequest(
+      "http://localhost:3000/onboarding?plan=pro",
+    );
     const middlewareEvent = {} as Parameters<NextMiddleware>[1];
 
     const response = await proxy(request, middlewareEvent);
 
     expect(authMock).toHaveBeenCalledTimes(1);
     expect(response?.headers.get("location")).toContain(
-      "/auth-error?returnTo=%2Fonboarding",
+      "/auth-error?returnTo=%2Fonboarding%3Fplan%3Dpro",
     );
   });
 


### PR DESCRIPTION
## Summary
- Switch the auth-error sign-in action from Clerk's modal flow to redirect flow so sign-in completion is not posted through `/auth-error`.
- Sanitize `returnTo` before passing it to Clerk, allowing only same-origin app paths and preventing auth-error loops.
- Preserve protected-route query strings in the auth-error redirect and cover the behavior with focused tests.

## Root cause
Sentry showed a Safari user completing Clerk verification on `/auth-error?returnTo=/dashboard/listings`, followed by a failed app-side POST from Next's server-action reducer while the modal auth flow was still running over the recovery page.

## Validation
- `pnpm --filter @daylily-catalog/main test -- tests/auth-return-to.test.ts tests/proxy-seller-funnel.test.ts`
- `pnpm --filter @daylily-catalog/main exec eslint src/app/auth-error/auth-error-page-client.tsx src/app/auth-error/auth-return-to.ts src/proxy.ts tests/auth-return-to.test.ts tests/proxy-seller-funnel.test.ts`
- `codex review --uncommitted` on the original checkout; it found unrelated pre-existing dirty-work findings, none against this auth patch.