### PR TITLE
Add maintainability hotspot report

### DIFF
--- a/apps/main/docs/maintainability-hotspots.md
+++ b/apps/main/docs/maintainability-hotspots.md
@@ -1,0 +1,26 @@
+# Maintainability Hotspots
+
+The maintainability hotspot report is an advisory file-size signal for source
+and test files. It is a smell to investigate, not an automatic quality
+judgment: a large file can still be reasonable, and a small file can still be
+hard to maintain.
+
+Run it before large refactors, after adding a major feature file, or during
+code review when a file feels too large to reason about comfortably.
+
+```sh
+pnpm maintainability:hotspots
+```
+
+To smoke-check threshold behavior locally:
+
+```sh
+node scripts/report-source-hotspots.mjs --max-lines 1200 --fail-on-threshold
+```
+
+The current stance is to keep this out of CI as a blocker. Use the report to
+find candidates for characterization tests and planned extraction work before
+refactoring.
+
+The default report excludes `apps/main/src/components/ui` because those files
+are mostly local shadcn UI components and should not dominate the signal.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "migrate:generate": "TURBO_CACHE_DIR=.turbo turbo run migrate:generate --filter=@daylily-catalog/main",
     "browser-tools-server": "TURBO_CACHE_DIR=.turbo turbo run browser-tools-server --filter=@daylily-catalog/main",
     "profile:queries": "TURBO_CACHE_DIR=.turbo turbo run profile:queries --filter=@daylily-catalog/main",
