### PR TITLE
fix(auth): delegate protected-route handling to Clerk

### DIFF
--- a/apps/main/src/proxy.ts
+++ b/apps/main/src/proxy.ts
@@ -43,15 +43,7 @@ const protectedRouteProxy = clerkMiddleware(async (auth, req) => {
     return undefined;
   }
 
-  const { userId } = await auth();
-
-  if (!userId) {
-    // Redirect to our custom auth error page instead of Clerk's sign-in page
-    const returnTo = encodeURIComponent(req.nextUrl.pathname);
-    return NextResponse.redirect(
-      new URL(`/auth-error?returnTo=${returnTo}`, req.url),
-    );
-  }
+  await auth.protect();
 
   return undefined;
 });

--- a/apps/main/tests/proxy-seller-funnel.test.ts
+++ b/apps/main/tests/proxy-seller-funnel.test.ts
@@ -3,9 +3,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest, type NextMiddleware } from "next/server";
 
-const authMock = vi.hoisted(() =>
-  vi.fn(async () => ({ userId: null as string | null })),
-);
+const { authMock, authProtectMock } = vi.hoisted(() => {
+  const protect = vi.fn(async () => undefined);
+  return {
+    authProtectMock: protect,
+    authMock: Object.assign(
+      vi.fn(async () => ({ userId: null as string | null })),
+      { protect },
+    ),
+  };
+});
 const createRouteMatcherMock = vi.hoisted(() =>
   vi.fn((routes: string[]) => {
     return (request: NextRequest) => {
@@ -58,37 +65,43 @@ describe("seller funnel proxy protection", () => {
 
     expect(response).toBeUndefined();
     expect(authMock).not.toHaveBeenCalled();
+    expect(authProtectMock).not.toHaveBeenCalled();
   });
 
-  it("redirects unauthenticated onboarding access to auth-error", async () => {
-    authMock.mockResolvedValueOnce({ userId: null });
-
-    const request = new NextRequest("http://localhost:3000/onboarding");
+  it("delegates dashboard RSC auth handling to Clerk without an auth-error redirect", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/dashboard/listings?_rsc=test",
+      {
+        headers: {
+          accept: "text/x-component",
+          "next-url": "/dashboard",
+          "sec-fetch-dest": "empty",
+        },
+      },
+    );
     const middlewareEvent = {} as Parameters<NextMiddleware>[1];
 
     const response = await proxy(request, middlewareEvent);
 
-    expect(authMock).toHaveBeenCalledTimes(1);
-    expect(response?.headers.get("location")).toContain(
-      "/auth-error?returnTo=%2Fonboarding",
+    expect(authProtectMock).toHaveBeenCalledTimes(1);
+    expect(authMock).not.toHaveBeenCalled();
+    expect(response?.headers.get("location") ?? "").not.toContain(
+      "/auth-error",
     );
   });
 
-  it("allows authenticated onboarding access", async () => {
-    authMock.mockResolvedValueOnce({ userId: "user_123" });
-
+  it("delegates onboarding protection to Clerk", async () => {
     const request = new NextRequest("http://localhost:3000/onboarding");
     const middlewareEvent = {} as Parameters<NextMiddleware>[1];
 
     const response = await proxy(request, middlewareEvent);
 
-    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(authProtectMock).toHaveBeenCalledTimes(1);
+    expect(authMock).not.toHaveBeenCalled();
     expect(response).toBeUndefined();
   });
 
   it("runs Clerk middleware for subscribe success", async () => {
-    authMock.mockResolvedValueOnce({ userId: "user_123" });
-
     const request = new NextRequest(
       "http://localhost:3000/subscribe/success?redirect=/dashboard",
     );
@@ -96,7 +109,8 @@ describe("seller funnel proxy protection", () => {
 
     const response = await proxy(request, middlewareEvent);
 
-    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(authProtectMock).toHaveBeenCalledTimes(1);
+    expect(authMock).not.toHaveBeenCalled();
     expect(response).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

The proxy was translating every null Clerk userId into `/auth-error`, including auth misses during App Router/RSC navigation. This replaces the custom userId check with `auth.protect()`, keeping protected routes fail-closed while allowing Clerk to handle signed-out and pending-session responses through its normal flow.

A regression test covers an RSC request to `/dashboard/listings` and asserts that the application no longer produces an `/auth-error` redirect.

Deliberate behavior change: unauthenticated access to onboarding and subscribe-success will now follow Clerk’s normal sign-in handling instead of the custom `/auth-error` page. This follows directly from removing the shared custom redirect and avoids adding route-specific branches solely to preserve the old behavior.

## Validation

- `pnpm exec vitest run tests/proxy-seller-funnel.test.ts tests/proxy-matcher.test.ts`
- `pnpm typecheck`
- `pnpm exec eslint src/proxy.ts tests/proxy-seller-funnel.test.ts`