### PR TITLE
Refocus public README docs on project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,25 @@ Daylily Catalog is a catalog, storefront, and seller dashboard for daylily
 growers. It serves public grower catalogs and cultivar pages while giving
 sellers tools for listings, images, lists, subscriptions, and catalog content.
 
-## Project Layout
+The project is production software, not a starter template. This public
+repository is primarily useful as a source view of the product architecture and
+implementation choices rather than as a turnkey local setup guide.
+
+## Product Scope
+
+- Public grower catalogs with searchable listings and cultivar details.
+- Seller dashboard workflows for listings, images, lists, tags, and storefront
+  content.
+- Subscription and checkout flows for paid catalog features.
+- Read-only MCP tools for querying public catalog data and authenticated seller
+  inventory.
+- Search and cultivar-reference workflows for daylily-specific data.
+
+## Repository Shape
 
 The main application lives in `apps/main` as the `@daylily-catalog/main`
-workspace package. The root package mostly provides pnpm and Turbo commands for
-running that app.
+workspace package. The root package is mostly workspace orchestration for that
+app.
 
 ## Stack
 
@@ -21,29 +35,16 @@ running that app.
 - Vitest and Playwright for automated tests
 - Sentry and PostHog for observability
 
-## Quick Commands
-
-Run these from the repository root:
-
-| Command | Purpose |
-| --- | --- |
-| `pnpm install` | Install workspace dependencies and generate Prisma client output. |
-| `pnpm dev` | Start the main app in development mode. |
-| `pnpm lint` | Run the app lint gate. |
-| `pnpm typecheck` | Run TypeScript checking. |
-| `pnpm test` | Run Vitest tests. |
-| `pnpm test:e2e` | Run Playwright end-to-end tests. |
-
-Use `pnpm main <script>` to run an app script directly, for example
-`pnpm main test -- tests/public-profile-route.test.ts`.
-
-## Key Docs
+## Internal Documentation
 
 - `apps/main/README.md` - app-specific map and development notes.
-- `apps/main/docs/e2e-tests.md` - Playwright workflow and conventions.
+- `apps/main/docs/README.md` - index of app runbooks and product notes.
 - `apps/main/docs/deploy-vps.md` - VPS Docker deployment runbook.
 - `apps/main/docs/public-rendering-cache-strategy.md` - public page rendering
   and cache strategy.
 - `apps/main/docs/local-query-profiler.md` - local query profiling workflow.
-- `apps/main/docs/README.md` - index of app runbooks and product notes.
 - `AGENTS.md` - coding-agent conventions, repo gotchas, and command notes.
+
+Local operation depends on private environment configuration. When running
+repo scripts in an existing configured checkout, prefer the documented
+runbooks and the `env:dev` wrapper where environment loading matters.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Daylily Catalog
+
+Daylily Catalog is a catalog, storefront, and seller dashboard for daylily
+growers. It serves public grower catalogs and cultivar pages while giving
+sellers tools for listings, images, lists, subscriptions, and catalog content.
+
+## Project Layout
+
+The main application lives in `apps/main` as the `@daylily-catalog/main`
+workspace package. The root package mostly provides pnpm and Turbo commands for
+running that app.
+
+## Stack
+
+- Next.js App Router and React
+- Prisma with SQLite locally and Turso/libSQL in hosted environments
+- tRPC for app APIs
+- Clerk for authentication
+- Stripe for subscriptions and checkout
+- TanStack DB for dashboard client data
+- Vitest and Playwright for automated tests
+- Sentry and PostHog for observability
+
+## Quick Commands
+
+Run these from the repository root:
+
+| Command | Purpose |
+| --- | --- |
+| `pnpm install` | Install workspace dependencies and generate Prisma client output. |
+| `pnpm dev` | Start the main app in development mode. |
+| `pnpm lint` | Run the app lint gate. |
+| `pnpm typecheck` | Run TypeScript checking. |
+| `pnpm test` | Run Vitest tests. |
+| `pnpm test:e2e` | Run Playwright end-to-end tests. |
+
+Use `pnpm main <script>` to run an app script directly, for example
+`pnpm main test -- tests/public-profile-route.test.ts`.
+
+## Key Docs
+
+- `apps/main/README.md` - app-specific map and development notes.
+- `apps/main/docs/e2e-tests.md` - Playwright workflow and conventions.
+- `apps/main/docs/deploy-vps.md` - VPS Docker deployment runbook.
+- `apps/main/docs/public-rendering-cache-strategy.md` - public page rendering
+  and cache strategy.
+- `apps/main/docs/local-query-profiler.md` - local query profiling workflow.
+- `apps/main/docs/README.md` - index of app runbooks and product notes.
+- `AGENTS.md` - coding-agent conventions, repo gotchas, and command notes.

