### PR TITLE
[codex] Read ImageAsset URLs behind flag

### DIFF
--- a/src/app/api/google-merchant-feed/route.ts
+++ b/src/app/api/google-merchant-feed/route.ts
@@ -6,6 +6,7 @@ import {
   withResolvedDisplayAhsListing,
   v2AhsCultivarDisplaySelect,
 } from "@/lib/utils/ahs-display";
+import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
 
 // Constants for merchant feed configuration
 const SHIPPING_WEIGHT = "0.5 lb";
@@ -19,6 +20,22 @@ export async function GET(_request: Request) {
     const include = {
       images: {
         take: 4, // Get up to 4 images (1 main + 3 additional)
+        orderBy: {
+          order: "asc" as const,
+        },
+      },
+      imageAssets: {
+        select: {
+          id: true,
+          legacyImageId: true,
+          originalUrl: true,
+          displayUrl: true,
+          thumbUrl: true,
+          blurUrl: true,
+        },
+        orderBy: {
+          order: "asc" as const,
+        },
       },
       cultivarReference: {
         include: {
@@ -58,6 +75,12 @@ export async function GET(_request: Request) {
       try {
         const displayListing = withResolvedDisplayAhsListing(listing);
         const displayAhsListing = displayListing.ahsListing;
+        const resolvedImages = resolveLegacyImagesWithAssets({
+          images: displayListing.images,
+          imageAssets: displayListing.imageAssets,
+          variant: "display",
+          source: "google-merchant-feed",
+        });
         const listingName =
           displayListing.title ?? displayAhsListing?.name ?? "Unnamed Daylily";
         // Combine descriptions
@@ -72,8 +95,8 @@ export async function GET(_request: Request) {
         }
 
         const imageUrl =
-          displayListing.images?.[0]?.url ?? displayAhsListing?.ahsImageUrl;
-        const additionalImages = displayListing.images?.slice(1, 4) ?? [];
+          resolvedImages[0]?.url ?? displayAhsListing?.ahsImageUrl;
+        const additionalImages = resolvedImages.slice(1, 4);
         const productUrl = `${baseUrl}/${displayListing.userId}/${displayListing.id}`;
         const catalogName =
           displayListing.user.profile?.title ??

--- a/src/lib/utils/cloudflareLoader.tsx
+++ b/src/lib/utils/cloudflareLoader.tsx
@@ -1,9 +1,19 @@
 import { IMAGE_CONFIG } from "@/components/optimized-image";
 
+const STATIC_IMAGE_ASSET_HOST = "media.daylilycatalog.com";
+
+function isStaticImageAssetUrl(src: string) {
+  try {
+    return new URL(src).hostname.toLowerCase() === STATIC_IMAGE_ASSET_HOST;
+  } catch {
+    return false;
+  }
+}
+
 // Helper function for metadata image optimization that handles both public and external images
 export const getOptimizedMetaImageUrl = (src: string) => {
   // If the image is from our public folder (starts with /assets), return as is
-  if (src.startsWith("/assets")) {
+  if (src.startsWith("/assets") || isStaticImageAssetUrl(src)) {
     return src;
   }
 

--- a/src/server/db/public-listing-read-model.ts
+++ b/src/server/db/public-listing-read-model.ts
@@ -10,6 +10,7 @@ import { getCachedProUserIds } from "@/server/db/getCachedProUserIds";
 import { db } from "@/server/db";
 import { getUserIdFromSlugOrId } from "@/server/db/getPublicProfile";
 import { isPublished } from "@/server/db/public-visibility/filters";
+import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
 
 export const publicListingSelect = {
   id: true,
@@ -56,6 +57,19 @@ export const publicListingSelect = {
       order: "asc",
     },
   },
+  imageAssets: {
+    select: {
+      id: true,
+      legacyImageId: true,
+      originalUrl: true,
+      displayUrl: true,
+      thumbUrl: true,
+      blurUrl: true,
+    },
+    orderBy: {
+      order: "asc",
+    },
+  },
 } as const;
 
 export const listingSelect = publicListingSelect;
@@ -74,12 +88,20 @@ interface GetListingsArgs {
 function buildListingView<T extends ListingPayload>(listing: T) {
   const displayListing = withResolvedDisplayAhsListing(listing);
   const displayAhsListing = displayListing.ahsListing;
+  const resolvedImages = resolveLegacyImagesWithAssets({
+    images: displayListing.images,
+    imageAssets: displayListing.imageAssets,
+    variant: "display",
+    source: "public-listing",
+  });
+  const publicListing = { ...displayListing };
+  delete (publicListing as Partial<typeof publicListing>).imageAssets;
 
   return {
-    ...displayListing,
+    ...publicListing,
     ahsListing: displayAhsListing,
     images:
-      displayListing.images.length === 0 && displayAhsListing?.ahsImageUrl
+      resolvedImages.length === 0 && displayAhsListing?.ahsImageUrl
         ? [
             {
               id: `ahs-${displayListing.id}`,
@@ -87,7 +109,7 @@ function buildListingView<T extends ListingPayload>(listing: T) {
               updatedAt: displayListing.updatedAt,
             },
           ]
-        : displayListing.images,
+        : resolvedImages,
   };
 }
 

--- a/src/server/db/public-seller-read-model.ts
+++ b/src/server/db/public-seller-read-model.ts
@@ -4,6 +4,7 @@ import { db } from "@/server/db";
 import { getLatestDate } from "@/server/db/public-date-utils";
 import { getCachedProUserIds } from "@/server/db/getCachedProUserIds";
 import { isPublished } from "@/server/db/public-visibility/filters";
+import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
 
 export interface PublicSellerSummary {
   id: string;
@@ -49,7 +50,9 @@ interface PublicSellerSummaryOptions {
   activeUserIds?: readonly string[] | Set<string>;
 }
 
-function parseProfileContent(content: string | null): OutputData | string | null {
+function parseProfileContent(
+  content: string | null,
+): OutputData | string | null {
   if (!content) {
     return null;
   }
@@ -67,9 +70,7 @@ function toActiveUserIdSet(activeUserIds?: readonly string[] | Set<string>) {
     return null;
   }
 
-  return activeUserIds instanceof Set
-    ? activeUserIds
-    : new Set(activeUserIds);
+  return activeUserIds instanceof Set ? activeUserIds : new Set(activeUserIds);
 }
 
 export function buildPublicSellerProfile(args: {
@@ -198,6 +199,19 @@ export async function getPublicSellerSummariesByUserIds(
                 order: "asc",
               },
             },
+            imageAssets: {
+              select: {
+                id: true,
+                legacyImageId: true,
+                originalUrl: true,
+                displayUrl: true,
+                thumbUrl: true,
+                blurUrl: true,
+              },
+              orderBy: {
+                order: "asc",
+              },
+            },
           },
         },
         _count: {
@@ -236,7 +250,12 @@ export async function getPublicSellerSummariesByUserIds(
         description: user.profile?.description ?? null,
         location: user.profile?.location ?? null,
         images:
-          user.profile?.images.map((image) => ({
+          resolveLegacyImagesWithAssets({
+            images: user.profile?.images ?? [],
+            imageAssets: user.profile?.imageAssets ?? [],
+            variant: "display",
+            source: "public-seller",
+          }).map((image) => ({
             id: image.id,
             url: image.url,
           })) ?? [],

--- a/tests/get-public-listings.test.ts
+++ b/tests/get-public-listings.test.ts
@@ -74,6 +74,7 @@ function createListing(id: string, title: string) {
       ahsListing: null,
     },
     images: [],
+    imageAssets: [],
   };
 }
 
@@ -99,7 +100,8 @@ describe("getPublicListings helpers", () => {
       return;
     }
 
-    process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA = originalV2DisplayFlag;
+    process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA =
+      originalV2DisplayFlag;
   });
 
   it("uses the same deterministic sorted ids for cursor pagination", async () => {


### PR DESCRIPTION
## Summary

Wires ImageAsset URL resolution into public read paths behind `USE_IMAGE_ASSETS`:

- public listing read model can resolve ImageAsset display URLs
- public seller summaries can resolve ImageAsset display URLs
- Google Merchant feed can resolve ImageAsset display URLs
- metadata image helper skips Cloudflare transforms for static `media.daylilycatalog.com` URLs

With `USE_IMAGE_ASSETS=false`, legacy image URLs remain the read path.

Stacked on #215.

## Validation

- `pnpm test -- tests/get-public-listings.test.ts tests/image-asset-read-model.test.ts`
- Previously validated as part of the full branch with full unit, lint, typecheck, and flag-off E2E runs.