### PR TITLE
[codex] Fix Caddy forwarded origin headers

### DIFF
--- a/apps/main/deploy/vps/caddy-route.caddy
+++ b/apps/main/deploy/vps/caddy-route.caddy
@@ -1,6 +1,10 @@
 @daylilycatalog host daylilycatalog.com prod.daylilycatalog.com
 handle @daylilycatalog {
-  reverse_proxy app:3000
+  reverse_proxy app:3000 {
+    header_up X-Forwarded-Proto https
+    header_up X-Forwarded-Host {host}
+    header_up X-Forwarded-Port 443
+  }
 }
 
 @daylilycatalog_www host www.daylilycatalog.com


### PR DESCRIPTION
## Summary

Fix the repo-managed VPS Caddy route so requests proxied from Cloudflare Tunnel tell the app the public origin is HTTPS.

The dashboard auth failure showed Clerk rejecting session refresh with `session-token-expired-refresh-refresh_request_origin_azp_mismatch` because the app received `X-Forwarded-Proto: http` even though users access `https://daylilycatalog.com`.

This keeps the existing `@daylilycatalog` matcher and `www` redirect, and sets the upstream forwarded origin headers on `reverse_proxy app:3000`:

- `X-Forwarded-Proto: https`
- `X-Forwarded-Host: {host}`
- `X-Forwarded-Port: 443`

The durable fix belongs in the repo-managed deploy config because `sync-server-config` syncs VPS config from `main`.

## Verification

- `git diff --name-only` only includes `apps/main/deploy/vps/caddy-route.caddy`
- `git diff --check`
- `caddy` is not installed on this machine, so I could not run `caddy fmt` or `caddy validate` locally