### PR TITLE
[codex] Add ImageAsset storage helpers

### DIFF
--- a/src/server/services/image-asset-read-model.ts
+++ b/src/server/services/image-asset-read-model.ts
@@ -1,0 +1,123 @@
+import { reportError } from "@/lib/error-utils";
+
+export interface LegacyImageRow {
+  id: string;
+  url: string;
+}
+
+export interface ImageAssetUrlRow {
+  id: string;
+  legacyImageId: string | null;
+  originalUrl: string | null;
+  displayUrl: string | null;
+  thumbUrl: string | null;
+  blurUrl: string | null;
+}
+
+export type ImageAssetVariant = "display" | "thumb" | "blur";
+
+function areImageAssetsEnabled() {
+  return process.env.USE_IMAGE_ASSETS === "true";
+}
+
+function getVariantUrl(asset: ImageAssetUrlRow, variant: ImageAssetVariant) {
+  if (variant === "thumb") return asset.thumbUrl;
+  if (variant === "blur") return asset.blurUrl;
+  return asset.displayUrl;
+}
+
+export function buildImageAssetMap(assets: readonly ImageAssetUrlRow[]) {
+  const map = new Map<string, ImageAssetUrlRow>();
+
+  for (const asset of assets) {
+    map.set(asset.id, asset);
+
+    if (asset.legacyImageId) {
+      map.set(asset.legacyImageId, asset);
+    }
+  }
+
+  return map;
+}
+
+export function resolveImageAssetUrl(args: {
+  image: LegacyImageRow;
+  imageAssetByLegacyId: ReadonlyMap<string, ImageAssetUrlRow>;
+  variant?: ImageAssetVariant;
+  source: string;
+}) {
+  if (!areImageAssetsEnabled()) {
+    return args.image.url;
+  }
+
+  const variant = args.variant ?? "display";
+  const asset = args.imageAssetByLegacyId.get(args.image.id);
+
+  if (!asset) {
+    reportError({
+      error: new Error("ImageAsset row missing for legacy image"),
+      level: "warning",
+      context: {
+        source: args.source,
+        imageId: args.image.id,
+        requestedVariant: variant,
+      },
+    });
+
+    return args.image.url;
+  }
+
+  const variantUrl = getVariantUrl(asset, variant);
+  if (variantUrl) {
+    return variantUrl;
+  }
+
+  if (asset.originalUrl) {
+    reportError({
+      error: new Error("ImageAsset variant missing; using original fallback"),
+      level: "warning",
+      context: {
+        source: args.source,
+        imageId: args.image.id,
+        imageAssetId: asset.id,
+        requestedVariant: variant,
+      },
+    });
+
+    return asset.originalUrl;
+  }
+
+  reportError({
+    error: new Error("ImageAsset has no usable URL; using legacy fallback"),
+    level: "warning",
+    context: {
+      source: args.source,
+      imageId: args.image.id,
+      imageAssetId: asset.id,
+      requestedVariant: variant,
+    },
+  });
+
+  return args.image.url;
+}
+
+export function resolveLegacyImagesWithAssets<
+  TImage extends LegacyImageRow,
+>(args: {
+  images: readonly TImage[];
+  imageAssets?: readonly ImageAssetUrlRow[] | null;
+  variant?: ImageAssetVariant;
+  source: string;
+}) {
+  const imageAssetByLegacyId = buildImageAssetMap(args.imageAssets ?? []);
+
+  return args.images.map((image) => ({
+    ...image,
+    url: resolveImageAssetUrl({
+      image,
+      imageAssetByLegacyId,
+      variant: args.variant,
+      source: args.source,
+    }),
+  }));
+}