--- a/apps/main/README.md
+++ b/apps/main/README.md
@@ -15,38 +15,34 @@ read-only tools, search, and operational scripts for the main product.
 - `prisma/` - Prisma schema, migrations, and reviewed data-migration SQL.
 - `tests/` - Vitest integration/unit specs and Playwright end-to-end specs.
 
-## Development Commands
+## Operational Context
 
-Run these from the repository root:
+This app expects environment-specific configuration for database access,
+authentication, payments, storage, observability, and production-like smoke
+tests. Do not treat this README as a complete local setup guide.
 
-| Command | Purpose |
-| --- | --- |
-| `pnpm main dev` | Start the app with `scripts/with-env.mjs` and Next dev. |
-| `pnpm main lint` | Run ESLint over `src`. |
-| `pnpm main typecheck` | Run `tsc --noEmit`. |
-| `pnpm main test` | Run the Vitest suite. |
-| `pnpm main test -- tests/<file>.test.ts` | Run one Vitest file. |
-| `pnpm main test:e2e` | Run the Playwright suite. |
-| `pnpm main profile:queries` | Run the strategic local query profiler. |
+For configured checkouts, scripts that need local environment values should run
+through the existing environment wrapper. At the root, `pnpm env:dev ...`
+delegates to this package's `scripts/with-env.mjs --env development -- ...`;
+inside `apps/main`, the equivalent is `pnpm env:dev ...`.
 
-The root scripts (`pnpm dev`, `pnpm lint`, `pnpm typecheck`, `pnpm test`, and
-`pnpm test:e2e`) delegate to this package through Turbo.
+Routine verification and operational workflows are documented in the runbooks
+linked below and in `../../AGENTS.md`.
 
 ## Environment Loading
 
-Development commands use `scripts/with-env.mjs`. For `--env development`, it
-loads `.env.development` from the repository root first and then
-`apps/main/.env.development` if that file exists. Keep local secrets in ignored
-env files and update `.env.example` when adding or renaming required variables.
+`scripts/with-env.mjs` loads the requested `.env.<name>` file from the
+repository root first and then `apps/main/.env.<name>` if that file exists.
+Keep local secrets in ignored env files and update `.env.example` when adding
+or renaming required variables.
 
-## Testing Notes
+## Testing And Runbooks
 
-- Unit and integration tests use Vitest: `pnpm main test`.
-- A focused Vitest file can be run with
-  `pnpm main test -- tests/<file>.test.ts`.
-- Browser tests use Playwright: `pnpm main test:e2e`.
-- Local Playwright runs create a temp SQLite database when `BASE_URL` is not
-  set. Attach/preview runs use `BASE_URL` and should not seed data.
+The repo has focused Vitest coverage for app-owned behavior and Playwright
+coverage for browser flows. Local Playwright runs can create temporary SQLite
+databases; attach/preview runs use `BASE_URL` and should not seed data. See the
+linked docs for the current workflow details instead of copying commands from
+memory.
 
 ## Related Docs
 

--- a/apps/main/README.md
+++ b/apps/main/README.md
@@ -1,29 +1,60 @@
-# Create T3 App
+# @daylily-catalog/main
 
