### PR TITLE
[codex] Add ImageAsset backfill tools

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,11 +7,16 @@ coverage
 node_modules
 tests
 docs
+downloads
+local
 .server-deploy
 *.log
 *.sqlite
 *.sqlite-shm
 *.sqlite-wal
+*.db
+*.db-*
+*.db.bak-*
 .env
 .env.development
 .env.production

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN groupadd --system --gid 1001 nodejs \
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/image-assets ./scripts/image-assets
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules ./node_modules
 
 USER nextjs
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "test:e2e": "playwright test",
     "test:e2e:attach": "BASE_URL=http://localhost:3000 playwright test",
     "profile:queries": "bash scripts/profile-queries-strategic.sh",
-    "db:sync:seed": "bash scripts/sync-seeded-daylily-catalog-from-local.sh"
+    "db:sync:seed": "bash scripts/sync-seeded-daylily-catalog-from-local.sh",
+    "image-assets:backfill": "node scripts/image-assets/backfill-legacy-images-to-r2.mjs",
+    "image-assets:variants": "node scripts/image-assets/process-image-asset-variants.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.882.0",
@@ -122,6 +124,7 @@
     "react-textarea-autosize": "^8.5.9",
     "recharts": "^2.15.4",
     "server-only": "^0.0.1",
+    "sharp": "^0.35.1",
     "slugify": "^1.6.6",
     "sonner": "^2.0.7",
     "stripe": "^18.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      sharp:
+        specifier: ^0.35.1
+        version: 0.35.1
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -900,6 +903,9 @@ packages:
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/runtime@1.5.0':
     resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
 
