### PR TITLE
Use legacy AHS images for cultivar heroes

### DIFF
--- a/apps/main/src/lib/utils/ahs-display.ts
+++ b/apps/main/src/lib/utils/ahs-display.ts
@@ -310,7 +310,15 @@ export function getDisplayAhsListing(
     return null;
   }
 
-  return mapV2AhsCultivarToDisplayAhsListing(v2AhsCultivar);
+  const v2DisplayAhsListing =
+    mapV2AhsCultivarToDisplayAhsListing(v2AhsCultivar);
+
+  return {
+    ...v2DisplayAhsListing,
+    ahsImageUrl:
+      toNonEmptyDisplayValue(v2DisplayAhsListing.ahsImageUrl) ??
+      toNonEmptyDisplayValue(legacyAhsListing?.ahsImageUrl),
+  };
 }
 
 export function withResolvedDisplayAhsListing<TSource extends AhsDisplaySource>(

--- a/apps/main/src/server/db/public-cultivar-sections.ts
+++ b/apps/main/src/server/db/public-cultivar-sections.ts
@@ -163,9 +163,25 @@ function sortOffersBestMatch(
 
 function getCultivarHeroImages(
   cultivarReference: PublicCultivarReferenceData["cultivarReference"],
+  listingCards: CultivarListingCards,
 ) {
+  const catalogImages = listingCards.flatMap((listing) =>
+    listing.images
+      .filter((image) => image.id !== `ahs-${listing.id}`)
+      .map((image) => ({
+        alt: `${listing.title} catalog image`,
+        id: image.id,
+        listingId: listing.id,
+        sellerSlug: listing.userSlug,
+        sellerTitle: listing.sellerTitle,
+        source: "catalog" as const,
+        url: image.url,
+      })),
+  );
+
   return cultivarReference.ahsListing?.ahsImageUrl
     ? [
+        ...catalogImages.slice(0, 11),
         {
           alt: cultivarReference.ahsListing.name
             ? `${cultivarReference.ahsListing.name} AHS image`
@@ -178,7 +194,7 @@ function getCultivarHeroImages(
           url: cultivarReference.ahsListing.ahsImageUrl,
         },
       ]
-    : [];
+    : catalogImages.slice(0, 12);
 }
 
 function toGardenCards(args: {
@@ -358,7 +374,7 @@ export async function buildPublicCultivarSummary(args: PublicCultivarContext) {
     freshness: {
       cultivarUpdatedAt: cultivarReference.updatedAt,
     },
-    heroImages: getCultivarHeroImages(cultivarReference),
+    heroImages: getCultivarHeroImages(cultivarReference, args.listingCards),
     quickSpecs: {
       all: allSpecs.all,
       top: allSpecs.top,

--- a/apps/main/tests/get-public-cultivars.test.ts
+++ b/apps/main/tests/get-public-cultivars.test.ts
@@ -223,6 +223,11 @@ describe("getPublicCultivarPage", () => {
             url: "https://example.com/top-b.jpg",
             updatedAt: new Date("2026-01-10T00:00:00.000Z"),
           },
+          ...Array.from({ length: 12 }, (_, index) => ({
+            id: `img-top-extra-${index}`,
+            url: `https://example.com/top-extra-${index}.jpg`,
+            updatedAt: new Date("2026-01-09T00:00:00.000Z"),
+          })),
         ],
         lists: [{ id: "list-show", title: "Show Winners" }],
       },
@@ -356,6 +361,10 @@ describe("getPublicCultivarPage", () => {
     ).toEqual(["listing-top-a", "listing-top-b"]);
 
     expect(result?.heroImages[0]).toMatchObject({
+      source: "catalog",
+    });
+    expect(result?.heroImages).toHaveLength(12);
+    expect(result?.heroImages.at(-1)).toMatchObject({
       source: "ahs",
       url: "https://example.com/ahs.jpg",
     });
@@ -570,7 +579,7 @@ describe("getPublicCultivarPage", () => {
         flower_form_names: "Double",
         unusual_forms_names: "Crispate",
         parentage: "(V2 A x V2 B)",
-        image_url: "https://example.com/v2.jpg",
+        image_url: "   ",
       },
     });
 
@@ -588,6 +597,11 @@ describe("getPublicCultivarPage", () => {
     expect(result?.cultivar.ahsListing).toMatchObject({
       id: "v2-2",
       hybridizer: "Gregory-CJ & V.",
+      ahsImageUrl: "https://example.com/legacy.jpg",
+    });
+    expect(result?.heroImages[0]).toMatchObject({
+      source: "ahs",
+      url: "https://example.com/legacy.jpg",
     });
   });
 


### PR DESCRIPTION
## Summary
- Fall back to legacy AHS image URLs when the V2 display listing has no usable image
- Build public cultivar hero images from listing catalog images first, then include the AHS image when present
- Extend public cultivar tests to cover catalog image ordering and the legacy image fallback

## Testing
- Not run (not requested)