### PR TITLE
fix(auth): avoid Clerk redirects for protected RSC requests

### DIFF
--- a/apps/main/src/proxy.ts
+++ b/apps/main/src/proxy.ts
@@ -38,8 +38,30 @@ const publicAgentDiscoveryPaths = new Set([
   "/llms-full.txt",
 ]);
 
+function isRscRequest(req: NextRequest) {
+  return (
+    req.nextUrl.searchParams.has("_rsc") ||
+    req.headers.get("accept")?.includes("text/x-component")
+  );
+}
+
 const protectedRouteProxy = clerkMiddleware(async (auth, req) => {
   if (!isProtectedRoute(req)) {
+    return undefined;
+  }
+
+  if (isRscRequest(req)) {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return new NextResponse("Authentication required", {
+        status: 401,
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+        },
+      });
+    }
+
     return undefined;
   }
 

--- a/apps/main/tests/proxy-seller-funnel.test.ts
+++ b/apps/main/tests/proxy-seller-funnel.test.ts
@@ -68,7 +68,7 @@ describe("seller funnel proxy protection", () => {
     expect(authProtectMock).not.toHaveBeenCalled();
   });
 
-  it("delegates dashboard RSC auth handling to Clerk without an auth-error redirect", async () => {
+  it("fails signed-out dashboard RSC requests closed without an external redirect", async () => {
     const request = new NextRequest(
       "http://localhost:3000/dashboard/listings?_rsc=test",
       {
@@ -83,11 +83,61 @@ describe("seller funnel proxy protection", () => {
 
     const response = await proxy(request, middlewareEvent);
 
+    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(authProtectMock).not.toHaveBeenCalled();
+    expect(response?.status).toBe(401);
+    expect(response?.headers.get("location")).toBeNull();
+  });
+
+  it("allows signed-in dashboard RSC requests through", async () => {
+    authMock.mockResolvedValueOnce({ userId: "user_123" });
+
+    const request = new NextRequest(
+      "http://localhost:3000/dashboard/listings?_rsc=test",
+      {
+        headers: {
+          accept: "text/x-component",
+          "next-url": "/dashboard",
+          "sec-fetch-dest": "empty",
+        },
+      },
+    );
+    const middlewareEvent = {} as Parameters<NextMiddleware>[1];
+
+    const response = await proxy(request, middlewareEvent);
+
+    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(authProtectMock).not.toHaveBeenCalled();
+    expect(response).toBeUndefined();
+  });
+
+  it("fails signed-out onboarding RSC requests closed without an external redirect", async () => {
+    const request = new NextRequest("http://localhost:3000/onboarding?_rsc=test", {
+      headers: {
+        accept: "text/x-component",
+        "next-url": "/start-membership",
+        "sec-fetch-dest": "empty",
+      },
+    });
+    const middlewareEvent = {} as Parameters<NextMiddleware>[1];
+
+    const response = await proxy(request, middlewareEvent);
+
+    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(authProtectMock).not.toHaveBeenCalled();
+    expect(response?.status).toBe(401);
+    expect(response?.headers.get("location")).toBeNull();
+  });
+
+  it("delegates dashboard document navigation protection to Clerk", async () => {
+    const request = new NextRequest("http://localhost:3000/dashboard/listings");
+    const middlewareEvent = {} as Parameters<NextMiddleware>[1];
+
+    const response = await proxy(request, middlewareEvent);
+
     expect(authProtectMock).toHaveBeenCalledTimes(1);
     expect(authMock).not.toHaveBeenCalled();
-    expect(response?.headers.get("location") ?? "").not.toContain(
-      "/auth-error",
-    );
+    expect(response).toBeUndefined();
   });
 
   it("delegates onboarding protection to Clerk", async () => {


### PR DESCRIPTION
## Summary

Fixes the post-sign-out/App Router console failure where protected `_rsc` fetches were redirected to Clerk hosted sign-in on `accounts.daylilycatalog.com`, causing browser CORS failures.

Protected RSC requests now still fail closed, but signed-out users receive a same-origin `401` response instead of an external redirect. Normal document navigations continue to delegate to Clerk via `auth.protect()`.

## Validation

- `pnpm exec vitest run tests/proxy-seller-funnel.test.ts tests/proxy-matcher.test.ts`
- `pnpm exec eslint src/proxy.ts tests/proxy-seller-funnel.test.ts`

`pnpm typecheck` is currently blocked by unrelated generated Prisma/dependency drift in `ImageAsset` types and missing `sharp` declarations on current `origin/main`.