### PR TITLE
Read ImageAsset URLs behind flag

### DIFF
--- a/apps/main/src/app/api/google-merchant-feed/route.ts
+++ b/apps/main/src/app/api/google-merchant-feed/route.ts
@@ -102,7 +102,6 @@ export async function GET(_request: Request) {
                 ? displayListing.imageAssets
                 : [],
             variant: "display",
-            source: "google-merchant-feed",
           });
           const listingName =
             displayListing.title ??

--- a/apps/main/src/app/api/google-merchant-feed/route.ts
+++ b/apps/main/src/app/api/google-merchant-feed/route.ts
@@ -9,11 +9,27 @@ import {
 import { getProUserIds } from "@/server/db/getProUserIds";
 import { shouldShowToPublic } from "@/server/db/public-visibility/filters";
 import { getCloudflareUrlForDaylilyS3Image } from "@/lib/utils/cloudflareLoader";
-import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
+import {
+  areImageAssetsEnabled,
+  resolveLegacyImagesWithAssets,
+} from "@/server/services/image-asset-read-model";
 
 // Constants for merchant feed configuration
 const SHIPPING_WEIGHT = "0.5 lb";
 const FEED_BATCH_SIZE = 200;
+const imageAssetInclude = {
+  select: {
+    id: true,
+    legacyImageId: true,
+    originalUrl: true,
+    displayUrl: true,
+    thumbUrl: true,
+    blurUrl: true,
+  },
+  orderBy: {
+    order: "asc" as const,
+  },
+};
 
 export async function GET(_request: Request) {
   try {
@@ -31,19 +47,7 @@ export async function GET(_request: Request) {
           order: "asc" as const,
         },
       },
-      imageAssets: {
-        select: {
-          id: true,
-          legacyImageId: true,
-          originalUrl: true,
-          displayUrl: true,
-          thumbUrl: true,
-          blurUrl: true,
-        },
-        orderBy: {
-          order: "asc" as const,
-        },
-      },
+      ...(areImageAssetsEnabled() ? { imageAssets: imageAssetInclude } : {}),
       cultivarReference: {
         include: {
           ahsListing: {
@@ -93,7 +97,10 @@ export async function GET(_request: Request) {
           const displayAhsListing = displayListing.ahsListing;
           const resolvedImages = resolveLegacyImagesWithAssets({
             images: displayListing.images,
-            imageAssets: displayListing.imageAssets,
+            imageAssets:
+              "imageAssets" in displayListing
+                ? displayListing.imageAssets
+                : [],
             variant: "display",
             source: "google-merchant-feed",
           });

--- a/apps/main/src/app/api/google-merchant-feed/route.ts
+++ b/apps/main/src/app/api/google-merchant-feed/route.ts
@@ -9,6 +9,7 @@ import {
 import { getProUserIds } from "@/server/db/getProUserIds";
 import { shouldShowToPublic } from "@/server/db/public-visibility/filters";
 import { getCloudflareUrlForDaylilyS3Image } from "@/lib/utils/cloudflareLoader";
+import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
 
 // Constants for merchant feed configuration
 const SHIPPING_WEIGHT = "0.5 lb";
@@ -26,6 +27,22 @@ export async function GET(_request: Request) {
     const include = {
       images: {
         take: 4, // Get up to 4 images (1 main + 3 additional)
+        orderBy: {
+          order: "asc" as const,
+        },
+      },
+      imageAssets: {
+        select: {
+          id: true,
+          legacyImageId: true,
+          originalUrl: true,
+          displayUrl: true,
+          thumbUrl: true,
+          blurUrl: true,
+        },
+        orderBy: {
+          order: "asc" as const,
+        },
       },
       cultivarReference: {
         include: {
@@ -74,6 +91,12 @@ export async function GET(_request: Request) {
         try {
           const displayListing = withResolvedDisplayAhsListing(listing);
           const displayAhsListing = displayListing.ahsListing;
+          const resolvedImages = resolveLegacyImagesWithAssets({
+            images: displayListing.images,
+            imageAssets: displayListing.imageAssets,
+            variant: "display",
+            source: "google-merchant-feed",
+          });
           const listingName =
             displayListing.title ??
             displayAhsListing?.name ??
@@ -90,11 +113,11 @@ export async function GET(_request: Request) {
           }
 
           const rawImageUrl =
-            displayListing.images?.[0]?.url ?? displayAhsListing?.ahsImageUrl;
+            resolvedImages[0]?.url ?? displayAhsListing?.ahsImageUrl;
           const imageUrl = rawImageUrl
             ? getCloudflareUrlForDaylilyS3Image(rawImageUrl)
             : null;
-          const additionalImages = displayListing.images?.slice(1, 4) ?? [];
+          const additionalImages = resolvedImages.slice(1, 4);
           const productUrl = `${baseUrl}/${displayListing.userId}/${displayListing.id}`;
           const catalogName =
             displayListing.user.profile?.title ??

--- a/apps/main/src/lib/utils/cloudflareLoader.tsx
+++ b/apps/main/src/lib/utils/cloudflareLoader.tsx
@@ -18,6 +18,15 @@ const TRUSTED_META_IMAGE_HOSTS = new Set([
   "www.daylilycatalog.com",
   "daylily-catalog-images.s3.amazonaws.com",
 ]);
+const STATIC_IMAGE_ASSET_HOST = "media.daylilycatalog.com";
+
+function isStaticImageAssetUrl(src: string) {
+  try {
+    return new URL(src).hostname.toLowerCase() === STATIC_IMAGE_ASSET_HOST;
+  } catch {
+    return false;
+  }
+}
 
 function isTrustedMetaImageUrl(src: string) {
   try {
@@ -73,7 +82,7 @@ export function getDaylilyS3ImageTransformSource(src: string) {
 
 // Helper function for metadata image optimization that handles both public and external images
 export const getOptimizedMetaImageUrl = (src: string) => {
-  if (src.startsWith("/assets")) {
+  if (src.startsWith("/assets") || isStaticImageAssetUrl(src)) {
     return src;
   }
 

--- a/apps/main/src/lib/utils/cloudflareLoader.tsx
+++ b/apps/main/src/lib/utils/cloudflareLoader.tsx
@@ -18,15 +18,6 @@ const TRUSTED_META_IMAGE_HOSTS = new Set([
   "www.daylilycatalog.com",
   "daylily-catalog-images.s3.amazonaws.com",
 ]);
-const STATIC_IMAGE_ASSET_HOST = "media.daylilycatalog.com";
-
-function isStaticImageAssetUrl(src: string) {
-  try {
-    return new URL(src).hostname.toLowerCase() === STATIC_IMAGE_ASSET_HOST;
-  } catch {
-    return false;
-  }
-}
 
 function isTrustedMetaImageUrl(src: string) {
   try {
@@ -82,7 +73,7 @@ export function getDaylilyS3ImageTransformSource(src: string) {
 
 // Helper function for metadata image optimization that handles both public and external images
 export const getOptimizedMetaImageUrl = (src: string) => {
-  if (src.startsWith("/assets") || isStaticImageAssetUrl(src)) {
+  if (src.startsWith("/assets")) {
     return src;
   }
 

--- a/apps/main/src/server/db/public-listing-read-model.ts
+++ b/apps/main/src/server/db/public-listing-read-model.ts
@@ -103,7 +103,6 @@ function buildListingView<T extends ListingPayload>(listing: T) {
     images: displayListing.images,
     imageAssets: "imageAssets" in displayListing ? displayListing.imageAssets : [],
     variant: "display",
-    source: "public-listing",
   });
   const publicListing =
     "imageAssets" in displayListing

--- a/apps/main/src/server/db/public-listing-read-model.ts
+++ b/apps/main/src/server/db/public-listing-read-model.ts
@@ -17,6 +17,7 @@ import {
   isPublished,
 } from "@/server/db/public-visibility/filters";
 import { getCloudflareUrlForDaylilyS3Image } from "@/lib/utils/cloudflareLoader";
+import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
 
 export const publicListingSelect = {
   id: true,
@@ -64,6 +65,19 @@ export const publicListingSelect = {
       order: "asc",
     },
   },
+  imageAssets: {
+    select: {
+      id: true,
+      legacyImageId: true,
+      originalUrl: true,
+      displayUrl: true,
+      thumbUrl: true,
+      blurUrl: true,
+    },
+    orderBy: {
+      order: "asc",
+    },
+  },
 } as const;
 
 type ListingWithRelations = Awaited<ReturnType<typeof getListings>>[number];
@@ -80,8 +94,16 @@ interface GetListingsArgs {
 function buildListingView<T extends ListingPayload>(listing: T) {
   const displayListing = withResolvedDisplayAhsListing(listing);
   const displayAhsListing = displayListing.ahsListing;
+  const resolvedImages = resolveLegacyImagesWithAssets({
+    images: displayListing.images,
+    imageAssets: displayListing.imageAssets,
+    variant: "display",
+    source: "public-listing",
+  });
+  const publicListing = { ...displayListing };
+  delete (publicListing as Partial<typeof publicListing>).imageAssets;
   const images =
-    displayListing.images.length === 0 && displayAhsListing?.ahsImageUrl
+    resolvedImages.length === 0 && displayAhsListing?.ahsImageUrl
       ? [
           {
             id: `ahs-${displayListing.id}`,
@@ -89,10 +111,10 @@ function buildListingView<T extends ListingPayload>(listing: T) {
             updatedAt: displayListing.updatedAt,
           },
         ]
-      : displayListing.images;
+      : resolvedImages;
 
   return {
-    ...displayListing,
+    ...publicListing,
     ahsListing: displayAhsListing,
     userSlug: listing.user.profile?.slug ?? listing.userId,
     sellerTitle: listing.user.profile?.title ?? null,

--- a/apps/main/src/server/db/public-listing-read-model.ts
+++ b/apps/main/src/server/db/public-listing-read-model.ts
@@ -100,7 +100,8 @@ function buildListingView<T extends ListingPayload>(listing: T) {
     variant: "display",
     source: "public-listing",
   });
-  const { imageAssets: _imageAssets, ...publicListing } = displayListing;
+  const { imageAssets, ...publicListing } = displayListing;
+  void imageAssets;
   const images =
     resolvedImages.length === 0 && displayAhsListing?.ahsImageUrl
       ? [

--- a/apps/main/src/server/db/public-listing-read-model.ts
+++ b/apps/main/src/server/db/public-listing-read-model.ts
@@ -17,7 +17,24 @@ import {
   isPublished,
 } from "@/server/db/public-visibility/filters";
 import { getCloudflareUrlForDaylilyS3Image } from "@/lib/utils/cloudflareLoader";
-import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
+import {
+  areImageAssetsEnabled,
+  resolveLegacyImagesWithAssets,
+} from "@/server/services/image-asset-read-model";
+
+const imageAssetSelect = {
+  select: {
+    id: true,
+    legacyImageId: true,
+    originalUrl: true,
+    displayUrl: true,
+    thumbUrl: true,
+    blurUrl: true,
+  },
+  orderBy: {
+    order: "asc",
+  },
+} as const;
 
 export const publicListingSelect = {
   id: true,
@@ -65,19 +82,7 @@ export const publicListingSelect = {
       order: "asc",
     },
   },
-  imageAssets: {
-    select: {
-      id: true,
-      legacyImageId: true,
-      originalUrl: true,
-      displayUrl: true,
-      thumbUrl: true,
-      blurUrl: true,
-    },
-    orderBy: {
-      order: "asc",
-    },
-  },
+  ...(areImageAssetsEnabled() ? { imageAssets: imageAssetSelect } : {}),
 } as const;
 
 type ListingWithRelations = Awaited<ReturnType<typeof getListings>>[number];
@@ -96,12 +101,14 @@ function buildListingView<T extends ListingPayload>(listing: T) {
   const displayAhsListing = displayListing.ahsListing;
   const resolvedImages = resolveLegacyImagesWithAssets({
     images: displayListing.images,
-    imageAssets: displayListing.imageAssets,
+    imageAssets: "imageAssets" in displayListing ? displayListing.imageAssets : [],
     variant: "display",
     source: "public-listing",
   });
-  const { imageAssets, ...publicListing } = displayListing;
-  void imageAssets;
+  const publicListing =
+    "imageAssets" in displayListing
+      ? (({ imageAssets, ...listing }) => listing)(displayListing)
+      : displayListing;
   const images =
     resolvedImages.length === 0 && displayAhsListing?.ahsImageUrl
       ? [

--- a/apps/main/src/server/db/public-listing-read-model.ts
+++ b/apps/main/src/server/db/public-listing-read-model.ts
@@ -100,8 +100,7 @@ function buildListingView<T extends ListingPayload>(listing: T) {
     variant: "display",
     source: "public-listing",
   });
-  const publicListing = { ...displayListing };
-  delete (publicListing as Partial<typeof publicListing>).imageAssets;
+  const { imageAssets: _imageAssets, ...publicListing } = displayListing;
   const images =
     resolvedImages.length === 0 && displayAhsListing?.ahsImageUrl
       ? [

--- a/apps/main/src/server/db/public-listing-read-model.ts
+++ b/apps/main/src/server/db/public-listing-read-model.ts
@@ -107,7 +107,9 @@ function buildListingView<T extends ListingPayload>(listing: T) {
   });
   const publicListing =
     "imageAssets" in displayListing
-      ? (({ imageAssets, ...listing }) => listing)(displayListing)
+      ? (({ imageAssets: _imageAssets, ...listing }) => listing)(
+          displayListing,
+        )
       : displayListing;
   const images =
     resolvedImages.length === 0 && displayAhsListing?.ahsImageUrl

--- a/apps/main/src/server/db/public-seller-read-model.ts
+++ b/apps/main/src/server/db/public-seller-read-model.ts
@@ -263,7 +263,6 @@ export async function getPublicSellerSummariesByUserIds(
                 ? user.profile.imageAssets
                 : [],
             variant: "display",
-            source: "public-seller",
           }).map((image) => ({
             id: image.id,
             url: getCloudflareUrlForDaylilyS3Image(image.url),

--- a/apps/main/src/server/db/public-seller-read-model.ts
+++ b/apps/main/src/server/db/public-seller-read-model.ts
@@ -9,7 +9,24 @@ import {
 } from "@/server/db/public-visibility/filters";
 import { parseAndSanitizeEditorJsContent } from "@/server/security/editor-js-content";
 import { getCloudflareUrlForDaylilyS3Image } from "@/lib/utils/cloudflareLoader";
-import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
+import {
+  areImageAssetsEnabled,
+  resolveLegacyImagesWithAssets,
+} from "@/server/services/image-asset-read-model";
+
+const imageAssetSelect = {
+  select: {
+    id: true,
+    legacyImageId: true,
+    originalUrl: true,
+    displayUrl: true,
+    thumbUrl: true,
+    blurUrl: true,
+  },
+  orderBy: {
+    order: "asc",
+  },
+} as const;
 
 export interface PublicSellerSummary {
   id: string;
@@ -195,19 +212,9 @@ export async function getPublicSellerSummariesByUserIds(
                 order: "asc",
               },
             },
-            imageAssets: {
-              select: {
-                id: true,
-                legacyImageId: true,
-                originalUrl: true,
-                displayUrl: true,
-                thumbUrl: true,
-                blurUrl: true,
-              },
-              orderBy: {
-                order: "asc",
-              },
-            },
+            ...(areImageAssetsEnabled()
+              ? { imageAssets: imageAssetSelect }
+              : {}),
           },
         },
         _count: {
@@ -251,7 +258,10 @@ export async function getPublicSellerSummariesByUserIds(
         images:
           resolveLegacyImagesWithAssets({
             images: user.profile?.images ?? [],
-            imageAssets: user.profile?.imageAssets ?? [],
+            imageAssets:
+              user.profile && "imageAssets" in user.profile
+                ? user.profile.imageAssets
+                : [],
             variant: "display",
             source: "public-seller",
           }).map((image) => ({

--- a/apps/main/src/server/db/public-seller-read-model.ts
+++ b/apps/main/src/server/db/public-seller-read-model.ts
@@ -9,6 +9,7 @@ import {
 } from "@/server/db/public-visibility/filters";
 import { parseAndSanitizeEditorJsContent } from "@/server/security/editor-js-content";
 import { getCloudflareUrlForDaylilyS3Image } from "@/lib/utils/cloudflareLoader";
+import { resolveLegacyImagesWithAssets } from "@/server/services/image-asset-read-model";
 
 export interface PublicSellerSummary {
   id: string;
@@ -194,6 +195,19 @@ export async function getPublicSellerSummariesByUserIds(
                 order: "asc",
               },
             },
+            imageAssets: {
+              select: {
+                id: true,
+                legacyImageId: true,
+                originalUrl: true,
+                displayUrl: true,
+                thumbUrl: true,
+                blurUrl: true,
+              },
+              orderBy: {
+                order: "asc",
+              },
+            },
           },
         },
         _count: {
@@ -235,7 +249,12 @@ export async function getPublicSellerSummariesByUserIds(
         description: user.profile?.description ?? null,
         location: user.profile?.location ?? null,
         images:
-          user.profile?.images.map((image) => ({
+          resolveLegacyImagesWithAssets({
+            images: user.profile?.images ?? [],
+            imageAssets: user.profile?.imageAssets ?? [],
+            variant: "display",
+            source: "public-seller",
+          }).map((image) => ({
             id: image.id,
             url: getCloudflareUrlForDaylilyS3Image(image.url),
           })) ?? [],

--- a/apps/main/src/server/db/public-seller-read-model.ts
+++ b/apps/main/src/server/db/public-seller-read-model.ts
@@ -257,7 +257,7 @@ export async function getPublicSellerSummariesByUserIds(
           }).map((image) => ({
             id: image.id,
             url: getCloudflareUrlForDaylilyS3Image(image.url),
-          })) ?? [],
+          })),
         listingCount: user._count.listings,
         listCount: user._count.lists,
         hasActiveSubscription: activeUserIds.has(user.id),

--- a/apps/main/tests/e2e/pages/dashboard-listings.ts
+++ b/apps/main/tests/e2e/pages/dashboard-listings.ts
@@ -172,7 +172,6 @@ export class DashboardListings {
 
   private firstVisibleRowActionButton(): Locator {
     return this.page
-      .getByTestId("listing-table")
       .locator('[data-testid="listing-row-actions-trigger"]:visible')
       .first();
   }
@@ -198,7 +197,8 @@ export class DashboardListings {
       try {
         const trigger =
           rowActionButtonFactory?.() ?? this.firstVisibleRowActionButton();
-        await trigger.waitFor({ state: "visible" });
+        await trigger.waitFor({ state: "visible", timeout: 5000 });
+        await trigger.scrollIntoViewIfNeeded();
         await trigger.click({ force: true });
         await this.rowActionMenu().waitFor({ state: "visible", timeout: 2000 });
         return;

--- a/apps/main/tests/get-public-listings.test.ts
+++ b/apps/main/tests/get-public-listings.test.ts
@@ -76,6 +76,7 @@ function createListing(id: string, title: string) {
       ahsListing: null,
     },
     images: [],
+    imageAssets: [],
   };
 }
 

--- a/apps/main/tests/get-public-listings.test.ts
+++ b/apps/main/tests/get-public-listings.test.ts
@@ -42,6 +42,7 @@ import { applyWhereIn } from "./test-utils/apply-where-in";
 const originalV2DisplayFlag =
   process.env.NEXT_PUBLIC_USE_V2_CULTIVAR_DISPLAY_DATA;
 const originalCloudflareUrl = process.env.NEXT_PUBLIC_CLOUDFLARE_URL;
+const originalUseImageAssets = process.env.USE_IMAGE_ASSETS;
 
 function getQueryText(query: unknown): string {
   if (
@@ -109,6 +110,12 @@ describe("getPublicListings helpers", () => {
       delete process.env.NEXT_PUBLIC_CLOUDFLARE_URL;
     } else {
       process.env.NEXT_PUBLIC_CLOUDFLARE_URL = originalCloudflareUrl;
+    }
+
+    if (originalUseImageAssets === undefined) {
+      delete process.env.USE_IMAGE_ASSETS;
+    } else {
+      process.env.USE_IMAGE_ASSETS = originalUseImageAssets;
     }
   });
 
@@ -421,6 +428,60 @@ describe("getPublicListings helpers", () => {
     });
     expect(listing.images[0]?.url).toBe(
       "https://cf.daylilycatalog.com/cdn-cgi/image/width=800,fit=cover,format=auto,quality=90/https://daylily-catalog-images.s3.amazonaws.com/listings/every-friday-night.jpg",
+    );
+  });
+
+  it("uses ImageAsset display URLs for public listing detail when enabled", async () => {
+    process.env.USE_IMAGE_ASSETS = "true";
+    mockDb.listing.findFirst.mockResolvedValue({
+      ...createListing("id-a", "Every Friday Night"),
+      updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+      price: 30,
+      images: [
+        {
+          id: "image-a",
+          url: "https://daylily-catalog-images.s3.amazonaws.com/listings/every-friday-night.jpg",
+          updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+        },
+      ],
+      imageAssets: [
+        {
+          id: "image-a",
+          legacyImageId: "image-a",
+          originalUrl:
+            "https://media.daylilycatalog.com/users/user-1/listing-images/id-a/image-a/original.jpg",
+          displayUrl:
+            "https://media.daylilycatalog.com/users/user-1/listing-images/id-a/image-a/display-800.webp",
+          thumbUrl:
+            "https://media.daylilycatalog.com/users/user-1/listing-images/id-a/image-a/thumb-200.webp",
+          blurUrl:
+            "https://media.daylilycatalog.com/users/user-1/listing-images/id-a/image-a/blur-20.webp",
+        },
+      ],
+      user: {
+        profile: {
+          slug: "rolling-oaks",
+          title: "Rolling Oaks Daylilies",
+        },
+      },
+    });
+    mockDb.keyValue.findMany.mockResolvedValue([
+      {
+        key: "stripe:customer:cus-pro",
+        value: JSON.stringify({ status: "active" }),
+      },
+    ]);
+    mockDb.user.findMany.mockResolvedValue([
+      {
+        id: "user-1",
+        stripeCustomerId: "cus-pro",
+      },
+    ]);
+
+    const listing = await getPublicListingDetail("id-a");
+
+    expect(listing.images[0]?.url).toBe(
+      "https://media.daylilycatalog.com/users/user-1/listing-images/id-a/image-a/display-800.webp",
     );
   });
 


### PR DESCRIPTION
Replacement for #221, which was accidentally marked merged while repairing the branch stack.\n\nReplacement stack PR 4/5 for the ImageAsset/R2 migration, rebuilt from current origin/main monorepo layout.\n\nDepends on #223.\n\nScope:\n- Add feature-flagged ImageAsset URL reads for public listing/seller/feed paths.\n- Keep legacy S3 URLs routed through Cloudflare while allowing media.daylilycatalog.com URLs to pass through.\n- Keep behavior off by default.\n\nSafety:\n- No production Turso/R2/Cloudflare/AWS mutation.\n\nValidation:\n- pnpm --dir apps/main test -- tests/get-public-listings.test.ts tests/google-merchant-feed-route.test.ts tests/image-asset-read-model.test.ts tests/optimized-image.test.tsx.