@@ -1159,9 +1165,19 @@ packages:
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-arm64@0.35.1':
+    resolution: {integrity: sha512-T15JRWOubQ3f5+GxnWeIvo47u5qV0M9HBgJhT+f2gE1e9e6OhR6K73Re52Hm80qWcu1DNb3GweKmpr/MnuP2Ow==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
@@ -1171,8 +1187,24 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-darwin-x64@0.35.1':
+    resolution: {integrity: sha512-t1CPD0cr7XCHjwUj6tQ5MC0pCi866I+gUW6zbUX4aFPnKd1DFBtk0M+gWcjX8VeEzgfCNiSiNTVFZ6b7kvdbnQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.1':
+    resolution: {integrity: sha512-MBSQXqNPThW9EcZ905H6N4sEdX5EwZEYzGx5EBq9ncDCGJALMiY1xPFJxNdzuB1iBjLOpIfxajM6YxdvwmQSLA==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1181,8 +1213,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm64@1.3.0':
+    resolution: {integrity: sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -1191,8 +1233,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@img/sharp-libvips-linux-arm@1.3.0':
+    resolution: {integrity: sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==}
+    cpu: [arm]
+    os: [linux]
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.0':
+    resolution: {integrity: sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==}
     cpu: [ppc64]
     os: [linux]
 
@@ -1201,8 +1253,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.0':
+    resolution: {integrity: sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.3.0':
+    resolution: {integrity: sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==}
     cpu: [s390x]
     os: [linux]
 
@@ -1211,13 +1273,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-libvips-linux-x64@1.3.0':
+    resolution: {integrity: sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==}
+    cpu: [x64]
+    os: [linux]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
+    resolution: {integrity: sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.0':
+    resolution: {integrity: sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==}
     cpu: [x64]
     os: [linux]
 
@@ -1227,9 +1304,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@img/sharp-linux-arm64@0.35.1':
+    resolution: {integrity: sha512-ErCRyGU7LeoaFBZ0xW8hhLlXzhAg80sc4vxePB86qvtEvW1jEhhmbiNBP4oEzZfPMnu6HwHXfzD2W2kBU+RnCw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.35.1':
+    resolution: {integrity: sha512-jygmR02PpCYypt7xB7nst1vqjZp/BpRA/Kf9nK7qRponJ/KrLPaZWEG4G15z1d2FZ6XqI+T0350ha3RSnKx24A==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
 
@@ -1239,9 +1328,21 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@img/sharp-linux-ppc64@0.35.1':
+    resolution: {integrity: sha512-LUWZ2+r2UoLCd8j0RLCwQ4gL6w47+Y7igxtVnPIDXOOEjV86LpBkAHq5VpJeg+GHbw0KN/JWlPJOdZjyZnFqFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.35.1':
+    resolution: {integrity: sha512-i7x6J3mwF4JgT0sM4V4WlAWdJ0bucPtA9rzO1bTji1n5qgBq/W5nn87RvOQPleuuxahNoLdTngByD8/vDDLArw==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
 
@@ -1251,9 +1352,21 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@img/sharp-linux-s390x@0.35.1':
+    resolution: {integrity: sha512-0zSaTUjTF0kIWTSYxD4EG/nvCU4jez53+3RdURtoY3HvbXtIQ98W90JnrGz/oLRFuEnfIy9+7xeq883euc0ZWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.35.1':
+    resolution: {integrity: sha512-NbJD4mWdeyrNQKluO/tR/wBDOelcowSVGNBWxI0e3ZtlXc6F/UOVKDj1MLD4zl3oHTuvKW3s+MA9N54YTldAYw==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
@@ -1263,9 +1376,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@img/sharp-linuxmusl-arm64@0.35.1':
+    resolution: {integrity: sha512-VoW2sQCWI+0YIKQEmWJ8vzaQjTg9wIyfkFpvEfAS2h43X6iHu7GTk1hhOgB4IpSzCHe8UwQZIcx7b81VTaOrJA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.35.1':
+    resolution: {integrity: sha512-LjBoSd/c5JU0/K5MwzDMlgsSRP2bPn98JQGFFQAOLQ0bU/1z4ekxUdSKY9BmlwSh/cA+OrvpgsWqfZyYfVHBRw==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
@@ -1274,9 +1399,24 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
+  '@img/sharp-wasm32@0.35.1':
+    resolution: {integrity: sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.1':
+    resolution: {integrity: sha512-xU2ml2bU2OPxYVvW2A6ae4M1g5QKyhKG06P4FAt+YEaFQQO0919Qx+XxIZEUuWTMoDViLpMws2/dQwoe/VcA6A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-arm64@0.35.1':
+    resolution: {integrity: sha512-IkmHwuFhYpd3bTsN5SAahjwhiAcyXPooBt8vEUgxY3T0IP70sSJ0nU1xiPzZY8AH/OB1XpV3j8aZSVSOSfTbdA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
@@ -1286,9 +1426,21 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.1':
+    resolution: {integrity: sha512-wQahqCi9MD8Yxzg4gVM4fNrZxh+r6vD55PyIg+WJPaM5ZRUyF35iQpwJCuma3r6viU9/8Pxlc+XHV+woVa6nCQ==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.1':
+    resolution: {integrity: sha512-WzBtkYtZHATLPe8XRharxZXxQ9cdLrQWHiwxt+BJ5rBsisQrKeeV86ErxPSVhcG6xCEuNhs0SqLpWr7XDa2k6w==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -6173,6 +6325,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
 
@@ -6200,6 +6357,10 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  sharp@0.35.1:
+    resolution: {integrity: sha512-lW979AMi+ESidzMv/Lnv+F9bknzLyxLqFI05Sm433vOeRcltgxQmXpnfOOFIAlKtwXU/ksupm2srQoFCkR214g==}
+    engines: {node: '>=20.9.0'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -7886,6 +8047,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.5.0':
     dependencies:
       tslib: 2.8.1
@@ -8070,9 +8236,16 @@ snapshots:
   '@img/colour@1.0.0':
     optional: true
 
+  '@img/colour@1.1.0': {}
+
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.0
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -8080,34 +8253,74 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.0
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.1':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.1
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.0':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.0':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.0':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-riscv64@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.0':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-x64@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.0':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -8115,9 +8328,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.0
+    optional: true
+
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.0
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -8125,9 +8348,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.0
+    optional: true
+
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.0
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -8135,9 +8368,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.0
+    optional: true
+
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.0
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -8145,9 +8388,19 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.0
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.0
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -8155,13 +8408,32 @@ snapshots:
       '@emnapi/runtime': 1.8.1
     optional: true
 
+  '@img/sharp-wasm32@0.35.1':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.1':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.1
+    optional: true
+
   '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.1':
     optional: true
 
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.1':
+    optional: true
+
   '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.1':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -13514,6 +13786,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.4: {}
+
   seq-queue@0.0.5: {}
 
   serialize-javascript@6.0.2:
@@ -13577,6 +13851,38 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
     optional: true
+
+  sharp@0.35.1:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.1
+      '@img/sharp-darwin-x64': 0.35.1
+      '@img/sharp-freebsd-wasm32': 0.35.1
+      '@img/sharp-libvips-darwin-arm64': 1.3.0
+      '@img/sharp-libvips-darwin-x64': 1.3.0
+      '@img/sharp-libvips-linux-arm': 1.3.0
+      '@img/sharp-libvips-linux-arm64': 1.3.0
+      '@img/sharp-libvips-linux-ppc64': 1.3.0
+      '@img/sharp-libvips-linux-riscv64': 1.3.0
+      '@img/sharp-libvips-linux-s390x': 1.3.0
+      '@img/sharp-libvips-linux-x64': 1.3.0
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.0
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.0
+      '@img/sharp-linux-arm': 0.35.1
+      '@img/sharp-linux-arm64': 0.35.1
+      '@img/sharp-linux-ppc64': 0.35.1
+      '@img/sharp-linux-riscv64': 0.35.1
+      '@img/sharp-linux-s390x': 0.35.1
+      '@img/sharp-linux-x64': 0.35.1
+      '@img/sharp-linuxmusl-arm64': 0.35.1
+      '@img/sharp-linuxmusl-x64': 0.35.1
+      '@img/sharp-webcontainers-wasm32': 0.35.1
+      '@img/sharp-win32-arm64': 0.35.1
+      '@img/sharp-win32-ia32': 0.35.1
+      '@img/sharp-win32-x64': 0.35.1
 
   shebang-command@2.0.0:
     dependencies:

--- a/scripts/image-assets/backfill-legacy-images-to-r2.mjs
+++ b/scripts/image-assets/backfill-legacy-images-to-r2.mjs
@@ -1,0 +1,452 @@
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { PrismaClient } from "@prisma/client";
+import sharp from "sharp";
+
+const DEFAULT_CONCURRENCY = 5;
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_TIMEOUT_SECONDS = 60;
+const DEFAULT_MAX_SOURCE_BYTES = 25 * 1024 * 1024;
+const VARIANT_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const R2_BUCKET_NAME = "daylily-catalog-media";
+const R2_PUBLIC_BASE_URL = "https://media.daylilycatalog.com";
+const SENTRY_DSN =
+  "https://b3773458fec6aa0c594a9c1c73ed046a@o1136137.ingest.us.sentry.io/4508939597643776";
+
+let sentryCaptureException = null;
+if (process.env.NEXT_PUBLIC_SENTRY_ENABLED !== "false") {
+  try {
+    const Sentry = await import("@sentry/nextjs");
+    Sentry.init({ dsn: SENTRY_DSN, enableLogs: true });
+    sentryCaptureException = Sentry.captureException;
+  } catch (error) {
+    console.warn("[image-assets] sentry unavailable", error);
+  }
+}
+
+function readIntEnv(name, fallback) {
+  const value = process.env[name];
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: args.includes("--dry-run"),
+    retryFailed: args.includes("--retry-failed"),
+    limit:
+      Number.parseInt(args[args.indexOf("--limit") + 1] ?? "", 10) ||
+      readIntEnv("IMAGE_ASSET_BACKFILL_BATCH_SIZE", DEFAULT_BATCH_SIZE),
+  };
+}
+
+function captureScriptException(error, context) {
+  try {
+    sentryCaptureException?.(error, context);
+  } catch (captureError) {
+    console.warn("[image-assets] sentry capture failed", captureError);
+  }
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}
+
+async function createDb() {
+  const url = requireEnv("DATABASE_URL");
+
+  if (url.startsWith("file:")) {
+    const { PrismaBetterSqlite3 } = await import(
+      "@prisma/adapter-better-sqlite3"
+    );
+
+    return new PrismaClient({
+      adapter: new PrismaBetterSqlite3(
+        { url },
+        { timestampFormat: "unixepoch-ms" },
+      ),
+      log: ["error", "warn"],
+    });
+  }
+
+  if (url.startsWith("libsql://")) {
+    const { PrismaLibSql } = await import("@prisma/adapter-libsql");
+
+    return new PrismaClient({
+      adapter: new PrismaLibSql(
+        {
+          url,
+          authToken: process.env.TURSO_DATABASE_AUTH_TOKEN,
+        },
+        { timestampFormat: "unixepoch-ms" },
+      ),
+      log: ["error"],
+    });
+  }
+
+  throw new Error(`Unsupported DATABASE_URL: ${url}`);
+}
+
+function createR2Client() {
+  return new S3Client({
+    region: "auto",
+    endpoint: `https://${requireEnv("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: requireEnv("R2_ACCESS_KEY_ID"),
+      secretAccessKey: requireEnv("R2_SECRET_ACCESS_KEY"),
+    },
+  });
+}
+
+function publicUrlForKey(key) {
+  const baseUrl = (
+    process.env.R2_PUBLIC_BASE_URL ?? R2_PUBLIC_BASE_URL
+  ).replace(/\/+$/, "");
+  return `${baseUrl}/${key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")}`;
+}
+
+function extensionFromUrl(url) {
+  try {
+    const pathname = new URL(url).pathname;
+    const match = pathname.match(/\.([a-z0-9]+)$/i);
+    return match ? `.${match[1].toLowerCase()}` : ".jpg";
+  } catch {
+    return ".jpg";
+  }
+}
+
+function contentTypeFromExtension(url) {
+  const ext = extensionFromUrl(url);
+  if (ext === ".png") return "image/png";
+  if (ext === ".webp") return "image/webp";
+  if (ext === ".gif") return "image/gif";
+  return "image/jpeg";
+}
+
+function detectImageContentType(buffer, fallback) {
+  if (
+    buffer[0] === 0xff &&
+    buffer[1] === 0xd8 &&
+    buffer[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+
+  if (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47
+  ) {
+    return "image/png";
+  }
+
+  if (
+    buffer.subarray(0, 4).toString("ascii") === "RIFF" &&
+    buffer.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return "image/webp";
+  }
+
+  if (buffer.subarray(0, 3).toString("ascii") === "GIF") {
+    return "image/gif";
+  }
+
+  return fallback;
+}
+
+function originalKeyForImage(image) {
+  const ext = extensionFromUrl(image.url);
+
+  if (image.listingId) {
+    return `users/${image.listing.userId}/listing-images/${image.listingId}/${image.id}/original${ext}`;
+  }
+
+  if (image.userProfileId) {
+    return `users/${image.userProfile.userId}/profile-images/${image.id}/original${ext}`;
+  }
+
+  throw new Error(`Image ${image.id} has no supported owner.`);
+}
+
+function variantKeysFromOriginalKey(originalKey) {
+  const baseKey = originalKey.replace(
+    /\/(?:original|source-original|generated-original)\.[a-z0-9]+$/i,
+    "",
+  );
+  return {
+    displayKey: `${baseKey}/display-800.webp`,
+    thumbKey: `${baseKey}/thumb-200.webp`,
+    blurKey: `${baseKey}/blur-20.webp`,
+  };
+}
+
+async function fetchSourceBuffer(url) {
+  const timeoutSeconds = readIntEnv(
+    "IMAGE_ASSET_BACKFILL_DOWNLOAD_TIMEOUT_SECONDS",
+    DEFAULT_TIMEOUT_SECONDS,
+  );
+  const maxBytes = readIntEnv(
+    "IMAGE_ASSET_BACKFILL_MAX_SOURCE_BYTES",
+    DEFAULT_MAX_SOURCE_BYTES,
+  );
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Source download failed: ${response.status}`);
+    }
+
+    const responseContentType = response.headers.get("content-type");
+    const contentLength = Number.parseInt(
+      response.headers.get("content-length") ?? "",
+      10,
+    );
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      throw new Error(`Source image exceeds ${maxBytes} bytes.`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > maxBytes) {
+      throw new Error(`Source image exceeds ${maxBytes} bytes.`);
+    }
+
+    return {
+      buffer,
+      contentType: detectImageContentType(
+        buffer,
+        responseContentType?.startsWith("image/")
+          ? responseContentType
+          : contentTypeFromExtension(url),
+      ),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function uploadObject(r2, bucket, key, body, contentType, cacheControl) {
+  await r2.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+      CacheControl: cacheControl,
+    }),
+  );
+}
+
+async function backfillImage({ image, db, r2, bucket, dryRun }) {
+  const originalKey = originalKeyForImage(image);
+  const variantKeys = variantKeysFromOriginalKey(originalKey);
+  const ownerData = image.listingId
+    ? { listingId: image.listingId, kind: "listing" }
+    : { userProfileId: image.userProfileId, kind: "profile" };
+
+  if (dryRun) {
+    console.log("[dry-run] would backfill", image.id, originalKey, variantKeys);
+    return;
+  }
+
+  const { buffer, contentType } = await fetchSourceBuffer(image.url);
+  const base = sharp(buffer, { failOn: "error" }).rotate();
+  const [display, thumb, blur] = await Promise.all([
+    base
+      .clone()
+      .resize(800, 800, { fit: "cover" })
+      .webp({ quality: 82 })
+      .toBuffer(),
+    base
+      .clone()
+      .resize(200, 200, { fit: "cover" })
+      .webp({ quality: 78 })
+      .toBuffer(),
+    base
+      .clone()
+      .resize(20, 20, { fit: "cover" })
+      .webp({ quality: 35 })
+      .toBuffer(),
+  ]);
+
+  await Promise.all([
+    uploadObject(r2, bucket, originalKey, buffer, contentType, undefined),
+    uploadObject(
+      r2,
+      bucket,
+      variantKeys.displayKey,
+      display,
+      "image/webp",
+      VARIANT_CACHE_CONTROL,
+    ),
+    uploadObject(
+      r2,
+      bucket,
+      variantKeys.thumbKey,
+      thumb,
+      "image/webp",
+      VARIANT_CACHE_CONTROL,
+    ),
+    uploadObject(
+      r2,
+      bucket,
+      variantKeys.blurKey,
+      blur,
+      "image/webp",
+      VARIANT_CACHE_CONTROL,
+    ),
+  ]);
+
+  await db.imageAsset.upsert({
+    where: { id: image.id },
+    create: {
+      id: image.id,
+      legacyImageId: image.id,
+      order: image.order,
+      status: "ready",
+      originalKey,
+      originalUrl: publicUrlForKey(originalKey),
+      displayKey: variantKeys.displayKey,
+      displayUrl: publicUrlForKey(variantKeys.displayKey),
+      thumbKey: variantKeys.thumbKey,
+      thumbUrl: publicUrlForKey(variantKeys.thumbKey),
+      blurKey: variantKeys.blurKey,
+      blurUrl: publicUrlForKey(variantKeys.blurKey),
+      ...ownerData,
+    },
+    update: {
+      legacyImageId: image.id,
+      order: image.order,
+      status: "ready",
+      originalKey,
+      originalUrl: publicUrlForKey(originalKey),
+      displayKey: variantKeys.displayKey,
+      displayUrl: publicUrlForKey(variantKeys.displayKey),
+      thumbKey: variantKeys.thumbKey,
+      thumbUrl: publicUrlForKey(variantKeys.thumbKey),
+      blurKey: variantKeys.blurKey,
+      blurUrl: publicUrlForKey(variantKeys.blurKey),
+      ...ownerData,
+    },
+  });
+
+  console.log("[backfilled]", image.id);
+}
+
+async function runConcurrent(items, concurrency, worker) {
+  let index = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (index < items.length) {
+        const item = items[index++];
+        await worker(item);
+      }
+    },
+  );
+  await Promise.all(workers);
+}
+
+async function main() {
+  const args = parseArgs();
+  const db = await createDb();
+  const r2 = args.dryRun ? null : createR2Client();
+  const bucket = process.env.R2_BUCKET_NAME ?? R2_BUCKET_NAME;
+  const concurrency = readIntEnv(
+    "IMAGE_ASSET_BACKFILL_CONCURRENCY",
+    DEFAULT_CONCURRENCY,
+  );
+
+  try {
+    const existingAssets = await db.imageAsset.findMany({
+      where: args.retryFailed ? { status: "backfill_failed" } : undefined,
+      select: { id: true, legacyImageId: true },
+    });
+    const assetImageIds = existingAssets.map(
+      (asset) => asset.legacyImageId ?? asset.id,
+    );
+
+    const images = await db.image.findMany({
+      where: {
+        OR: [
+          { listingId: { not: null }, listing: { isNot: null } },
+          { userProfileId: { not: null }, userProfile: { isNot: null } },
+        ],
+        AND: [
+          {
+            OR: [
+              { listingId: { not: null } },
+              { userProfileId: { not: null } },
+            ],
+          },
+          args.retryFailed
+            ? {
+                id: {
+                  in: assetImageIds,
+                },
+              }
+            : {
+                NOT: {
+                  id: {
+                    in: assetImageIds,
+                  },
+                },
+              },
+        ],
+      },
+      include: {
+        listing: { select: { userId: true } },
+        userProfile: { select: { userId: true } },
+      },
+      orderBy: { createdAt: "asc" },
+      take: args.limit,
+    });
+
+    console.log(
+      `[image-assets] backfilling ${images.length} images with concurrency ${concurrency}`,
+    );
+
+    await runConcurrent(images, concurrency, async (image) => {
+      try {
+        await backfillImage({ image, db, r2, bucket, dryRun: args.dryRun });
+      } catch (error) {
+        console.error("[failed]", image.id, error);
+        captureScriptException(error, {
+          tags: { source: "image-assets:backfill" },
+          extra: { imageId: image.id },
+        });
+        if (!args.dryRun) {
+          await db.imageAsset.upsert({
+            where: { id: image.id },
+            create: {
+              id: image.id,
+              legacyImageId: image.id,
+              order: image.order,
+              kind: image.listingId ? "listing" : "profile",
+              status: "backfill_failed",
+              ...(image.listingId
+                ? { listingId: image.listingId }
+                : { userProfileId: image.userProfileId }),
+            },
+            update: { status: "backfill_failed" },
+          });
+        }
+      }
+    });
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error("[image-assets] fatal", error);
+  process.exitCode = 1;
+});

--- a/scripts/image-assets/process-image-asset-variants.mjs
+++ b/scripts/image-assets/process-image-asset-variants.mjs
@@ -1,0 +1,327 @@
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { PrismaClient } from "@prisma/client";
+import sharp from "sharp";
+import { revalidatePublicCacheForAsset } from "./public-cache-revalidation.mjs";
+
+const DEFAULT_CONCURRENCY = 5;
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_TIMEOUT_SECONDS = 60;
+const DEFAULT_MAX_SOURCE_BYTES = 25 * 1024 * 1024;
+const VARIANT_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const R2_BUCKET_NAME = "daylily-catalog-media";
+const R2_PUBLIC_BASE_URL = "https://media.daylilycatalog.com";
+const SENTRY_DSN =
+  "https://b3773458fec6aa0c594a9c1c73ed046a@o1136137.ingest.us.sentry.io/4508939597643776";
+
+let sentryCaptureException = null;
+if (process.env.NEXT_PUBLIC_SENTRY_ENABLED !== "false") {
+  try {
+    const Sentry = await import("@sentry/nextjs");
+    Sentry.init({ dsn: SENTRY_DSN, enableLogs: true });
+    sentryCaptureException = Sentry.captureException;
+  } catch (error) {
+    console.warn("[image-assets] sentry unavailable", error);
+  }
+}
+
+function readIntEnv(name, fallback) {
+  const value = process.env[name];
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const assetIdIndex = args.indexOf("--asset-id");
+  const assetId = assetIdIndex >= 0 ? args[assetIdIndex + 1] : null;
+
+  if (assetIdIndex >= 0 && (!assetId || assetId.startsWith("--"))) {
+    throw new Error("--asset-id requires a value.");
+  }
+
+  return {
+    dryRun: args.includes("--dry-run"),
+    retryFailed: args.includes("--retry-failed"),
+    assetId,
+    limit:
+      Number.parseInt(args[args.indexOf("--limit") + 1] ?? "", 10) ||
+      readIntEnv("IMAGE_ASSET_BACKFILL_BATCH_SIZE", DEFAULT_BATCH_SIZE),
+  };
+}
+
+function captureScriptException(error, context) {
+  try {
+    sentryCaptureException?.(error, context);
+  } catch (captureError) {
+    console.warn("[image-assets] sentry capture failed", captureError);
+  }
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+async function createDb() {
+  const url = requireEnv("DATABASE_URL");
+
+  if (url.startsWith("file:")) {
+    const { PrismaBetterSqlite3 } = await import(
+      "@prisma/adapter-better-sqlite3"
+    );
+
+    return new PrismaClient({
+      adapter: new PrismaBetterSqlite3(
+        { url },
+        { timestampFormat: "unixepoch-ms" },
+      ),
+      log: ["error", "warn"],
+    });
+  }
+
+  if (url.startsWith("libsql://")) {
+    const { PrismaLibSql } = await import("@prisma/adapter-libsql");
+
+    return new PrismaClient({
+      adapter: new PrismaLibSql(
+        {
+          url,
+          authToken: process.env.TURSO_DATABASE_AUTH_TOKEN,
+        },
+        { timestampFormat: "unixepoch-ms" },
+      ),
+      log: ["error"],
+    });
+  }
+
+  throw new Error(`Unsupported DATABASE_URL: ${url}`);
+}
+
+function createR2Client() {
+  return new S3Client({
+    region: "auto",
+    endpoint: `https://${requireEnv("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: requireEnv("R2_ACCESS_KEY_ID"),
+      secretAccessKey: requireEnv("R2_SECRET_ACCESS_KEY"),
+    },
+  });
+}
+
+function publicUrlForKey(key) {
+  const baseUrl = (
+    process.env.R2_PUBLIC_BASE_URL ?? R2_PUBLIC_BASE_URL
+  ).replace(/\/+$/, "");
+  return `${baseUrl}/${key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")}`;
+}
+
+function variantKeysFromOriginalKey(originalKey) {
+  const baseKey = originalKey.replace(
+    /\/(?:original|source-original|generated-original)\.[a-z0-9]+$/i,
+    "",
+  );
+  return {
+    displayKey: `${baseKey}/display-800.webp`,
+    thumbKey: `${baseKey}/thumb-200.webp`,
+    blurKey: `${baseKey}/blur-20.webp`,
+  };
+}
+
+async function fetchSourceBuffer(url) {
+  const timeoutSeconds = readIntEnv(
+    "IMAGE_ASSET_BACKFILL_DOWNLOAD_TIMEOUT_SECONDS",
+    DEFAULT_TIMEOUT_SECONDS,
+  );
+  const maxBytes = readIntEnv(
+    "IMAGE_ASSET_BACKFILL_MAX_SOURCE_BYTES",
+    DEFAULT_MAX_SOURCE_BYTES,
+  );
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Source download failed: ${response.status}`);
+    }
+
+    const contentLength = Number.parseInt(
+      response.headers.get("content-length") ?? "",
+      10,
+    );
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      throw new Error(`Source image exceeds ${maxBytes} bytes.`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > maxBytes) {
+      throw new Error(`Source image exceeds ${maxBytes} bytes.`);
+    }
+
+    return buffer;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function uploadWebp(r2, bucket, key, body) {
+  await r2.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: "image/webp",
+      CacheControl: VARIANT_CACHE_CONTROL,
+    }),
+  );
+}
+
+async function processAsset({ asset, db, r2, bucket, dryRun }) {
+  if (!asset.originalUrl || !asset.originalKey) {
+    throw new Error(`ImageAsset ${asset.id} has no originalUrl/originalKey.`);
+  }
+
+  const keys = variantKeysFromOriginalKey(asset.originalKey);
+  if (dryRun) {
+    console.log("[dry-run] would process", asset.id, keys);
+    return;
+  }
+
+  const source = await fetchSourceBuffer(asset.originalUrl);
+  const base = sharp(source, { failOn: "error" }).rotate();
+  const [display, thumb, blur] = await Promise.all([
+    base
+      .clone()
+      .resize(800, 800, { fit: "cover" })
+      .webp({ quality: 82 })
+      .toBuffer(),
+    base
+      .clone()
+      .resize(200, 200, { fit: "cover" })
+      .webp({ quality: 78 })
+      .toBuffer(),
+    base
+      .clone()
+      .resize(20, 20, { fit: "cover" })
+      .webp({ quality: 35 })
+      .toBuffer(),
+  ]);
+
+  await Promise.all([
+    uploadWebp(r2, bucket, keys.displayKey, display),
+    uploadWebp(r2, bucket, keys.thumbKey, thumb),
+    uploadWebp(r2, bucket, keys.blurKey, blur),
+  ]);
+
+  await db.imageAsset.update({
+    where: { id: asset.id },
+    data: {
+      displayKey: keys.displayKey,
+      displayUrl: publicUrlForKey(keys.displayKey),
+      thumbKey: keys.thumbKey,
+      thumbUrl: publicUrlForKey(keys.thumbKey),
+      blurKey: keys.blurKey,
+      blurUrl: publicUrlForKey(keys.blurKey),
+      status: "ready",
+    },
+  });
+
+  if (asset.legacyImageId) {
+    await db.image.update({
+      where: { id: asset.legacyImageId },
+      data: { updatedAt: new Date() },
+    });
+  }
+
+  try {
+    await revalidatePublicCacheForAsset({ asset, db });
+  } catch (error) {
+    console.error("[image-assets] public cache revalidation failed", {
+      imageAssetId: asset.id,
+      error,
+    });
+    captureScriptException(error, {
+      tags: { source: "image-assets:variants-revalidation" },
+      extra: { imageAssetId: asset.id },
+    });
+  }
+
+  console.log("[processed]", asset.id);
+}
+
+async function runConcurrent(items, concurrency, worker) {
+  let index = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (index < items.length) {
+        const item = items[index++];
+        await worker(item);
+      }
+    },
+  );
+  await Promise.all(workers);
+}
+
+async function main() {
+  const args = parseArgs();
+  const db = await createDb();
+  const r2 = args.dryRun ? null : createR2Client();
+  const bucket = process.env.R2_BUCKET_NAME ?? R2_BUCKET_NAME;
+  const concurrency = readIntEnv(
+    "IMAGE_ASSET_BACKFILL_CONCURRENCY",
+    DEFAULT_CONCURRENCY,
+  );
+
+  try {
+    const assets = await db.imageAsset.findMany({
+      where: {
+        ...(args.assetId ? { id: args.assetId } : {}),
+        status: args.retryFailed
+          ? { in: ["pending_variants", "variant_failed"] }
+          : "pending_variants",
+        originalUrl: { not: null },
+        originalKey: { not: null },
+        OR: [{ displayUrl: null }, { thumbUrl: null }, { blurUrl: null }],
+      },
+      orderBy: { createdAt: "asc" },
+      take: args.limit,
+    });
+
+    console.log(
+      `[image-assets] processing ${assets.length} assets with concurrency ${concurrency}`,
+    );
+
+    await runConcurrent(assets, concurrency, async (asset) => {
+      try {
+        await processAsset({ asset, db, r2, bucket, dryRun: args.dryRun });
+      } catch (error) {
+        console.error("[failed]", asset.id, error);
+        captureScriptException(error, {
+          tags: { source: "image-assets:variants" },
+          extra: { imageAssetId: asset.id },
+        });
+        if (!args.dryRun) {
+          await db.imageAsset.update({
+            where: { id: asset.id },
+            data: { status: "variant_failed" },
+          });
+        }
+      }
+    });
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error("[image-assets] fatal", error);
+  process.exitCode = 1;
+});

--- a/scripts/image-assets/public-cache-revalidation.mjs
+++ b/scripts/image-assets/public-cache-revalidation.mjs
@@ -1,0 +1,239 @@
+// @ts-nocheck
+
+const PUBLIC_REVALIDATION_SOURCE = "image-assets.variants";
+
+const PUBLIC_CACHE_TAGS = {
+  PUBLIC_PROFILES: "public:profiles",
+  PUBLIC_PROFILE: "public:profile",
+  PUBLIC_LISTINGS: "public:listings",
+  PUBLIC_LISTINGS_PAGE: "public:listings:page",
+  PUBLIC_FOR_SALE_COUNT: "public:listings:for-sale-count",
+  PUBLIC_CULTIVAR_PAGE: "public:cultivar:page",
+};
+
+function slugify(text) {
+  return text
+    .toString()
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^\w-]+/g, "")
+    .replace(/--+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
+}
+
+function toCultivarRouteSegment(name) {
+  if (!name) return null;
+
+  const normalized = name
+    .toString()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+
+  return slugify(normalized) || null;
+}
+
+function getPublicProfileTag(userId) {
+  return `${PUBLIC_CACHE_TAGS.PUBLIC_PROFILE}:${userId}`;
+}
+
+function getPublicSellerContentTag(userId) {
+  return `${PUBLIC_CACHE_TAGS.PUBLIC_PROFILE}:content:${userId}`;
+}
+
+function getPublicSellerListsTag(userId) {
+  return `${PUBLIC_CACHE_TAGS.PUBLIC_PROFILE}:lists:${userId}`;
+}
+
+function getPublicListingsPageTag(userId) {
+  return `${PUBLIC_CACHE_TAGS.PUBLIC_LISTINGS_PAGE}:${userId}`;
+}
+
+function getPublicForSaleCountTag(userId) {
+  return `${PUBLIC_CACHE_TAGS.PUBLIC_FOR_SALE_COUNT}:${userId}`;
+}
+
+function getPublicListingCardTag(listingId) {
+  return `${PUBLIC_CACHE_TAGS.PUBLIC_LISTINGS}:card:${listingId}`;
+}
+
+function getPublicCultivarTag(segment) {
+  return `${PUBLIC_CACHE_TAGS.PUBLIC_CULTIVAR_PAGE}:${segment}`;
+}
+
+function uniqueBy(items, getKey) {
+  return Array.from(new Map(items.map((item) => [getKey(item), item])).values());
+}
+
+function addCultivarTargets(targets, normalizedName) {
+  const segment = toCultivarRouteSegment(normalizedName);
+  if (!segment) return;
+
+  targets.paths.push({ path: `/cultivar/${segment}` });
+  targets.tags.push({ tag: getPublicCultivarTag(segment) });
+}
+
+function createPayload(paths, tags) {
+  return {
+    source: PUBLIC_REVALIDATION_SOURCE,
+    paths: uniqueBy(paths, (entry) => `${entry.type ?? "default"}:${entry.path}`),
+    tags: uniqueBy(tags, (entry) => `${entry.profile ?? "expire:0"}:${entry.tag}`),
+  };
+}
+
+async function buildListingPayload({ asset, db }) {
+  if (!asset.listingId) {
+    return createPayload([], []);
+  }
+
+  const listing = await db.listing.findUnique({
+    where: { id: asset.listingId },
+    select: {
+      id: true,
+      userId: true,
+      cultivarReference: {
+        select: {
+          normalizedName: true,
+        },
+      },
+      user: {
+        select: {
+          profile: {
+            select: {
+              slug: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!listing) {
+    return createPayload([], []);
+  }
+
+  const targets = {
+    paths: [{ path: `/${listing.user.profile?.slug ?? listing.userId}` }],
+    tags: [{ tag: getPublicListingCardTag(listing.id) }],
+  };
+
+  addCultivarTargets(targets, listing.cultivarReference?.normalizedName);
+
+  return createPayload(targets.paths, targets.tags);
+}
+
+async function buildProfilePayload({ asset, db }) {
+  if (!asset.userProfileId) {
+    return createPayload([], []);
+  }
+
+  const profile = await db.userProfile.findUnique({
+    where: { id: asset.userProfileId },
+    select: {
+      userId: true,
+      slug: true,
+    },
+  });
+
+  if (!profile) {
+    return createPayload([], []);
+  }
+
+  const targets = {
+    paths: [{ path: `/${profile.slug ?? profile.userId}` }, { path: "/catalogs" }],
+    tags: [
+      { tag: getPublicProfileTag(profile.userId) },
+      { tag: getPublicSellerContentTag(profile.userId) },
+      { tag: getPublicSellerListsTag(profile.userId) },
+      { tag: getPublicListingsPageTag(profile.userId) },
+      { tag: getPublicForSaleCountTag(profile.userId) },
+      { tag: PUBLIC_CACHE_TAGS.PUBLIC_PROFILES },
+    ],
+  };
+
+  const listings = await db.listing.findMany({
+    where: {
+      userId: profile.userId,
+      cultivarReference: {
+        normalizedName: {
+          not: null,
+        },
+      },
+    },
+    select: {
+      cultivarReference: {
+        select: {
+          normalizedName: true,
+        },
+      },
+    },
+  });
+
+  listings.forEach((listing) => {
+    addCultivarTargets(targets, listing.cultivarReference?.normalizedName);
+  });
+
+  return createPayload(targets.paths, targets.tags);
+}
+
+export async function buildPublicCacheRevalidationPayloadForAsset({
+  asset,
+  db,
+}) {
+  if (asset.listingId) {
+    return buildListingPayload({ asset, db });
+  }
+
+  return buildProfilePayload({ asset, db });
+}
+
+export async function postPublicCacheRevalidation({
+  fetchImpl = fetch,
+  payload,
+}) {
+  if (payload.paths.length === 0 && payload.tags.length === 0) {
+    return false;
+  }
+
+  const baseUrl = process.env.APP_BASE_URL?.trim();
+  const secret = process.env.CLERK_WEBHOOK_SECRET?.trim();
+
+  if (!baseUrl || !secret) {
+    console.warn(
+      "[image-assets] skipped public cache revalidation; APP_BASE_URL or CLERK_WEBHOOK_SECRET is missing",
+    );
+    return false;
+  }
+
+  const routeUrl = new URL("/api/internal/public-cache-revalidate", baseUrl);
+  const response = await fetchImpl(routeUrl, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${secret}`,
+      "content-type": "application/json",
+    },
+    cache: "no-store",
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Public cache revalidate route failed with status ${response.status}`,
+    );
+  }
+
+  return true;
+}
+
+export async function revalidatePublicCacheForAsset({ asset, db, fetchImpl }) {
+  const payload = await buildPublicCacheRevalidationPayloadForAsset({
+    asset,
+    db,
+  });
+
+  return postPublicCacheRevalidation({ payload, fetchImpl });
+}

--- a/tests/image-asset-public-cache-revalidation.test.ts
+++ b/tests/image-asset-public-cache-revalidation.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildPublicCacheRevalidationPayloadForAsset,
+  postPublicCacheRevalidation,
+} from "../scripts/image-assets/public-cache-revalidation.mjs";
+
+const originalAppBaseUrl = process.env.APP_BASE_URL;
+const originalClerkWebhookSecret = process.env.CLERK_WEBHOOK_SECRET;
+
+beforeEach(() => {
+  process.env.APP_BASE_URL = "https://daylilycatalog.com";
+  process.env.CLERK_WEBHOOK_SECRET = "test-secret";
+});
+
+afterEach(() => {
+  if (originalAppBaseUrl === undefined) {
+    delete process.env.APP_BASE_URL;
+  } else {
+    process.env.APP_BASE_URL = originalAppBaseUrl;
+  }
+
+  if (originalClerkWebhookSecret === undefined) {
+    delete process.env.CLERK_WEBHOOK_SECRET;
+  } else {
+    process.env.CLERK_WEBHOOK_SECRET = originalClerkWebhookSecret;
+  }
+
+  vi.restoreAllMocks();
+});
+
+describe("image asset public cache revalidation", () => {
+  it("builds listing cache targets for generated variants", async () => {
+    const db = {
+      listing: {
+        findUnique: vi.fn(async () => ({
+          id: "listing-1",
+          userId: "user-1",
+          cultivarReference: {
+            normalizedName: "Café Au Lait",
+          },
+          user: {
+            profile: {
+              slug: "garden-slug",
+            },
+          },
+        })),
+      },
+    };
+
+    const payload = await buildPublicCacheRevalidationPayloadForAsset({
+      asset: {
+        id: "asset-1",
+        listingId: "listing-1",
+        userProfileId: null,
+      },
+      db,
+    });
+
+    expect(payload).toEqual({
+      source: "image-assets.variants",
+      paths: [{ path: "/garden-slug" }, { path: "/cultivar/cafe-au-lait" }],
+      tags: [
+        { tag: "public:listings:card:listing-1" },
+        { tag: "public:cultivar:page:cafe-au-lait" },
+      ],
+    });
+  });
+
+  it("builds profile, catalog, and cultivar cache targets for profile variants", async () => {
+    const db = {
+      userProfile: {
+        findUnique: vi.fn(async () => ({
+          userId: "user-1",
+          slug: null,
+        })),
+      },
+      listing: {
+        findMany: vi.fn(async () => [
+          {
+            cultivarReference: {
+              normalizedName: "Alpha One",
+            },
+          },
+          {
+            cultivarReference: {
+              normalizedName: "Alpha One",
+            },
+          },
+        ]),
+      },
+    };
+
+    const payload = await buildPublicCacheRevalidationPayloadForAsset({
+      asset: {
+        id: "asset-1",
+        listingId: null,
+        userProfileId: "profile-1",
+      },
+      db,
+    });
+
+    expect(payload.paths).toEqual([
+      { path: "/user-1" },
+      { path: "/catalogs" },
+      { path: "/cultivar/alpha-one" },
+    ]);
+    expect(payload.tags).toEqual([
+      { tag: "public:profile:user-1" },
+      { tag: "public:profile:content:user-1" },
+      { tag: "public:profile:lists:user-1" },
+      { tag: "public:listings:page:user-1" },
+      { tag: "public:listings:for-sale-count:user-1" },
+      { tag: "public:profiles" },
+      { tag: "public:cultivar:page:alpha-one" },
+    ]);
+  });
+
+  it("posts the revalidation payload to the internal route", async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const payload = {
+      source: "image-assets.variants",
+      paths: [{ path: "/garden-slug" }],
+      tags: [{ tag: "public:listings:card:listing-1" }],
+    };
+
+    await expect(
+      postPublicCacheRevalidation({ fetchImpl, payload }),
+    ).resolves.toBe(true);
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL(
+        "/api/internal/public-cache-revalidate",
+        "https://daylilycatalog.com",
+      ),
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-secret",
+          "content-type": "application/json",
+        },
+        cache: "no-store",
+        body: JSON.stringify(payload),
+      }),
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,8 @@
   ],
   "exclude": [
     "node_modules",
+    "downloads",
+    "local",
     "playwright-report",
     "src/components/ui/**/*"
   ]


### PR DESCRIPTION
## Summary

Adds the offline/tooling side of the ImageAsset migration:

- local backfill script for migrating legacy S3 image rows into R2 ImageAsset originals and variants
- variant processor for generating display/thumb/blur assets with `sharp`
- public cache revalidation helper for standalone Node scripts
- package scripts for backfill/variants
- Docker/runtime packaging for the worker scripts
- `.dockerignore` and `tsconfig` exclusions for large local scratch roots

Stacked on #214.

## Validation

- `node --check scripts/image-assets/backfill-legacy-images-to-r2.mjs`
- `node --check scripts/image-assets/process-image-asset-variants.mjs`
- `pnpm test -- tests/image-asset-public-cache-revalidation.test.ts`
- Previously validated as part of the full branch with full unit, lint, typecheck, and flag-off E2E runs.

## Notes

The backfill script is intended to run locally/against rehearsed data first. This PR does not perform production Turso writes.