--- a/src/server/services/image-asset-storage.ts
+++ b/src/server/services/image-asset-storage.ts
@@ -1,0 +1,168 @@
+import path from "node:path";
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { env, requireEnv } from "@/env";
+
+export const IMAGE_ASSET_BUCKET_NAME = "daylily-catalog-media";
+export const IMAGE_ASSET_PUBLIC_BASE_URL = "https://media.daylilycatalog.com";
+export const IMAGE_ASSET_VARIANT_CACHE_CONTROL =
+  "public, max-age=31536000, immutable";
+
+export type UserImageAssetKind = "profile" | "listing";
+export type ImageAssetKind = UserImageAssetKind | "cultivar";
+
+export interface UserImageAssetKeyArgs {
+  kind: UserImageAssetKind;
+  userId: string;
+  imageAssetId: string;
+  listingId?: string | null;
+  versionId?: string | null;
+}
+
+export interface CultivarImageAssetKeyArgs {
+  cultivarReferenceId: string;
+  normalizedName: string | null | undefined;
+  imageAssetId: string;
+}
+
+export function areImageAssetsEnabled() {
+  return env.USE_IMAGE_ASSETS === "true";
+}
+
+export function areImageAssetUploadsConfigured() {
+  return Boolean(
+    env.R2_ACCOUNT_ID && env.R2_ACCESS_KEY_ID && env.R2_SECRET_ACCESS_KEY,
+  );
+}
+
+export function getR2BucketName() {
+  return env.R2_BUCKET_NAME ?? IMAGE_ASSET_BUCKET_NAME;
+}
+
+export function getR2PublicBaseUrl() {
+  return (env.R2_PUBLIC_BASE_URL ?? IMAGE_ASSET_PUBLIC_BASE_URL).replace(
+    /\/+$/,
+    "",
+  );
+}
+
+export function getR2Client() {
+  const accountId = requireEnv("R2_ACCOUNT_ID", env.R2_ACCOUNT_ID);
+
+  return new S3Client({
+    region: "auto",
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: requireEnv("R2_ACCESS_KEY_ID", env.R2_ACCESS_KEY_ID),
+      secretAccessKey: requireEnv(
+        "R2_SECRET_ACCESS_KEY",
+        env.R2_SECRET_ACCESS_KEY,
+      ),
+    },
+  });
+}
+
+export function buildR2PublicUrl(key: string) {
+  const encodedKey = key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  return `${getR2PublicBaseUrl()}/${encodedKey}`;
+}
+
+export function getSafeImageExtension(fileName: string) {
+  const ext = path.extname(fileName).toLowerCase();
+
+  if (/^\.[a-z0-9]+$/.test(ext)) {
+    return ext;
+  }
+
+  return ".jpg";
+}
+
+function sanitizePathSegment(value: string) {
+  const sanitized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+
+  return sanitized || "unknown";
+}
+
+export function buildUserImageAssetBaseKey(args: UserImageAssetKeyArgs) {
+  if (args.kind === "profile") {
+    return `users/${args.userId}/profile-images/${args.imageAssetId}`;
+  }
+
+  if (!args.listingId) {
+    throw new Error("listingId is required for listing image assets.");
+  }
+
+  return `users/${args.userId}/listing-images/${args.listingId}/${args.imageAssetId}`;
+}
+
+function buildVersionedImageAssetBaseKey(args: UserImageAssetKeyArgs) {
+  const baseKey = buildUserImageAssetBaseKey(args);
+
+  if (!args.versionId) {
+    return baseKey;
+  }
+
+  return `${baseKey}/versions/${args.versionId}`;
+}
+
+export function buildCultivarImageAssetBaseKey(
+  args: CultivarImageAssetKeyArgs,
+) {
+  return `cultivars/${sanitizePathSegment(args.normalizedName ?? "unknown")}-${args.cultivarReferenceId}/${args.imageAssetId}`;
+}
+
+export function buildOriginalImageAssetKey(
+  args: UserImageAssetKeyArgs & { fileName: string },
+) {
+  return `${buildVersionedImageAssetBaseKey(args)}/original${getSafeImageExtension(
+    args.fileName,
+  )}`;
+}
+
+export function isExpectedOriginalImageAssetKey(
+  args: UserImageAssetKeyArgs & { key: string; requireVersion?: boolean },
+) {
+  const baseKey = buildUserImageAssetBaseKey(args);
+  if (!args.key.startsWith(`${baseKey}/`)) {
+    return false;
+  }
+
+  const relativeKey = args.key.slice(baseKey.length + 1);
+  const expectedPattern = args.requireVersion
+    ? /^versions\/[a-f0-9]{12}\/original\.[a-z0-9]+$/
+    : /^(?:versions\/[a-f0-9]{12}\/)?original\.[a-z0-9]+$/;
+
+  return expectedPattern.test(relativeKey);
+}
+
+export function buildVariantImageAssetKeys(baseKey: string) {
+  return {
+    displayKey: `${baseKey}/display-800.webp`,
+    thumbKey: `${baseKey}/thumb-200.webp`,
+    blurKey: `${baseKey}/blur-20.webp`,
+  } as const;
+}
+
+export async function getR2PresignedPutUrl(args: {
+  key: string;
+  contentType: string;
+  cacheControl?: string;
+}) {
+  const command = new PutObjectCommand({
+    Bucket: getR2BucketName(),
+    Key: args.key,
+    ContentType: args.contentType,
+    CacheControl: args.cacheControl,
+  });
+
+  return getSignedUrl(getR2Client(), command, { expiresIn: 3600 });
+}