-This is a [T3 Stack](https://create.t3.gg/) project bootstrapped with `create-t3-app`.
+This package is the all-in-one Daylily Catalog Next.js app. It owns the public
+catalog pages, seller dashboard, onboarding flows, payments, API routes, MCP
+read-only tools, search, and operational scripts for the main product.
 
-## What's next? How do I make an app with this?
+## Directory Map
 
-We try to keep this project as simple as possible, so you can start with just the scaffolding we set up for you, and add additional things later when they become necessary.
+- `src/app/` - Next.js App Router routes, layouts, route handlers, and
+  route-local components.
+- `src/components/` - shared UI and feature components. `src/components/ui/`
+  contains shadcn components.
+- `src/server/` - tRPC routers, database clients, Clerk integration, Stripe,
+  MCP tools, search, analytics, and server-side services.
+- `prisma/` - Prisma schema, migrations, and reviewed data-migration SQL.
+- `tests/` - Vitest integration/unit specs and Playwright end-to-end specs.
 
-If you are not familiar with the different technologies used in this project, please refer to the respective docs. If you still are in the wind, please join our [Discord](https://t3.gg/discord) and ask for help.
+## Development Commands
 
-- [Next.js](https://nextjs.org)
-- [NextAuth.js](https://next-auth.js.org)
-- [Prisma](https://prisma.io)
-- [Drizzle](https://orm.drizzle.team)
-- [Tailwind CSS](https://tailwindcss.com)
-- [tRPC](https://trpc.io)
+Run these from the repository root:
 
-## Learn More
+| Command | Purpose |
+| --- | --- |
+| `pnpm main dev` | Start the app with `scripts/with-env.mjs` and Next dev. |
+| `pnpm main lint` | Run ESLint over `src`. |
+| `pnpm main typecheck` | Run `tsc --noEmit`. |
+| `pnpm main test` | Run the Vitest suite. |
+| `pnpm main test -- tests/<file>.test.ts` | Run one Vitest file. |
+| `pnpm main test:e2e` | Run the Playwright suite. |
+| `pnpm main profile:queries` | Run the strategic local query profiler. |
 
-To learn more about the [T3 Stack](https://create.t3.gg/), take a look at the following resources:
+The root scripts (`pnpm dev`, `pnpm lint`, `pnpm typecheck`, `pnpm test`, and
+`pnpm test:e2e`) delegate to this package through Turbo.
 
-- [Documentation](https://create.t3.gg/)
-- [Learn the T3 Stack](https://create.t3.gg/en/faq#what-learning-resources-are-currently-available) — Check out these awesome tutorials
+## Environment Loading
 
-You can check out the [create-t3-app GitHub repository](https://github.com/t3-oss/create-t3-app) — your feedback and contributions are welcome!
+Development commands use `scripts/with-env.mjs`. For `--env development`, it
+loads `.env.development` from the repository root first and then
+`apps/main/.env.development` if that file exists. Keep local secrets in ignored
+env files and update `.env.example` when adding or renaming required variables.
 
-## How do I deploy this?
+## Testing Notes
 
-Follow our deployment guides for [Vercel](https://create.t3.gg/en/deployment/vercel), [Netlify](https://create.t3.gg/en/deployment/netlify) and [Docker](https://create.t3.gg/en/deployment/docker) for more information.
+- Unit and integration tests use Vitest: `pnpm main test`.
+- A focused Vitest file can be run with
+  `pnpm main test -- tests/<file>.test.ts`.
+- Browser tests use Playwright: `pnpm main test:e2e`.
+- Local Playwright runs create a temp SQLite database when `BASE_URL` is not
+  set. Attach/preview runs use `BASE_URL` and should not seed data.
+
+## Related Docs
+
+- `docs/README.md` - categorized index for app runbooks.
+- `docs/e2e-tests.md` - Playwright workflow and tagging rules.
+- `docs/deploy-vps.md` - VPS Docker deployment and runtime contract.
+- `docs/public-rendering-cache-strategy.md` - public page cache strategy.
+- `docs/local-query-profiler.md` - local query profiling workflow.
+- `docs/prod-readonly-dashboard-smoke.md` - production-shaped read-only smoke
+  testing from local code.
+- `../../AGENTS.md` - agent-oriented repo conventions and gotchas.

--- a/apps/main/docs/README.md
+++ b/apps/main/docs/README.md
@@ -1,0 +1,40 @@
+# Daylily Catalog App Docs
+
+This directory holds focused runbooks and product notes for `apps/main`. Keep
+deep operational detail in the linked documents and use this index for routing.
+
+## Local Development and Tests
+
+- `e2e-tests.md` - Playwright local, preview, and page-object workflow.
+- `local-query-profiler.md` - local profiling against a production-shaped
+  SQLite snapshot.
+- `query-performance-notes.md` - query profiling findings and follow-up notes.
+- `shadcn-upgrades.md` - local shadcn component upgrade notes.
+
+## Deployment and Production
+
+- `deploy-vps.md` - VPS Docker deployment, runtime env, and host strategy.
+- `prod-readonly-dashboard-smoke.md` - read-only production-shaped dashboard
+  smoke workflow.
+- `db-backup-readme.md` - database backup workflow.
+- `public-rendering-cache-strategy.md` - public rendering and cache ownership.
+- `next-16-cache-migration-notes.md` - older cache migration notes retained for
+  context.
+
+## Data, Search, and Cultivar Migration
+
+- `db-migration.md` - database migration workflow.
+- `cultivar-reference-migration.md` - cultivar reference migration notes.
+- `cultivar-reference-dedupe-runbook.md` - cultivar reference dedupe runbook.
+- `v2-ahs-cultivar-migration.md` - V2 AHS cultivar migration notes.
+- `ahs-v2-migration-todo.json` - machine-readable V2 migration todo list.
+- `api-endpoints.md` - API endpoint reference.
+- `parentage-tree-api-example.md` - parentage API example.
+
+## Product and Features
+
+- `features.md` - product feature notes.
+- `user-stories.md` - user-story notes.
+- `landing-page.md` - landing page notes.
+- `onboarding-capture-review-2026-02-27.md` - onboarding capture review.
+- `todo.md` - app-level todo notes.


### PR DESCRIPTION
## Summary
- make the root README describe Daylily Catalog as a production project rather than a local setup guide
- replace command tables with product scope, stack, repository shape, and internal docs pointers
- clarify that local operation depends on private env configuration and the existing `env:dev` wrapper where environment loading matters

## Base
- Based on `origin/main` at `9111e5b83d367c76e3c32c6ecb59d44ab7c40065`

## Verification
- Docs-only change; no tests run.
- `git diff --check`
