### PR TITLE
Include app dependencies in production image

### DIFF
--- a/apps/main/Dockerfile
+++ b/apps/main/Dockerfile
@@ -61,6 +61,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/main/public ./apps/main/publ
 COPY --from=builder --chown=nextjs:nodejs /app/apps/main/scripts/build-public-search-index.mjs ./apps/main/scripts/build-public-search-index.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/apps/main/scripts/build-public-parentage-index.mjs ./apps/main/scripts/build-public-parentage-index.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/apps/main/.next/standalone ./
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules ./node_modules
+COPY --from=deps --chown=nextjs:nodejs /app/apps/main/node_modules ./apps/main/node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/apps/main/.next/static ./apps/main/.next/static
 
 USER nextjs


### PR DESCRIPTION
## Summary
- Copy pnpm root and app `node_modules` links into the production runner image after Next standalone output.
- Keep the standalone server entrypoint unchanged while allowing app-runtime imports for ImageAsset variant processing.

## Why
PR #227 moved ImageAsset variant processing into the app runtime. The deployed standalone image can serve the site, but the variant endpoint fails because runtime packages like `sharp`, AWS SDK, Prisma `adapter-libsql`, and libsql are not resolvable in the runner filesystem.

## Verification
Not locally Docker-built because the production build requires the app env build secret. CI Docker Image build should verify the Dockerfile build.

After deploy, verify inside the app container:

```sh
cd /app/apps/main
node -e 'for (const p of ["sharp","@aws-sdk/client-s3","@prisma/client","@prisma/adapter-libsql","@libsql/client"]) console.log(p, require.resolve(p))'
```

Then rerun:

```sh
curl -fsS -X POST http://127.0.0.1:3000/api/internal/image-assets/process-variants \
  -H "Authorization: Bearer $CLERK_WEBHOOK_SECRET" \
  -H "Content-Type: application/json" \
  -d '{"limit":25,"retryFailed":true}'
```
