### PR TITLE
Use image assets across cultivar views

### DIFF
--- a/apps/main/src/app/(public)/cultivar/[cultivarNormalizedName]/_components/cultivar-gallery.tsx
+++ b/apps/main/src/app/(public)/cultivar/[cultivarNormalizedName]/_components/cultivar-gallery.tsx
@@ -40,7 +40,7 @@ export function CultivarGallery({
     <section aria-label="Cultivar gallery" className="space-y-3">
       <div className="bg-muted/20 max-w-[400px] overflow-hidden rounded-xl border">
         <OptimizedImage
-          src={selectedImage.url}
+          image={selectedImage}
           alt={selectedImage.alt ?? `${cultivarName} image`}
           size="full"
           priority
@@ -68,7 +68,7 @@ export function CultivarGallery({
                 aria-pressed={isActive}
               >
                 <OptimizedImage
-                  src={image.url}
+                  image={image}
                   alt={image.alt ?? `${cultivarName} thumbnail`}
                   size="thumbnail"
                   className="h-16 w-full object-cover"

--- a/apps/main/src/app/(public)/cultivar/[cultivarNormalizedName]/_components/cultivar-garden-photos-section.tsx
+++ b/apps/main/src/app/(public)/cultivar/[cultivarNormalizedName]/_components/cultivar-garden-photos-section.tsx
@@ -36,7 +36,7 @@ export function CultivarGardenPhotosSection({
             >
               <div className="aspect-square overflow-hidden rounded-lg border">
                 <OptimizedImage
-                  src={photo.url}
+                  image={photo}
                   alt={`${photo.listingTitle} from ${photo.sellerTitle}`}
                   size="full"
                   className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.03]"

--- a/apps/main/src/app/(public)/cultivar/[cultivarNormalizedName]/_components/cultivar-offer-row.tsx
+++ b/apps/main/src/app/(public)/cultivar/[cultivarNormalizedName]/_components/cultivar-offer-row.tsx
@@ -39,6 +39,11 @@ interface CultivarOfferRowProps {
 
 export function CultivarOfferRow({ sellerSlug, offer }: CultivarOfferRowProps) {
   const listingHref = getOfferViewingHref(sellerSlug, offer.id);
+  const previewImage =
+    offer.previewImage ??
+    (offer.previewImageUrl
+      ? { id: `${offer.id}-preview`, url: offer.previewImageUrl }
+      : null);
   const updatedLabel = `Updated ${updatedDateFormatter.format(
     new Date(offer.updatedAt),
   )}`;
@@ -47,18 +52,18 @@ export function CultivarOfferRow({ sellerSlug, offer }: CultivarOfferRowProps) {
     <div
       className={cn(
         "flex flex-col gap-4 rounded-lg border p-4",
-        offer.previewImageUrl && "md:h-56 md:flex-row",
+        previewImage && "md:h-56 md:flex-row",
       )}
       data-testid="cultivar-offer-row"
       data-listing-id={offer.id}
     >
-      {offer.previewImageUrl && (
+      {previewImage && (
         <Link
           href={listingHref}
           className="aspect-square w-full shrink-0 overflow-hidden rounded-md border md:h-full md:w-auto"
         >
           <OptimizedImage
-            src={offer.previewImageUrl}
+            image={previewImage}
             alt={`${offer.title} listing image`}
             className="size-full object-cover"
             size="full"

--- a/apps/main/src/app/dashboard/_lib/dashboard-db/use-dashboard-listing-read-model.ts
+++ b/apps/main/src/app/dashboard/_lib/dashboard-db/use-dashboard-listing-read-model.ts
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useMemo, useRef } from "react";
-import type { Image } from "@prisma/client";
 import type { RouterOutputs } from "@/trpc/react";
 import { listingsCollection } from "./listings-collection";
 import { listsCollection } from "./lists-collection";
-import { imagesCollection } from "./images-collection";
+import {
+  imagesCollection,
+  type ImageCollectionItem,
+} from "./images-collection";
 import { cultivarReferencesCollection } from "./cultivar-references-collection";
 import { DASHBOARD_DB_QUERY_KEYS } from "./dashboard-db-keys";
 import { useSeededDashboardDbQuery } from "./use-seeded-dashboard-db-query";
@@ -18,7 +20,7 @@ type CultivarReference =
   RouterOutputs["dashboardDb"]["cultivarReference"]["listForUserListings"][number];
 
 export interface DashboardListingReadModel {
-  images: Image[];
+  images: ImageCollectionItem[];
   lists: List[];
   listingRows: ListingData[];
   listingsById: Map<string, ListingData>;
@@ -38,8 +40,8 @@ function buildListsByListingId(lists: List[]) {
   return map;
 }
 
-function buildImagesByListingId(images: Image[]) {
-  const map = new Map<string, Image[]>();
+function buildImagesByListingId(images: ImageCollectionItem[]) {
+  const map = new Map<string, ImageCollectionItem[]>();
 
   for (const image of images) {
     if (!image.listingId) continue;
@@ -68,7 +70,7 @@ function buildListingRows({
   listings,
 }: {
   cultivarReferenceById: Map<string, CultivarReference>;
-  imagesByListingId: Map<string, Image[]>;
+  imagesByListingId: Map<string, ImageCollectionItem[]>;
   listsByListingId: Map<string, Array<Pick<List, "id" | "title">>>;
   listings: Listing[];
 }) {
@@ -104,7 +106,7 @@ export function useDashboardListingReadModel(): DashboardListingReadModel {
         .orderBy(({ list }) => list.createdAt, "desc"),
     queryKey: DASHBOARD_DB_QUERY_KEYS.lists,
   });
-  const imagesQuery = useSeededDashboardDbQuery<Image>({
+  const imagesQuery = useSeededDashboardDbQuery<ImageCollectionItem>({
     debugLabel: "dashboard.images",
     query: (q) =>
       q

--- a/apps/main/src/app/dashboard/listings/_components/columns.tsx
+++ b/apps/main/src/app/dashboard/listings/_components/columns.tsx
@@ -21,7 +21,7 @@ import {
   matchesNumericRange,
   matchesTextContains,
 } from "@/components/public-catalog-search/public-catalog-search-filter-utils";
-import type { Image } from "@prisma/client";
+import type { ImageCollectionItem } from "@/app/dashboard/_lib/dashboard-db/images-collection";
 
 interface ListingListRef {
   id: string;
@@ -34,7 +34,7 @@ type CultivarReference =
 type CultivarReferenceAhsListing = CultivarReference["ahsListing"];
 
 export type ListingData = ListingBase & {
-  images: Image[];
+  images: ImageCollectionItem[];
   lists: ListingListRef[];
   ahsListing: CultivarReferenceAhsListing | null;
 };

--- a/apps/main/src/components/data-table/table-image-preview.tsx
+++ b/apps/main/src/components/data-table/table-image-preview.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { type Image as ImageType } from "@prisma/client";
-import { OptimizedImage } from "@/components/optimized-image";
+import {
+  OptimizedImage,
+  type OptimizedImageSource,
+} from "@/components/optimized-image";
 import { cn } from "@/lib/utils";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { ImageGallery } from "@/components/image-gallery";
 
 interface TableImagePreviewProps {
-  images: ImageType[];
+  images: OptimizedImageSource[];
   ahsImageUrl?: string | null;
 }
 
@@ -15,7 +17,7 @@ export function TableImagePreview({
   images,
   ahsImageUrl,
 }: TableImagePreviewProps) {
-  const allImages = [
+  const allImages: OptimizedImageSource[] = [
     ...images,
     ...(ahsImageUrl ? [{ url: ahsImageUrl, id: "ahs-image" }] : []),
   ];
@@ -34,7 +36,7 @@ export function TableImagePreview({
         >
           <div className="absolute overflow-hidden rounded-[4px]">
             <OptimizedImage
-              src={firstImage.url}
+              image={firstImage}
               alt="Image preview"
               size="thumbnail"
             />

--- a/apps/main/src/components/image-manager.tsx
+++ b/apps/main/src/components/image-manager.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { type Image } from "@prisma/client";
 import {
   DndContext,
   closestCenter,
@@ -35,12 +34,13 @@ import {
 } from "@/lib/error-utils";
 import {
   deleteImage,
+  type ImageCollectionItem,
   reorderImages,
 } from "@/app/dashboard/_lib/dashboard-db/images-collection";
 
 interface ImageManagerProps {
-  images: Image[];
-  onImagesChange?: (images: Image[]) => void;
+  images: ImageCollectionItem[];
+  onImagesChange?: (images: ImageCollectionItem[]) => void;
   onMutationSuccess?: () => void;
   referenceId: string;
   type: ImageType;
@@ -50,7 +50,7 @@ function SortableImage({
   image,
   dragControls,
 }: {
-  image: Image;
+  image: ImageCollectionItem;
   dragControls: (
     attributes: DraggableAttributes,
     listeners: Record<string, unknown>,
@@ -74,7 +74,7 @@ function SortableImage({
   return (
     <div ref={setNodeRef} style={style} className="relative aspect-square">
       <OptimizedImage
-        src={image.url}
+        image={image}
         alt="Daylily image"
         size="thumbnail"
         className="rounded-lg border"
@@ -91,7 +91,8 @@ export function ImageManager({
   referenceId,
   type,
 }: ImageManagerProps) {
-  const [imageToDelete, setImageToDelete] = useState<Image | null>(null);
+  const [imageToDelete, setImageToDelete] =
+    useState<ImageCollectionItem | null>(null);
   const {
     isDialogOpen: isDeleteDialogOpen,
     isPending,

--- a/apps/main/src/components/image-popover.tsx
+++ b/apps/main/src/components/image-popover.tsx
@@ -65,7 +65,7 @@ export function ImagePopover({
             className={cn(
               "overflow-hidden rounded-md",
               isSingleImage
-                ? "aspect-square w-[300px]"
+                ? "aspect-square w-[200px]"
                 : "aspect-square w-[100px]",
             )}
           >

--- a/apps/main/src/components/image-preview-dialog.tsx
+++ b/apps/main/src/components/image-preview-dialog.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { type Image as ImageType } from "@prisma/client";
 import { Expand } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { ImageGallery } from "@/components/image-gallery";
 import { cn } from "@/lib/utils";
+import type { OptimizedImageSource } from "@/components/optimized-image";
 
 interface ImagePreviewDialogProps {
-  images: ImageType[];
+  images: OptimizedImageSource[];
   className?: string;
   size?: "sm" | "md";
 }

--- a/apps/main/src/components/optimized-image.tsx
+++ b/apps/main/src/components/optimized-image.tsx
@@ -103,7 +103,9 @@ export function OptimizedImage({
   fit = IMAGE_CONFIG.FIT,
   ...props
 }: OptimizedImageProps) {
-  const [loaded, setLoaded] = React.useState(false);
+  const [loadedImageUrl, setLoadedImageUrl] = React.useState<string | null>(
+    null,
+  );
   const imageVariant = variant ?? (size === "thumbnail" ? "thumb" : "display");
   const resolvedImage = resolveImageSource({
     image,
@@ -140,18 +142,19 @@ export function OptimizedImage({
         })
       : resolvedImage.src);
 
+  const loaded = loadedImageUrl === imageUrl;
   const handleLoad: React.ReactEventHandler<HTMLImageElement> =
     React.useCallback(() => {
       // In development, hold the overlay a bit so you can observe the blur-up
       if (process.env.NODE_ENV === "development") {
         const { MIN, MAX } = IMAGE_CONFIG.DEBUG.BLUR_DELAY;
         const ms = Math.floor(Math.random() * (MAX - MIN + 1)) + MIN;
-        const id = setTimeout(() => setLoaded(true), ms);
-        return () => clearTimeout(id);
+        setTimeout(() => setLoadedImageUrl(imageUrl), ms);
+        return;
       }
       // In production, fade overlay immediately after paint
-      setLoaded(true);
-    }, []);
+      setLoadedImageUrl(imageUrl);
+    }, [imageUrl]);
 
   return (
     <div

--- a/apps/main/src/server/api/routers/dashboard-db/image.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/image.ts
@@ -17,9 +17,8 @@ import {
 import type { db } from "@/server/db";
 import {
   areImageAssetsEnabled,
-  buildImageAssetMap,
   imageAssetUrlSelect,
-  resolveImageAssetUrl,
+  resolveLegacyImagesWithAssets,
 } from "@/server/services/image-asset-read-model";
 import {
   buildR2PublicUrl,
@@ -263,16 +262,12 @@ async function resolveDashboardImageRows(args: {
     },
     select: imageAssetUrlSelect,
   });
-  const imageAssetByLegacyId = buildImageAssetMap(assets);
 
-  return args.rows.map((row) => ({
-    ...row,
-    url: resolveImageAssetUrl({
-      image: row,
-      imageAssetByLegacyId,
-      variant: "thumb",
-    }),
-  }));
+  return resolveLegacyImagesWithAssets({
+    images: args.rows,
+    imageAssets: assets,
+    variant: "thumb",
+  });
 }
 
 export const dashboardDbImageRouter = createTRPCRouter({

--- a/apps/main/src/server/db/public-cultivar-sections.ts
+++ b/apps/main/src/server/db/public-cultivar-sections.ts
@@ -6,6 +6,7 @@ import {
   type PublicCultivarReferenceData,
 } from "@/server/db/public-cultivar-context";
 import { getCloudflareUrlForDaylilyS3Image } from "@/lib/utils/cloudflareLoader";
+import type { ImageAssetView } from "@/server/services/image-asset-read-model";
 
 const CULTIVAR_SPEC_FIELDS = [
   ["Scape Height", "scapeHeight"],
@@ -44,6 +45,25 @@ type PublicRelatedCultivar = {
   segment: string;
   year: string | null;
 };
+
+type PublicCultivarImage = {
+  id: string;
+  url: string;
+  imageAsset?: ImageAssetView;
+};
+
+type CultivarListingCardImage = CultivarListingCards[number]["images"][number];
+
+function toPublicCultivarImage(
+  image: CultivarListingCardImage,
+): PublicCultivarImage & CultivarListingCardImage {
+  return {
+    ...image,
+    url: image.imageAsset
+      ? image.url
+      : getCloudflareUrlForDaylilyS3Image(image.url),
+  };
+}
 
 function getCultivarDisplayName(
   normalizedName: string | null,
@@ -169,15 +189,18 @@ function getCultivarHeroImages(
   const catalogImages = listingCards.flatMap((listing) =>
     listing.images
       .filter((image) => image.id !== `ahs-${listing.id}`)
-      .map((image) => ({
-        alt: `${listing.title} catalog image`,
-        id: image.id,
-        listingId: listing.id,
-        sellerSlug: listing.userSlug,
-        sellerTitle: listing.sellerTitle,
-        source: "catalog" as const,
-        url: getCloudflareUrlForDaylilyS3Image(image.url),
-      })),
+      .map((image) => {
+        const publicImage = toPublicCultivarImage(image);
+
+        return {
+          ...publicImage,
+          alt: `${listing.title} catalog image`,
+          listingId: listing.id,
+          sellerSlug: listing.userSlug,
+          sellerTitle: listing.sellerTitle,
+          source: "catalog" as const,
+        };
+      }),
   );
 
   return cultivarReference.ahsListing?.ahsImageUrl
@@ -214,7 +237,7 @@ function toGardenCards(args: {
       location: string | null;
       listingCount: number;
       listCount: number;
-      profileImages: Array<{ id: string; url: string }>;
+      profileImages: PublicCultivarImage[];
       createdAt: Date;
       updatedAt: Date;
       offers: Array<{
@@ -225,6 +248,7 @@ function toGardenCards(args: {
         description: string | null;
         updatedAt: Date;
         imageCount: number;
+        previewImage?: PublicCultivarImage | null;
         previewImageUrl: string | null;
         lists: Array<{ id: string; title: string }>;
       }>;
@@ -260,14 +284,17 @@ function toGardenCards(args: {
       return;
     }
 
+    const previewImage = listing.images[0]
+      ? toPublicCultivarImage(listing.images[0])
+      : null;
+
     gardenCard.offers.push({
       description: listing.description,
       id: listing.id,
       imageCount: listing.images.length,
       lists: listing.lists,
-      previewImageUrl: listing.images[0]?.url
-        ? getCloudflareUrlForDaylilyS3Image(listing.images[0].url)
-        : null,
+      previewImage,
+      previewImageUrl: previewImage?.url ?? null,
       price: listing.price,
       slug: listing.slug,
       title: listing.title,
@@ -322,15 +349,18 @@ function toGardenPhotos(args: {
         return [];
       }
 
-      return listing.images.map((image) => ({
-        id: image.id,
-        listingId: listing.id,
-        listingTitle: listing.title,
-        sellerSlug: summary.slug ?? summary.id,
-        sellerTitle: summary.title ?? summary.slug ?? "Unnamed Garden",
-        updatedAt: image.updatedAt,
-        url: getCloudflareUrlForDaylilyS3Image(image.url),
-      }));
+      return listing.images.map((image) => {
+        const publicImage = toPublicCultivarImage(image);
+
+        return {
+          ...publicImage,
+          listingId: listing.id,
+          listingTitle: listing.title,
+          sellerSlug: summary.slug ?? summary.id,
+          sellerTitle: summary.title ?? summary.slug ?? "Unnamed Garden",
+          updatedAt: image.updatedAt,
+        };
+      });
     })
     .sort((a, b) => {
       const aUpdatedAt = toDate(a.updatedAt);

--- a/apps/main/tests/dashboard-db-image-router.test.ts
+++ b/apps/main/tests/dashboard-db-image-router.test.ts
@@ -1,6 +1,14 @@
 // @vitest-environment node
 
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import type { TRPCInternalContext } from "@/server/api/trpc";
 
 process.env.SKIP_ENV_VALIDATION = "1";
@@ -26,6 +34,7 @@ vi.mock("@aws-sdk/s3-request-presigner", () => ({
 
 type RouterModule = typeof import("@/server/api/routers/dashboard-db/image");
 let dashboardDbImageRouter: RouterModule["dashboardDbImageRouter"];
+const originalUseImageAssets = process.env.USE_IMAGE_ASSETS;
 
 beforeAll(async () => {
   ({ dashboardDbImageRouter } = await import(
@@ -46,6 +55,7 @@ interface MockDb {
   };
   imageAsset: {
     deleteMany: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
     updateMany: ReturnType<typeof vi.fn>;
   };
   listing: {
@@ -69,6 +79,7 @@ function createMockDb(): MockDb {
   };
   const imageAsset = {
     deleteMany: vi.fn(),
+    findMany: vi.fn(),
     updateMany: vi.fn(),
   };
   return {
@@ -103,6 +114,15 @@ describe("dashboardDb.image", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     s3Mocks.getSignedUrl.mockResolvedValue("https://upload-url.example");
+  });
+
+  afterEach(() => {
+    if (originalUseImageAssets === undefined) {
+      delete process.env.USE_IMAGE_ASSETS;
+      return;
+    }
+
+    process.env.USE_IMAGE_ASSETS = originalUseImageAssets;
   });
 
   it("presigns only allowed image types with a server-derived extension and content length", async () => {
@@ -262,6 +282,55 @@ describe("dashboardDb.image", () => {
     expect(db.listing.findMany).not.toHaveBeenCalled();
     expect(db.userProfile.findUnique).not.toHaveBeenCalled();
     expect(db.image.findMany).not.toHaveBeenCalled();
+  });
+
+  it("sync returns dashboard thumb URLs with ImageAsset metadata when asset reads are enabled", async () => {
+    process.env.USE_IMAGE_ASSETS = "true";
+    const db = createMockDb();
+    db.$queryRaw.mockResolvedValueOnce([
+      {
+        id: "image-1",
+        url: "https://daylily-catalog-images.s3.amazonaws.com/listing/image-1.jpg",
+        order: 1,
+        listingId: "listing-1",
+        userProfileId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+        status: null,
+      },
+    ]);
+    db.imageAsset.findMany.mockResolvedValueOnce([
+      {
+        id: "asset-1",
+        legacyImageId: "image-1",
+        status: "ready",
+        originalUrl: "https://media.example/image-1/original.jpg",
+        displayUrl: "https://media.example/image-1/display-800.webp",
+        thumbUrl: "https://media.example/image-1/thumb-200.webp",
+        blurUrl: "https://media.example/image-1/blur-20.webp",
+      },
+    ]);
+
+    const caller = createCaller(db);
+    const result = await caller.sync({ since: null });
+
+    expect(result[0]).toMatchObject({
+      id: "image-1",
+      url: "https://media.example/image-1/thumb-200.webp",
+      imageAsset: {
+        id: "asset-1",
+        displayUrl: "https://media.example/image-1/display-800.webp",
+        thumbUrl: "https://media.example/image-1/thumb-200.webp",
+        blurUrl: "https://media.example/image-1/blur-20.webp",
+      },
+    });
+    expect(db.imageAsset.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          legacyImageId: { in: ["image-1"] },
+        },
+      }),
+    );
   });
 
   it("sync returns an empty page when the owner-checked query has no rows", async () => {

--- a/apps/main/tests/get-public-cultivars.test.ts
+++ b/apps/main/tests/get-public-cultivars.test.ts
@@ -121,8 +121,16 @@ describe("getPublicCultivarPage", () => {
           images: [
             {
               id: "img-top-c",
-              url: "https://example.com/top-c.jpg",
+              url: "https://media.example/top-c/display-800.webp",
               updatedAt: new Date("2026-01-15T00:00:00.000Z"),
+              imageAsset: {
+                id: "asset-top-c",
+                status: "ready",
+                originalUrl: "https://media.example/top-c/original.jpg",
+                displayUrl: "https://media.example/top-c/display-800.webp",
+                thumbUrl: "https://media.example/top-c/thumb-200.webp",
+                blurUrl: "https://media.example/top-c/blur-20.webp",
+              },
             },
           ],
           lists: [],
@@ -173,13 +181,29 @@ describe("getPublicCultivarPage", () => {
     expect(offers.freshness.offersUpdatedAt).toEqual(
       new Date("2026-01-15T00:00:00.000Z"),
     );
-    expect(photos.gardenPhotos[0]?.id).toBe("img-top-c");
+    expect(photos.gardenPhotos[0]).toMatchObject({
+      id: "img-top-c",
+      url: "https://media.example/top-c/display-800.webp",
+      imageAsset: {
+        blurUrl: "https://media.example/top-c/blur-20.webp",
+      },
+    });
     expect(photos.freshness.photosUpdatedAt).toEqual(
       new Date("2026-01-15T00:00:00.000Z"),
     );
     expect(offers.offers.gardenCards[0]?.offers[0]?.previewImageUrl).toBe(
       "https://cf.daylilycatalog.com/cdn-cgi/image/width=800,fit=cover,format=auto,quality=90/https://daylily-catalog-images.s3.amazonaws.com/listing/top-a.jpg",
     );
+    expect(offers.offers.gardenCards[0]?.offers[1]).toMatchObject({
+      id: "listing-top-b",
+      previewImageUrl: "https://media.example/top-c/display-800.webp",
+      previewImage: {
+        imageAsset: {
+          displayUrl: "https://media.example/top-c/display-800.webp",
+          thumbUrl: "https://media.example/top-c/thumb-200.webp",
+        },
+      },
+    });
   });
 
   it("returns conversion-ready cultivar payload with pro offers only", async () => {

--- a/apps/main/tests/optimized-image.test.tsx
+++ b/apps/main/tests/optimized-image.test.tsx
@@ -88,6 +88,79 @@ describe("OptimizedImage", () => {
     expect(reportErrorMock).toHaveBeenCalledTimes(0);
   });
 
+  it("uses ImageAsset variants directly and resets the blur overlay for each source", () => {
+    const firstImage = {
+      id: "image-1",
+      url: "https://legacy.example/image-1.jpg",
+      imageAsset: {
+        id: "asset-1",
+        status: "ready",
+        originalUrl: "https://media.example/image-1/original.jpg",
+        displayUrl: "https://media.example/image-1/display-800.webp",
+        thumbUrl: "https://media.example/image-1/thumb-200.webp",
+        blurUrl: "https://media.example/image-1/blur-20.webp",
+      },
+    };
+    const secondImage = {
+      id: "image-2",
+      url: "https://legacy.example/image-2.jpg",
+      imageAsset: {
+        id: "asset-2",
+        status: "ready",
+        originalUrl: "https://media.example/image-2/original.jpg",
+        displayUrl: "https://media.example/image-2/display-800.webp",
+        thumbUrl: "https://media.example/image-2/thumb-200.webp",
+        blurUrl: "https://media.example/image-2/blur-20.webp",
+      },
+    };
+
+    const { container, rerender } = render(
+      <OptimizedImage alt="Asset image" image={firstImage} size="full" />,
+    );
+
+    const image = screen.getByRole("img");
+    const blurOverlay = container.querySelector(
+      '[aria-hidden="true"]',
+    ) as HTMLElement;
+
+    expect(image).toHaveAttribute(
+      "src",
+      "https://media.example/image-1/display-800.webp",
+    );
+    expect(blurOverlay.getAttribute("style")).toContain(
+      "https://media.example/image-1/blur-20.webp",
+    );
+    expect(blurOverlay.className).toContain("opacity-100");
+
+    fireEvent.load(image);
+    expect(blurOverlay.className).toContain("opacity-0");
+
+    rerender(
+      <OptimizedImage alt="Asset image" image={secondImage} size="full" />,
+    );
+
+    const nextBlurOverlay = container.querySelector(
+      '[aria-hidden="true"]',
+    ) as HTMLElement;
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "https://media.example/image-2/display-800.webp",
+    );
+    expect(nextBlurOverlay.getAttribute("style")).toContain(
+      "https://media.example/image-2/blur-20.webp",
+    );
+    expect(nextBlurOverlay.className).toContain("opacity-100");
+
+    rerender(
+      <OptimizedImage alt="Asset image" image={secondImage} size="thumbnail" />,
+    );
+
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "https://media.example/image-2/thumb-200.webp",
+    );
+  });
+
   it("does not report external host load failures", () => {
     const externalSrc =
       "https://www.daylilydatabase.org/AHSPhoto/C/ChinaBlushCherylDay_1584735345.jpg";


### PR DESCRIPTION
## Summary
- Pass full image objects into `OptimizedImage` across public cultivar and dashboard image surfaces
- Carry `ImageAsset` metadata through public cultivar read models so previews and galleries can use resolved variants directly
- Update dashboard listing/image types and add coverage for asset-backed URL resolution and blur-overlay resets

## Testing
- Added unit and integration-style coverage for dashboard image sync, public cultivar payload shaping, and optimized image variant handling
- Not run (not requested)