### PR TITLE
[codex] Dual-write ImageAsset uploads

### DIFF
--- a/src/app/start-onboarding/start-onboarding-page-client.tsx
+++ b/src/app/start-onboarding/start-onboarding-page-client.tsx
@@ -440,11 +440,12 @@ export function StartOnboardingPageClient({
     updateImageRecord: updateImageMutation.mutateAsync,
     updateListing: updateListingMutation.mutateAsync,
     updateProfile: updateProfileMutation.mutateAsync,
-    uploadImageBlob: ({ blob, referenceId, type }) =>
+    uploadImageBlob: ({ blob, imageId, referenceId, type }) =>
       uploadOnboardingImageBlob({
         blob,
         type,
         referenceId,
+        imageId,
         getPresignedUrl: getImagePresignedUrlMutation.mutateAsync,
       }),
     useExistingProfileImage,
@@ -831,34 +832,53 @@ async function uploadOnboardingImageBlob({
   blob,
   type,
   referenceId,
+  imageId,
   getPresignedUrl,
 }: {
   blob: Blob;
   type: "profile" | "listing";
   referenceId: string;
+  imageId?: string | null;
   getPresignedUrl: (input: {
     type: "profile" | "listing";
     fileName: string;
     contentType: string;
     size: number;
     referenceId: string;
+    imageId?: string;
   }) => Promise<{
+    imageId?: string;
     presignedUrl: string;
     key: string;
     url: string;
+    r2?: {
+      presignedUrl: string;
+      key: string;
+      url: string;
+    } | null;
   }>;
 }) {
   const fileNamePrefix = type === "profile" ? "profile" : "listing";
   const fileName = `onboarding-${fileNamePrefix}-${Date.now()}.jpg`;
   const contentType = blob.type || "image/jpeg";
 
-  const { presignedUrl, key, url } = await getPresignedUrl({
-    type,
-    fileName,
-    contentType,
-    size: blob.size,
-    referenceId,
-  });
+  const { imageId: presignedImageId, presignedUrl, key, url, r2 } =
+    await getPresignedUrl({
+      type,
+      fileName,
+      contentType,
+      size: blob.size,
+      referenceId,
+      ...(imageId ? { imageId } : {}),
+    });
+
+  if (r2) {
+    await uploadFileWithProgress({
+      presignedUrl: r2.presignedUrl,
+      file: blob,
+      onProgress: () => undefined,
+    });
+  }
 
   await uploadFileWithProgress({
     presignedUrl,
@@ -866,7 +886,7 @@ async function uploadOnboardingImageBlob({
     onProgress: () => undefined,
   });
 
-  return { url, key };
+  return { imageId: presignedImageId, url, key, r2OriginalKey: r2?.key };
 }
 
 async function fetchImageBlobFromUrl(imageUrl: string) {

--- a/src/app/start-onboarding/use-onboarding-save-flow.ts
+++ b/src/app/start-onboarding/use-onboarding-save-flow.ts
@@ -17,7 +17,9 @@ import {
 } from "./onboarding-utils";
 
 interface UploadedImage {
+  imageId?: string;
   key: string;
+  r2OriginalKey?: string;
   url: string;
 }
 
@@ -27,7 +29,9 @@ interface UseOnboardingSaveFlowArgs {
   clearPendingProfileUpload: () => void;
   clearPendingStarterImage: () => void;
   createImageRecord: (args: {
+    imageId?: string;
     key: string;
+    r2OriginalKey?: string;
     referenceId: string;
     type: "listing" | "profile";
     url: string;
@@ -63,6 +67,7 @@ interface UseOnboardingSaveFlowArgs {
   setSelectedListingImageUrl: Dispatch<SetStateAction<string | null>>;
   updateImageRecord: (args: {
     imageId: string;
+    r2OriginalKey?: string;
     referenceId: string;
     type: "listing" | "profile";
     url: string;
@@ -85,6 +90,7 @@ interface UseOnboardingSaveFlowArgs {
   }) => Promise<unknown>;
   uploadImageBlob: (args: {
     blob: Blob;
+    imageId?: string | null;
     referenceId: string;
     type: "listing" | "profile";
   }) => Promise<UploadedImage>;
@@ -153,6 +159,7 @@ export function useOnboardingSaveFlow({
           blob: pendingProfileUploadBlob,
           type: "profile",
           referenceId: profileId,
+          imageId: earliestPersistedProfileImageId,
         });
         uploadedProfileImage = nextUploadedProfileImage;
 
@@ -181,6 +188,7 @@ export function useOnboardingSaveFlow({
             blob: starterBlobToUpload,
             type: "profile",
             referenceId: profileId,
+            imageId: earliestPersistedProfileImageId,
           });
 
           clearPendingStarterImage();
@@ -219,6 +227,7 @@ export function useOnboardingSaveFlow({
               referenceId: profileId,
               imageId: earliestPersistedProfileImageId,
               url: uploadedProfileImage.url,
+              r2OriginalKey: uploadedProfileImage.r2OriginalKey,
             });
           } else {
             await createImageRecord({
@@ -226,6 +235,8 @@ export function useOnboardingSaveFlow({
               referenceId: profileId,
               url: uploadedProfileImage.url,
               key: uploadedProfileImage.key,
+              imageId: uploadedProfileImage.imageId,
+              r2OriginalKey: uploadedProfileImage.r2OriginalKey,
             });
           }
         } catch (error) {
@@ -306,7 +317,9 @@ export function useOnboardingSaveFlow({
 
       let listingImageToSave: string | null =
         selectedListingImageUrl ?? selectedCultivarImageUrl ?? null;
+      let listingImageIdToSave: string | undefined;
       let listingImageKeyToSave: string | null = null;
+      let listingR2OriginalKeyToSave: string | undefined;
       let shouldPersistUploadedListingImage = false;
 
       if (pendingListingUploadBlob) {
@@ -314,10 +327,13 @@ export function useOnboardingSaveFlow({
           blob: pendingListingUploadBlob,
           type: "listing",
           referenceId: listingId,
+          imageId: earliestPersistedListingImageId,
         });
 
         listingImageToSave = uploadedListingImage.url;
+        listingImageIdToSave = uploadedListingImage.imageId;
         listingImageKeyToSave = uploadedListingImage.key;
+        listingR2OriginalKeyToSave = uploadedListingImage.r2OriginalKey;
         shouldPersistUploadedListingImage = true;
         clearPendingListingUpload();
         setSelectedListingImageUrl(uploadedListingImage.url);
@@ -334,6 +350,7 @@ export function useOnboardingSaveFlow({
             referenceId: listingId,
             imageId: earliestPersistedListingImageId,
             url: listingImageToSave,
+            r2OriginalKey: listingR2OriginalKeyToSave,
           });
           setSelectedListingImageId(updatedImage.id);
         } else {
@@ -342,6 +359,8 @@ export function useOnboardingSaveFlow({
             referenceId: listingId,
             url: listingImageToSave,
             key: listingImageKeyToSave,
+            imageId: listingImageIdToSave,
+            r2OriginalKey: listingR2OriginalKeyToSave,
           });
           if (createdImage?.id) {
             setSelectedListingImageId(createdImage.id);

--- a/src/hooks/use-image-upload.ts
+++ b/src/hooks/use-image-upload.ts
@@ -4,7 +4,11 @@ import { toast } from "sonner";
 import { uploadFileWithProgress } from "@/lib/utils";
 import { type ImageType } from "@/types/image";
 import { type Image } from "@prisma/client";
-import { getErrorMessage, normalizeError, reportError } from "@/lib/error-utils";
+import {
+  getErrorMessage,
+  normalizeError,
+  reportError,
+} from "@/lib/error-utils";
 import { createImage } from "@/app/dashboard/_lib/dashboard-db/images-collection";
 
 interface UseImageUploadOptions {
@@ -32,7 +36,7 @@ export function useImageUpload({
         setIsUploading(true);
         setProgress(0);
 
-        const { presignedUrl, key, url } =
+        const { imageId, presignedUrl, key, url, r2 } =
           await getPresignedUrlMutation.mutateAsync({
             type,
             fileName: `${Date.now()}.jpg`,
@@ -42,10 +46,19 @@ export function useImageUpload({
           });
 
         step = "upload";
+        if (r2) {
+          await uploadFileWithProgress({
+            presignedUrl: r2.presignedUrl,
+            file,
+            onProgress: (value) => setProgress(Math.floor(value / 2)),
+          });
+        }
+
         await uploadFileWithProgress({
           presignedUrl,
           file,
-          onProgress: setProgress,
+          onProgress: (value) =>
+            setProgress(r2 ? 50 + Math.floor(value / 2) : value),
         });
 
         step = "create";
@@ -54,6 +67,8 @@ export function useImageUpload({
           referenceId,
           url,
           key,
+          imageId,
+          r2OriginalKey: r2?.key,
         });
 
         toast.success("Image uploaded successfully");
@@ -89,4 +104,3 @@ export function useImageUpload({
     isUploading,
   };
 }
-

--- a/src/lib/test-utils/e2e-db.ts
+++ b/src/lib/test-utils/e2e-db.ts
@@ -43,12 +43,12 @@ export function assertSafeTestDbUrl(sqliteUrl: string) {
     throw new Error(`Test DB URL must start with "file:". Got: ${sqliteUrl}`);
   }
   const absolute = normalizeDbPath(sqliteUrl);
-  const allowedRoots = [path.resolve(process.cwd(), "tests", ".tmp") + path.sep];
+  const allowedRoots = [
+    path.resolve(process.cwd(), "tests", ".tmp") + path.sep,
+  ];
   const isAllowed = allowedRoots.some((root) => absolute.startsWith(root));
   if (!isAllowed) {
-    throw new Error(
-      `Test DB path must be under tests/.tmp. Got: ${absolute}.`,
-    );
+    throw new Error(`Test DB path must be under tests/.tmp. Got: ${absolute}.`);
   }
 }
 
@@ -70,7 +70,9 @@ export function ensureLocalTempDbSafety(url?: string) {
 
 function isRetryableSqliteCleanupError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
-  return /Operation has timed out|SQLITE_BUSY|database is locked/i.test(message);
+  return /Operation has timed out|SQLITE_BUSY|database is locked/i.test(
+    message,
+  );
 }
 
 function sleep(ms: number) {
@@ -82,8 +84,13 @@ async function configureSqliteConnection(db: PrismaClient) {
 }
 
 async function clearTempDb(db: PrismaClient) {
-  for (let attempt = 0; attempt <= SQLITE_CLEAR_RETRY_DELAYS_MS.length; attempt++) {
+  for (
+    let attempt = 0;
+    attempt <= SQLITE_CLEAR_RETRY_DELAYS_MS.length;
+    attempt++
+  ) {
     try {
+      await db.imageAsset.deleteMany();
       await db.image.deleteMany();
       await db.$executeRaw`DELETE FROM "_ListToListing"`;
       await db.list.deleteMany();

--- a/src/server/api/routers/dashboard-db/image.ts
+++ b/src/server/api/routers/dashboard-db/image.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
+import { after } from "next/server";
 import { protectedProcedure, createTRPCRouter } from "@/server/api/trpc";
 import { env, requireEnv } from "@/env";
 import { APP_CONFIG } from "@/config/constants";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import path from "node:path";
 import { imageTypeSchema } from "@/types/image";
@@ -20,6 +22,18 @@ import {
   invalidateDashboardMutation,
   parseDashboardSyncSince,
 } from "./dashboard-db-router-helpers";
+import {
+  buildImageAssetMap,
+  resolveImageAssetUrl,
+} from "@/server/services/image-asset-read-model";
+import {
+  areImageAssetUploadsConfigured,
+  buildOriginalImageAssetKey,
+  buildR2PublicUrl,
+  getR2PresignedPutUrl,
+  areImageAssetsEnabled,
+  isExpectedOriginalImageAssetKey,
+} from "@/server/services/image-asset-storage";
 
 const imageSelect = {
   id: true,
@@ -50,6 +64,97 @@ async function getImageInvalidationReferences(args: {
       );
 }
 
+async function resolveDashboardImageRows(args: {
+  db: DbClient;
+  rows: Array<{
+    id: string;
+    url: string;
+    order: number;
+    listingId: string | null;
+    userProfileId: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    status: string | null;
+  }>;
+}) {
+  if (!areImageAssetsEnabled() || args.rows.length === 0) {
+    return args.rows;
+  }
+
+  const assets = await args.db.imageAsset.findMany({
+    where: {
+      OR: [
+        { legacyImageId: { in: args.rows.map((row) => row.id) } },
+        { id: { in: args.rows.map((row) => row.id) } },
+      ],
+    },
+    select: {
+      id: true,
+      legacyImageId: true,
+      originalUrl: true,
+      displayUrl: true,
+      thumbUrl: true,
+      blurUrl: true,
+    },
+  });
+  const imageAssetByLegacyId = buildImageAssetMap(assets);
+
+  return args.rows.map((row) => ({
+    ...row,
+    url: resolveImageAssetUrl({
+      image: row,
+      imageAssetByLegacyId,
+      variant: "thumb",
+      source: "dashboardDb.image",
+    }),
+  }));
+}
+
+function scheduleImageAssetVariantProcessing(imageAssetId: string) {
+  after(async () => {
+    await new Promise<void>((resolve) => {
+      const child = spawn(
+        process.execPath,
+        [
+          "scripts/image-assets/process-image-asset-variants.mjs",
+          "--asset-id",
+          imageAssetId,
+          "--limit",
+          "1",
+        ],
+        {
+          cwd: process.cwd(),
+          env: process.env,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        console.log("[image-assets:variants]", chunk.toString().trim());
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        console.error("[image-assets:variants]", chunk.toString().trim());
+      });
+      child.on("error", (error) => {
+        console.error("[image-assets:variants] failed to start", {
+          imageAssetId,
+          error,
+        });
+        resolve();
+      });
+      child.on("close", (code) => {
+        if (code !== 0) {
+          console.error("[image-assets:variants] exited non-zero", {
+            imageAssetId,
+            code,
+          });
+        }
+        resolve();
+      });
+    });
+  });
+}
+
 export const dashboardDbImageRouter = createTRPCRouter({
   getPresignedUrl: protectedProcedure
     .input(
@@ -59,6 +164,7 @@ export const dashboardDbImageRouter = createTRPCRouter({
         contentType: z.string(),
         size: z.number().max(APP_CONFIG.UPLOAD.MAX_FILE_SIZE),
         referenceId: z.string(),
+        imageId: z.string().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -87,9 +193,24 @@ export const dashboardDbImageRouter = createTRPCRouter({
         },
       });
 
+      const imageId = input.imageId ?? crypto.randomUUID();
       const ext = path.extname(input.fileName);
       const fileId = crypto.randomBytes(4).toString("hex");
       const key = `${ctx.user.id}/${input.referenceId}/${fileId}${ext}`;
+      const shouldPresignR2 = areImageAssetUploadsConfigured();
+      const r2VersionId = input.imageId
+        ? crypto.randomBytes(6).toString("hex")
+        : null;
+      const r2OriginalKey = shouldPresignR2
+        ? buildOriginalImageAssetKey({
+            kind: input.type,
+            userId: ctx.user.id,
+            listingId: input.type === "listing" ? input.referenceId : null,
+            imageAssetId: imageId,
+            versionId: r2VersionId,
+            fileName: input.fileName,
+          })
+        : null;
 
       const command = new PutObjectCommand({
         Bucket: requireEnv("AWS_BUCKET_NAME", env.AWS_BUCKET_NAME),
@@ -100,16 +221,31 @@ export const dashboardDbImageRouter = createTRPCRouter({
       const bucketName = requireEnv("AWS_BUCKET_NAME", env.AWS_BUCKET_NAME);
       const region = requireEnv("AWS_REGION", env.AWS_REGION);
       const url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+      const r2PresignedUrl = r2OriginalKey
+        ? await getR2PresignedPutUrl({
+            key: r2OriginalKey,
+            contentType: input.contentType,
+          })
+        : null;
 
       return {
+        imageId,
         presignedUrl: url,
         key,
         url: `https://${bucketName}.s3.${region}.amazonaws.com/${key}`,
+        r2:
+          r2OriginalKey && r2PresignedUrl
+            ? {
+                presignedUrl: r2PresignedUrl,
+                key: r2OriginalKey,
+                url: buildR2PublicUrl(r2OriginalKey),
+              }
+            : null,
       } as const;
     }),
 
   list: protectedProcedure.query(async ({ ctx }) => {
-    return ctx.db.image.findMany({
+    const rows = await ctx.db.image.findMany({
       where: {
         OR: [
           { listing: { userId: ctx.user.id } },
@@ -123,13 +259,15 @@ export const dashboardDbImageRouter = createTRPCRouter({
       ],
       select: imageSelect,
     });
+
+    return resolveDashboardImageRows({ db: ctx.db, rows });
   }),
 
   sync: protectedProcedure
     .input(z.object({ since: z.iso.datetime().nullable() }))
     .query(async ({ ctx, input }) => {
       const since = parseDashboardSyncSince(input.since);
-      return ctx.db.image.findMany({
+      const rows = await ctx.db.image.findMany({
         where: {
           OR: [
             { listing: { userId: ctx.user.id } },
@@ -140,6 +278,8 @@ export const dashboardDbImageRouter = createTRPCRouter({
         orderBy: { updatedAt: "asc" },
         select: imageSelect,
       });
+
+      return resolveDashboardImageRows({ db: ctx.db, rows });
     }),
 
   create: protectedProcedure
@@ -149,6 +289,8 @@ export const dashboardDbImageRouter = createTRPCRouter({
         referenceId: z.string(),
         url: z.string().min(1),
         key: z.string().min(1),
+        imageId: z.string().optional(),
+        r2OriginalKey: z.string().min(1).optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -172,16 +314,63 @@ export const dashboardDbImageRouter = createTRPCRouter({
           : { userProfileId: input.referenceId };
 
       const currentCount = await ctx.db.image.count({ where: whereClause });
+      const shouldCreateImageAsset = Boolean(input.r2OriginalKey);
 
-      const image = await ctx.db.image.create({
-        data: {
-          url: input.url,
-          order: currentCount,
-          ...(input.type === "listing"
-            ? { listingId: input.referenceId }
-            : { userProfileId: input.referenceId }),
-        },
-        select: imageSelect,
+      if (input.r2OriginalKey) {
+        if (!input.imageId || !areImageAssetUploadsConfigured()) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Image asset upload metadata is invalid",
+          });
+        }
+
+        const isExpectedKey = isExpectedOriginalImageAssetKey({
+          kind: input.type,
+          userId: ctx.user.id,
+          listingId: input.type === "listing" ? input.referenceId : null,
+          imageAssetId: input.imageId,
+          key: input.r2OriginalKey,
+        });
+
+        if (!isExpectedKey) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Image asset upload metadata is invalid",
+          });
+        }
+      }
+
+      const image = await ctx.db.$transaction(async (tx) => {
+        const created = await tx.image.create({
+          data: {
+            ...(input.imageId ? { id: input.imageId } : {}),
+            url: input.url,
+            order: currentCount,
+            ...(input.type === "listing"
+              ? { listingId: input.referenceId }
+              : { userProfileId: input.referenceId }),
+          },
+          select: imageSelect,
+        });
+
+        if (shouldCreateImageAsset && input.r2OriginalKey) {
+          await tx.imageAsset.create({
+            data: {
+              id: created.id,
+              legacyImageId: created.id,
+              kind: input.type,
+              order: currentCount,
+              status: "pending_variants",
+              originalKey: input.r2OriginalKey,
+              originalUrl: buildR2PublicUrl(input.r2OriginalKey),
+              ...(input.type === "listing"
+                ? { listingId: input.referenceId }
+                : { userProfileId: input.referenceId }),
+            },
+          });
+        }
+
+        return created;
       });
 
       await invalidateDashboardMutation({
@@ -195,7 +384,16 @@ export const dashboardDbImageRouter = createTRPCRouter({
         }),
       });
 
-      return image;
+      const [resolved] = await resolveDashboardImageRows({
+        db: ctx.db,
+        rows: [image],
+      });
+
+      if (shouldCreateImageAsset) {
+        scheduleImageAssetVariantProcessing(image.id);
+      }
+
+      return resolved ?? image;
     }),
 
   update: protectedProcedure
@@ -205,6 +403,7 @@ export const dashboardDbImageRouter = createTRPCRouter({
         referenceId: z.string(),
         imageId: z.string(),
         url: z.string().min(1),
+        r2OriginalKey: z.string().min(1).optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -243,10 +442,77 @@ export const dashboardDbImageRouter = createTRPCRouter({
         });
       }
 
-      const image = await ctx.db.image.update({
-        where: { id: input.imageId },
-        data: { url: input.url },
-        select: imageSelect,
+      if (input.r2OriginalKey) {
+        if (!areImageAssetUploadsConfigured()) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Image asset upload metadata is invalid",
+          });
+        }
+
+        const isExpectedKey = isExpectedOriginalImageAssetKey({
+          kind: input.type,
+          userId: ctx.user.id,
+          listingId: input.type === "listing" ? input.referenceId : null,
+          imageAssetId: input.imageId,
+          key: input.r2OriginalKey,
+          requireVersion: true,
+        });
+
+        if (!isExpectedKey) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Image asset upload metadata is invalid",
+          });
+        }
+      }
+
+      const image = await ctx.db.$transaction(async (tx) => {
+        const updated = await tx.image.update({
+          where: { id: input.imageId },
+          data: { url: input.url },
+          select: imageSelect,
+        });
+
+        if (input.r2OriginalKey) {
+          await tx.imageAsset.upsert({
+            where: { legacyImageId: input.imageId },
+            create: {
+              id: input.imageId,
+              legacyImageId: input.imageId,
+              kind: input.type,
+              order: updated.order,
+              status: "pending_variants",
+              originalKey: input.r2OriginalKey,
+              originalUrl: buildR2PublicUrl(input.r2OriginalKey),
+              ...(input.type === "listing"
+                ? { listingId: input.referenceId }
+                : { userProfileId: input.referenceId }),
+            },
+            update: {
+              kind: input.type,
+              order: updated.order,
+              status: "pending_variants",
+              originalKey: input.r2OriginalKey,
+              originalUrl: buildR2PublicUrl(input.r2OriginalKey),
+              displayKey: null,
+              displayUrl: null,
+              thumbKey: null,
+              thumbUrl: null,
+              blurKey: null,
+              blurUrl: null,
+              ...(input.type === "listing"
+                ? { listingId: input.referenceId, userProfileId: null }
+                : { listingId: null, userProfileId: input.referenceId }),
+            },
+          });
+        } else {
+          await tx.imageAsset.deleteMany({
+            where: { legacyImageId: input.imageId },
+          });
+        }
+
+        return updated;
       });
 
       await invalidateDashboardMutation({
@@ -260,7 +526,16 @@ export const dashboardDbImageRouter = createTRPCRouter({
         }),
       });
 
-      return image;
+      const [resolved] = await resolveDashboardImageRows({
+        db: ctx.db,
+        rows: [image],
+      });
+
+      if (input.r2OriginalKey) {
+        scheduleImageAssetVariantProcessing(image.id);
+      }
+
+      return resolved ?? image;
     }),
 
   reorder: protectedProcedure
@@ -311,12 +586,16 @@ export const dashboardDbImageRouter = createTRPCRouter({
       ];
 
       await ctx.db.$transaction(
-        mergedOrder.map((img, index) =>
+        mergedOrder.flatMap((img, index) => [
           ctx.db.image.update({
             where: { id: img.id },
             data: { order: index },
           }),
-        ),
+          ctx.db.imageAsset.updateMany({
+            where: { legacyImageId: img.id },
+            data: { order: index },
+          }),
+        ]),
       );
 
       await invalidateDashboardMutation({
@@ -363,6 +642,9 @@ export const dashboardDbImageRouter = createTRPCRouter({
 
       await ctx.db.$transaction(async (tx) => {
         await tx.image.delete({ where: { id: input.imageId } });
+        await tx.imageAsset.deleteMany({
+          where: { legacyImageId: input.imageId },
+        });
 
         const remaining = await tx.image.findMany({
           where: whereClause,
@@ -372,10 +654,16 @@ export const dashboardDbImageRouter = createTRPCRouter({
 
         await Promise.all(
           remaining.map((img, index) =>
-            tx.image.update({
-              where: { id: img.id },
-              data: { order: index },
-            }),
+            Promise.all([
+              tx.image.update({
+                where: { id: img.id },
+                data: { order: index },
+              }),
+              tx.imageAsset.updateMany({
+                where: { legacyImageId: img.id },
+                data: { order: index },
+              }),
+            ]),
           ),
         );
       });

--- a/tests/dashboard-db-collections.test.tsx
+++ b/tests/dashboard-db-collections.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { useLiveQuery } from "@tanstack/react-db";
 import { createTRPCProxyClient, type TRPCLink } from "@trpc/client";
@@ -8,8 +8,21 @@ import type { AppRouter } from "@/server/api/root";
 import type { TRPCInternalContext } from "@/server/api/trpc";
 import { callerLink, withTempAppDb } from "@/lib/test-utils/app-test-db";
 
+const originalV2DisplayFlag =
+  process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA;
+
 beforeEach(() => {
+  process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA = "false";
   localStorage.clear();
+});
+
+afterEach(() => {
+  if (originalV2DisplayFlag === undefined) {
+    delete process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA = originalV2DisplayFlag;
 });
 
 function ListingsViewer({

--- a/tests/dashboard-db-image-assets.test.ts
+++ b/tests/dashboard-db-image-assets.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment node
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TRPCInternalContext } from "@/server/api/trpc";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL ??= "file:./tests/.tmp/dashboard-db-image-assets.sqlite";
+process.env.NEXT_PUBLIC_CLOUDFLARE_URL ??= "https://images.example";
+process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ??= "pk_test_example";
+process.env.R2_ACCOUNT_ID = "account-1";
+process.env.R2_ACCESS_KEY_ID = "r2-key";
+process.env.R2_SECRET_ACCESS_KEY = "r2-secret";
+process.env.R2_BUCKET_NAME = "daylily-media";
+process.env.R2_PUBLIC_BASE_URL = "https://media.daylilycatalog.com";
+
+const afterMock = vi.hoisted(() => vi.fn());
+const revalidatePathMock = vi.hoisted(() => vi.fn());
+const revalidateTagMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/server", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/server")>("next/server");
+
+  return {
+    ...actual,
+    after: afterMock,
+  };
+});
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+  revalidateTag: revalidateTagMock,
+}));
+
+vi.mock("@/server/analytics/public-isr-posthog", () => ({
+  trackPublicIsrPathInvalidation: vi.fn(),
+  trackPublicIsrTagInvalidation: vi.fn(),
+}));
+
+let dashboardDbImageRouter: typeof import("@/server/api/routers/dashboard-db/image").dashboardDbImageRouter;
+
+beforeAll(async () => {
+  ({ dashboardDbImageRouter } = await import(
+    "@/server/api/routers/dashboard-db/image"
+  ));
+});
+
+function createContext(db: unknown) {
+  return {
+    db: db as TRPCInternalContext["db"],
+    _authUser: { id: "user-1" } as TRPCInternalContext["_authUser"],
+    headers: new Headers(),
+  };
+}
+
+function createImageRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "image-1",
+    url: "https://legacy.example/image.jpg",
+    order: 0,
+    listingId: "listing-1",
+    userProfileId: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    status: null,
+    ...overrides,
+  };
+}
+
+describe("dashboard image asset mutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.USE_IMAGE_ASSETS = "false";
+  });
+
+  it("creates the legacy Image and matching ImageAsset for R2 uploads", async () => {
+    const createdImage = createImageRow();
+    const tx = {
+      image: {
+        create: vi.fn().mockResolvedValue(createdImage),
+      },
+      imageAsset: {
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+    const db = {
+      $transaction: vi.fn(async (callback: (txArg: typeof tx) => unknown) =>
+        callback(tx),
+      ),
+      image: {
+        count: vi.fn().mockResolvedValue(0),
+      },
+      imageAsset: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      listing: {
+        findFirst: vi.fn().mockResolvedValue({ id: "listing-1" }),
+        findUnique: vi.fn().mockResolvedValue({
+          id: "listing-1",
+          userId: "user-1",
+          cultivarReference: null,
+        }),
+      },
+      userProfile: {
+        findUnique: vi.fn().mockResolvedValue({ slug: "garden" }),
+      },
+    };
+
+    const caller = dashboardDbImageRouter.createCaller(createContext(db));
+
+    await caller.create({
+      type: "listing",
+      referenceId: "listing-1",
+      imageId: "image-1",
+      key: "legacy-key.jpg",
+      url: "https://legacy.example/image.jpg",
+      r2OriginalKey: "users/user-1/listing-images/listing-1/image-1/original.jpg",
+    });
+
+    expect(tx.image.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          id: "image-1",
+          listingId: "listing-1",
+          url: "https://legacy.example/image.jpg",
+        }),
+      }),
+    );
+    expect(tx.imageAsset.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        id: "image-1",
+        legacyImageId: "image-1",
+        listingId: "listing-1",
+        originalKey: "users/user-1/listing-images/listing-1/image-1/original.jpg",
+        originalUrl:
+          "https://media.daylilycatalog.com/users/user-1/listing-images/listing-1/image-1/original.jpg",
+        status: "pending_variants",
+      }),
+    });
+    expect(afterMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets variant URLs when replacing an image through R2", async () => {
+    const updatedImage = createImageRow({
+      url: "https://legacy.example/replacement.jpg",
+    });
+    const tx = {
+      image: {
+        update: vi.fn().mockResolvedValue(updatedImage),
+      },
+      imageAsset: {
+        upsert: vi.fn().mockResolvedValue(undefined),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+    const db = {
+      $transaction: vi.fn(async (callback: (txArg: typeof tx) => unknown) =>
+        callback(tx),
+      ),
+      image: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "image-1",
+          listingId: "listing-1",
+          userProfileId: null,
+        }),
+      },
+      imageAsset: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      listing: {
+        findFirst: vi.fn().mockResolvedValue({ id: "listing-1" }),
+        findUnique: vi.fn().mockResolvedValue({
+          id: "listing-1",
+          userId: "user-1",
+          cultivarReference: null,
+        }),
+      },
+      userProfile: {
+        findUnique: vi.fn().mockResolvedValue({ slug: "garden" }),
+      },
+    };
+
+    const caller = dashboardDbImageRouter.createCaller(createContext(db));
+
+    await caller.update({
+      type: "listing",
+      referenceId: "listing-1",
+      imageId: "image-1",
+      url: "https://legacy.example/replacement.jpg",
+      r2OriginalKey:
+        "users/user-1/listing-images/listing-1/image-1/versions/a1b2c3d4e5f6/original.jpg",
+    });
+
+    expect(tx.imageAsset.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { legacyImageId: "image-1" },
+        update: expect.objectContaining({
+          displayKey: null,
+          displayUrl: null,
+          thumbKey: null,
+          thumbUrl: null,
+          blurKey: null,
+          blurUrl: null,
+          originalKey:
+            "users/user-1/listing-images/listing-1/image-1/versions/a1b2c3d4e5f6/original.jpg",
+          originalUrl:
+            "https://media.daylilycatalog.com/users/user-1/listing-images/listing-1/image-1/versions/a1b2c3d4e5f6/original.jpg",
+          status: "pending_variants",
+        }),
+      }),
+    );
+    expect(tx.imageAsset.deleteMany).not.toHaveBeenCalled();
+    expect(afterMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/dashboard-db-public-isr-invalidation.test.ts
+++ b/tests/dashboard-db-public-isr-invalidation.test.ts
@@ -454,6 +454,9 @@ describe("dashboardDb public ISR invalidation", () => {
           status: null,
         }),
       },
+      imageAsset: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
       listing: {
         findMany: vi.fn().mockResolvedValue([
           {
@@ -477,6 +480,13 @@ describe("dashboardDb public ISR invalidation", () => {
         findFirst: vi.fn().mockResolvedValue({ id: "profile-1" }),
         findUnique: vi.fn().mockResolvedValue({ slug: "garden" }),
       },
+      $transaction: vi.fn(
+        async (
+          callback: (
+            tx: typeof db,
+          ) => Promise<unknown>,
+        ) => callback(db),
+      ),
     };
 
     const caller = dashboardDbImageRouter.createCaller(createContext(db));

--- a/tests/use-image-upload.test.ts
+++ b/tests/use-image-upload.test.ts
@@ -62,16 +62,18 @@ describe("useImageUpload", () => {
     };
 
     getPresignedUrlMutateAsyncMock.mockResolvedValue({
+      imageId: "img-1",
       presignedUrl: "https://upload-url.example",
       key: "abc123.jpg",
       url: uploadedImage.url,
+      r2: {
+        presignedUrl: "https://r2-upload-url.example",
+        key: "users/user-1/listing-images/listing-1/img-1/original.jpg",
+        url: "https://media.daylilycatalog.com/users/user-1/listing-images/listing-1/img-1/original.jpg",
+      },
     });
     uploadFileWithProgressMock.mockImplementation(
-      async ({
-        onProgress,
-      }: {
-        onProgress: (value: number) => void;
-      }) => {
+      async ({ onProgress }: { onProgress: (value: number) => void }) => {
         onProgress(25);
         onProgress(100);
       },
@@ -102,7 +104,16 @@ describe("useImageUpload", () => {
         referenceId: "listing-1",
       }),
     );
-    expect(uploadFileWithProgressMock).toHaveBeenCalledWith(
+    expect(uploadFileWithProgressMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        presignedUrl: "https://r2-upload-url.example",
+        file,
+        onProgress: expect.any(Function),
+      }),
+    );
+    expect(uploadFileWithProgressMock).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         presignedUrl: "https://upload-url.example",
         file,
@@ -114,9 +125,13 @@ describe("useImageUpload", () => {
       referenceId: "listing-1",
       url: uploadedImage.url,
       key: "abc123.jpg",
+      imageId: "img-1",
+      r2OriginalKey: "users/user-1/listing-images/listing-1/img-1/original.jpg",
     });
     expect(onSuccess).toHaveBeenCalledWith(uploadedImage);
-    expect(toastSuccessMock).toHaveBeenCalledWith("Image uploaded successfully");
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Image uploaded successfully",
+    );
     expect(returned).toEqual(uploadedImage);
 
     await waitFor(() => {
@@ -126,7 +141,9 @@ describe("useImageUpload", () => {
   });
 
   it("handles presigned-url failure and resets state", async () => {
-    getPresignedUrlMutateAsyncMock.mockRejectedValue(new Error("Presign failed"));
+    getPresignedUrlMutateAsyncMock.mockRejectedValue(
+      new Error("Presign failed"),
+    );
 
     const { result } = renderHook(() =>
       useImageUpload({


### PR DESCRIPTION
## Summary

Adds ImageAsset dual-write behavior for app uploads while keeping legacy S3 Image rows intact:

- presigns R2 originals only when R2 upload config is present
- dashboard uploads send both R2 and S3 objects, then create/update the legacy Image row
- creates or updates the corresponding ImageAsset row with server-derived R2 URLs
- uses versioned replacement keys so immutable variant URLs are not reused
- resets stale variant URLs on replacement uploads
- schedules variant processing asynchronously after ImageAsset writes
- keeps delete/reorder behavior in sync between legacy Image and ImageAsset rows
- extends onboarding image upload paths to carry ImageAsset metadata

Stacked on #216.

## Validation

- `pnpm test -- tests/use-image-upload.test.ts tests/dashboard-db-image-assets.test.ts tests/dashboard-db-public-isr-invalidation.test.ts tests/dashboard-db-collections.test.tsx`
- Full branch validation before split:
  - `pnpm test` passed: 95 files, 281 tests
  - `SKIP_ENV_VALIDATION=1 npx tsc --noEmit`
  - `SKIP_ENV_VALIDATION=1 pnpm lint`
  - `USE_IMAGE_ASSETS=false SKIP_ENV_VALIDATION=1 pnpm test:e2e -- tests/e2e/listing-image-manager.e2e.ts tests/e2e/create-edit-listing-flow.e2e.ts`

## Review focus

This PR is the highest-risk part of the stack. Review the flag/config gating, server-side R2 key validation, replacement upload key shape, and legacy S3 behavior staying canonical for successful uploads.