+    "maintainability:hotspots": "node scripts/report-source-hotspots.mjs",
     "db:sync:seed": "TURBO_CACHE_DIR=.turbo turbo run db:sync:seed --filter=@daylily-catalog/main"
   },
   "devDependencies": {

--- a/scripts/report-source-hotspots.mjs
+++ b/scripts/report-source-hotspots.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const repoRoot = process.cwd();
+const sourceRoot = "apps/main/src";
+const testRoot = "apps/main/tests";
+const roots = [
+  { label: "Source", path: sourceRoot, maxLinesOption: "maxLines" },
+  { label: "Test", path: testRoot, maxLinesOption: "maxTestLines" },
+];
+
+const includedExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs"]);
+const ignoredSegments = new Set([
+  "node_modules",
+  ".next",
+  "coverage",
+  "playwright-report",
+  "test-results",
+]);
+const ignoredPaths = new Set(["apps/main/src/components/ui"]);
+
+const defaultOptions = {
+  limit: 20,
+  maxLines: 1200,
+  maxTestLines: 1200,
+  failOnThreshold: false,
+};
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function relativePath(absolutePath) {
+  return toPosixPath(path.relative(repoRoot, absolutePath));
+}
+
+function isIgnored(absolutePath) {
+  const relative = relativePath(absolutePath);
+
+  if (
+    ignoredPaths.has(relative) ||
+    [...ignoredPaths].some((ignoredPath) => relative.startsWith(`${ignoredPath}/`))
+  ) {
+    return true;
+  }
+
+  return relative.split("/").some((segment) => ignoredSegments.has(segment));
+}
+
+function parsePositiveInteger(optionName, rawValue) {
+  const value = Number.parseInt(rawValue, 10);
+
+  if (!Number.isSafeInteger(value) || value <= 0 || String(value) !== rawValue) {
+    throw new Error(`${optionName} must be a positive integer.`);
+  }
+
+  return value;
+}
+
+function readOptionValue(args, index, optionName) {
+  const value = args[index + 1];
+
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${optionName} requires a value.`);
+  }
+
+  return value;
+}
+
+function parseArgs(args) {
+  const options = { ...defaultOptions };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--") {
+      continue;
+    }
+
+    if (arg === "--fail-on-threshold") {
+      options.failOnThreshold = true;
+      continue;
+    }
+
+    if (arg === "--limit") {
+      const value = readOptionValue(args, index, arg);
+      options.limit = parsePositiveInteger(arg, value);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--max-lines") {
+      const value = readOptionValue(args, index, arg);
+      options.maxLines = parsePositiveInteger(arg, value);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--max-test-lines") {
+      const value = readOptionValue(args, index, arg);
+      options.maxTestLines = parsePositiveInteger(arg, value);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+function countLines(contents) {
+  if (contents.length === 0) {
+    return 0;
+  }
+
+  const lines = contents.split("\n");
+  return lines.at(-1) === "" ? lines.length - 1 : lines.length;
+}
+
+async function collectFiles(directory) {
+  if (isIgnored(directory)) {
+    return [];
+  }
+
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name);
+
+    if (isIgnored(absolutePath)) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(absolutePath)));
+      continue;
+    }
+
+    if (entry.isFile() && includedExtensions.has(path.extname(entry.name))) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+async function collectHotspots(rootPath) {
+  const absoluteRoot = path.resolve(repoRoot, rootPath);
+  const files = await collectFiles(absoluteRoot);
+  const rows = [];
+
+  for (const file of files) {
+    const contents = await readFile(file, "utf8");
+    rows.push({
+      lines: countLines(contents),
+      path: relativePath(file),
+    });
+  }
+
+  return rows.sort((left, right) => {
+    if (right.lines !== left.lines) {
+      return right.lines - left.lines;
+    }
+
+    return left.path.localeCompare(right.path);
+  });
+}
+
+function printTable(title, rows, limit) {
+  console.log(`${title} (top ${limit})`);
+  console.log("lines  path");
+  console.log("-----  ----");
+
+  for (const row of rows.slice(0, limit)) {
+    console.log(`${String(row.lines).padEnd(5)}  ${row.path}`);
+  }
+
+  console.log("");
+}
+
+function printThresholdGroup(label, threshold, failures, limit) {
+  if (failures.length === 0) {
+    return;
+  }
+
+  console.error(`${label} files over ${threshold} lines:`);
+
+  for (const row of failures.slice(0, limit)) {
+    console.error(`  ${row.lines}  ${row.path}`);
+  }
+
+  if (failures.length > limit) {
+    console.error(`  ... and ${failures.length - limit} more`);
+  }
+}
+
+function printThresholdFailures(groupedFailures, options) {
+  console.error("Maintainability hotspot thresholds exceeded.");
+
+  for (const group of groupedFailures) {
+    printThresholdGroup(group.label, group.threshold, group.failures, options.limit);
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const results = [];
+
+  for (const root of roots) {
+    results.push({
+      ...root,
+      rows: await collectHotspots(root.path),
+    });
+  }
+
+  for (const result of results) {
+    printTable(`${result.label} hotspots`, result.rows, options.limit);
+  }
+
+  if (!options.failOnThreshold) {
+    return;
+  }
+
+  const groupedFailures = results
+    .map((result) => {
+      const threshold = options[result.maxLinesOption];
+
+      return {
+        label: result.label,
+        threshold,
+        failures: result.rows.filter((row) => row.lines > threshold),
+      };
+    })
+    .filter((group) => group.failures.length > 0);
+
+  if (groupedFailures.length > 0) {
+    printThresholdFailures(groupedFailures, options);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a `pnpm maintainability:hotspots` script for source and test file-size reporting
- document the report as an advisory refactoring signal, not a CI blocker
- include optional threshold mode for local smoke checks

## Base
- Based on `origin/main` at `9111e5b83d367c76e3c32c6ecb59d44ab7c40065`

## Verification
- `pnpm maintainability:hotspots`
- `node scripts/report-source-hotspots.mjs --max-lines 2000 --max-test-lines 1300 --fail-on-threshold`
- `node scripts/report-source-hotspots.mjs --max-lines 10 --fail-on-threshold` exited non-zero as expected
- `pnpm typecheck`
- `pnpm lint`