--- a/tests/image-asset-read-model.test.ts
+++ b/tests/image-asset-read-model.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const reportErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/error-utils", () => ({
+  reportError: reportErrorMock,
+}));
+
+import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
+
+const originalUseImageAssets = process.env.USE_IMAGE_ASSETS;
+
+describe("image asset read model", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalUseImageAssets === undefined) {
+      delete process.env.USE_IMAGE_ASSETS;
+      return;
+    }
+
+    process.env.USE_IMAGE_ASSETS = originalUseImageAssets;
+  });
+
+  it("keeps legacy URLs when ImageAsset reads are disabled", () => {
+    process.env.USE_IMAGE_ASSETS = "false";
+
+    const [image] = resolveLegacyImagesWithAssets({
+      images: [{ id: "image-1", url: "https://legacy.example/image.jpg" }],
+      imageAssets: [
+        {
+          id: "asset-1",
+          legacyImageId: "image-1",
+          originalUrl: "https://media.example/original.webp",
+          displayUrl: "https://media.example/display.webp",
+          thumbUrl: "https://media.example/thumb.webp",
+          blurUrl: "https://media.example/blur.webp",
+        },
+      ],
+      source: "test",
+    });
+
+    expect(image?.url).toBe("https://legacy.example/image.jpg");
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the requested ImageAsset variant when enabled", () => {
+    process.env.USE_IMAGE_ASSETS = "true";
+
+    const [image] = resolveLegacyImagesWithAssets({
+      images: [{ id: "image-1", url: "https://legacy.example/image.jpg" }],
+      imageAssets: [
+        {
+          id: "asset-1",
+          legacyImageId: "image-1",
+          originalUrl: "https://media.example/original.webp",
+          displayUrl: "https://media.example/display.webp",
+          thumbUrl: "https://media.example/thumb.webp",
+          blurUrl: "https://media.example/blur.webp",
+        },
+      ],
+      source: "test",
+      variant: "thumb",
+    });
+
+    expect(image?.url).toBe("https://media.example/thumb.webp");
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the ImageAsset original and reports missing variants", () => {
+    process.env.USE_IMAGE_ASSETS = "true";
+
+    const [image] = resolveLegacyImagesWithAssets({
+      images: [{ id: "image-1", url: "https://legacy.example/image.jpg" }],
+      imageAssets: [
+        {
+          id: "asset-1",
+          legacyImageId: "image-1",
+          originalUrl: "https://media.example/original.webp",
+          displayUrl: null,
+          thumbUrl: null,
+          blurUrl: null,
+        },
+      ],
+      source: "public-listing",
+      variant: "display",
+    });
+
+    expect(image?.url).toBe("https://media.example/original.webp");
+    expect(reportErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "warning",
+        context: expect.objectContaining({
+          imageId: "image-1",
+          imageAssetId: "asset-1",
+          requestedVariant: "display",
+          source: "public-listing",
+        }),
+      }),
+    );
+  });
+});

--- a/tests/image-asset-storage.test.ts
+++ b/tests/image-asset-storage.test.ts
@@ -1,0 +1,68 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL ??=
+  "file:./tests/.tmp/image-asset-storage-test.sqlite";
+
+let storage: typeof import("@/server/services/image-asset-storage");
+
+beforeAll(async () => {
+  storage = await import("@/server/services/image-asset-storage");
+});
+
+describe("image asset storage keys", () => {
+  it("keeps first-upload keys stable", () => {
+    const key = storage.buildOriginalImageAssetKey({
+      kind: "listing",
+      userId: "user-1",
+      listingId: "listing-1",
+      imageAssetId: "image-1",
+      fileName: "daylily.JPG",
+    });
+
+    expect(key).toBe(
+      "users/user-1/listing-images/listing-1/image-1/original.jpg",
+    );
+    expect(
+      storage.isExpectedOriginalImageAssetKey({
+        kind: "listing",
+        userId: "user-1",
+        listingId: "listing-1",
+        imageAssetId: "image-1",
+        key,
+      }),
+    ).toBe(true);
+  });
+
+  it("supports versioned replacement keys for immutable variant URLs", () => {
+    const key = storage.buildOriginalImageAssetKey({
+      kind: "profile",
+      userId: "user-1",
+      imageAssetId: "image-1",
+      versionId: "a1b2c3d4e5f6",
+      fileName: "profile.png",
+    });
+
+    expect(key).toBe(
+      "users/user-1/profile-images/image-1/versions/a1b2c3d4e5f6/original.png",
+    );
+    expect(
+      storage.isExpectedOriginalImageAssetKey({
+        kind: "profile",
+        userId: "user-1",
+        imageAssetId: "image-1",
+        key,
+        requireVersion: true,
+      }),
+    ).toBe(true);
+    expect(
+      storage.isExpectedOriginalImageAssetKey({
+        kind: "profile",
+        userId: "user-1",
+        imageAssetId: "image-1",
+        key: "users/user-1/profile-images/image-1/original.png",
+        requireVersion: true,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds pure ImageAsset helper code without wiring the app to use it yet:

- builds and validates R2 ImageAsset keys and public URLs
- supports stable first-upload keys and versioned replacement keys
- adds read-model URL resolution for legacy `Image` rows plus ImageAsset variants
- reports missing ImageAsset rows or variants while preserving fallback behavior

Stacked on #213.

## Validation

- `pnpm test -- tests/image-asset-storage.test.ts tests/image-asset-read-model.test.ts`
- Previously validated as part of the full branch with full unit, lint, typecheck, and flag-off E2E runs.