### PR TITLE
fix(auth): keep protected RSC auth responses same-origin

### DIFF
--- a/apps/main/src/proxy.ts
+++ b/apps/main/src/proxy.ts
@@ -38,14 +38,43 @@ const publicAgentDiscoveryPaths = new Set([
   "/llms-full.txt",
 ]);
 
+function isDocumentNavigation(req: NextRequest) {
+  const accept = req.headers.get("accept") ?? "";
+  const secFetchDest = req.headers.get("sec-fetch-dest");
+
+  return (
+    secFetchDest === "document" ||
+    secFetchDest === "iframe" ||
+    accept.includes("text/html")
+  );
+}
+
 const protectedRouteProxy = clerkMiddleware(async (auth, req) => {
   if (!isProtectedRoute(req)) {
     return undefined;
   }
 
-  await auth.protect();
+  const { isAuthenticated, redirectToSignIn } = await auth();
 
-  return undefined;
+  if (isAuthenticated) {
+    return undefined;
+  }
+
+  if (isDocumentNavigation(req)) {
+    return redirectToSignIn({
+      returnBackUrl: new URL(
+        `${req.nextUrl.pathname}${req.nextUrl.search}`,
+        req.url,
+      ),
+    });
+  }
+
+  return new NextResponse(null, {
+    status: 404,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
 });
 
 export function proxy(req: NextRequest, event: NextFetchEvent) {

--- a/apps/main/tests/proxy-seller-funnel.test.ts
+++ b/apps/main/tests/proxy-seller-funnel.test.ts
@@ -1,18 +1,12 @@
 // @vitest-environment node
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { NextRequest, type NextMiddleware } from "next/server";
+import { NextRequest, NextResponse, type NextMiddleware } from "next/server";
 
-const { authMock, authProtectMock } = vi.hoisted(() => {
-  const protect = vi.fn(async () => undefined);
-  return {
-    authProtectMock: protect,
-    authMock: Object.assign(
-      vi.fn(async () => ({ userId: null as string | null })),
-      { protect },
-    ),
-  };
-});
+const { authMock, redirectToSignInMock } = vi.hoisted(() => ({
+  redirectToSignInMock: vi.fn(),
+  authMock: vi.fn(),
+}));
 const createRouteMatcherMock = vi.hoisted(() =>
   vi.fn((routes: string[]) => {
     return (request: NextRequest) => {
@@ -47,6 +41,16 @@ describe("seller funnel proxy protection", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
+
+    redirectToSignInMock.mockReturnValue(
+      NextResponse.redirect("https://accounts.daylilycatalog.com/sign-in"),
+    );
+
+    authMock.mockResolvedValue({
+      isAuthenticated: true,
+      redirectToSignIn: redirectToSignInMock,
+    });
+
     ({ proxy } = await import("@/proxy"));
   });
 
@@ -65,10 +69,55 @@ describe("seller funnel proxy protection", () => {
 
     expect(response).toBeUndefined();
     expect(authMock).not.toHaveBeenCalled();
-    expect(authProtectMock).not.toHaveBeenCalled();
+    expect(redirectToSignInMock).not.toHaveBeenCalled();
   });
 
-  it("delegates dashboard RSC auth handling to Clerk without an auth-error redirect", async () => {
+  it("allows authenticated dashboard access", async () => {
+    const request = new NextRequest("http://localhost:3000/dashboard/listings");
+    const middlewareEvent = {} as Parameters<NextMiddleware>[1];
+
+    const response = await proxy(request, middlewareEvent);
+
+    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(response).toBeUndefined();
+    expect(redirectToSignInMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects unauthenticated dashboard document navigations through Clerk", async () => {
+    const clerkRedirect = NextResponse.redirect(
+      "https://accounts.daylilycatalog.com/sign-in",
+    );
+
+    redirectToSignInMock.mockReturnValueOnce(clerkRedirect);
+    authMock.mockResolvedValueOnce({
+      isAuthenticated: false,
+      redirectToSignIn: redirectToSignInMock,
+    });
+
+    const request = new NextRequest("http://localhost:3000/dashboard/listings", {
+      headers: {
+        accept: "text/html",
+        "sec-fetch-dest": "document",
+      },
+    });
+    const middlewareEvent = {} as Parameters<NextMiddleware>[1];
+
+    const response = await proxy(request, middlewareEvent);
+
+    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(redirectToSignInMock).toHaveBeenCalledTimes(1);
+    expect(redirectToSignInMock).toHaveBeenCalledWith({
+      returnBackUrl: new URL("/dashboard/listings", "http://localhost:3000"),
+    });
+    expect(response).toBe(clerkRedirect);
+  });
+
+  it("returns 404 without redirect for unauthenticated dashboard RSC requests", async () => {
+    authMock.mockResolvedValueOnce({
+      isAuthenticated: false,
+      redirectToSignIn: redirectToSignInMock,
+    });
+
     const request = new NextRequest(
       "http://localhost:3000/dashboard/listings?_rsc=test",
       {
@@ -83,34 +132,72 @@ describe("seller funnel proxy protection", () => {
 
     const response = await proxy(request, middlewareEvent);
 
-    expect(authProtectMock).toHaveBeenCalledTimes(1);
-    expect(authMock).not.toHaveBeenCalled();
-    expect(response?.headers.get("location") ?? "").not.toContain(
-      "/auth-error",
-    );
+    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(redirectToSignInMock).not.toHaveBeenCalled();
+    expect(response?.status).toBe(404);
+    expect(response?.headers.get("location")).toBeNull();
+    expect(response?.headers.get("cache-control")).toBe("no-store");
   });
 
-  it("delegates onboarding protection to Clerk", async () => {
-    const request = new NextRequest("http://localhost:3000/onboarding");
+  it("redirects unauthenticated onboarding document navigations through Clerk", async () => {
+    const clerkRedirect = NextResponse.redirect(
+      "https://accounts.daylilycatalog.com/sign-in",
+    );
+
+    redirectToSignInMock.mockReturnValueOnce(clerkRedirect);
+    authMock.mockResolvedValueOnce({
+      isAuthenticated: false,
+      redirectToSignIn: redirectToSignInMock,
+    });
+
+    const request = new NextRequest("http://localhost:3000/onboarding", {
+      headers: {
+        accept: "text/html",
+        "sec-fetch-dest": "document",
+      },
+    });
     const middlewareEvent = {} as Parameters<NextMiddleware>[1];
 
     const response = await proxy(request, middlewareEvent);
 
-    expect(authProtectMock).toHaveBeenCalledTimes(1);
-    expect(authMock).not.toHaveBeenCalled();
-    expect(response).toBeUndefined();
+    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(redirectToSignInMock).toHaveBeenCalledWith({
+      returnBackUrl: new URL("/onboarding", "http://localhost:3000"),
+    });
+    expect(response).toBe(clerkRedirect);
   });
 
-  it("runs Clerk middleware for subscribe success", async () => {
+  it("redirects unauthenticated subscribe success document navigations through Clerk", async () => {
+    const clerkRedirect = NextResponse.redirect(
+      "https://accounts.daylilycatalog.com/sign-in",
+    );
+
+    redirectToSignInMock.mockReturnValueOnce(clerkRedirect);
+    authMock.mockResolvedValueOnce({
+      isAuthenticated: false,
+      redirectToSignIn: redirectToSignInMock,
+    });
+
     const request = new NextRequest(
       "http://localhost:3000/subscribe/success?redirect=/dashboard",
+      {
+        headers: {
+          accept: "text/html",
+          "sec-fetch-dest": "document",
+        },
+      },
     );
     const middlewareEvent = {} as Parameters<NextMiddleware>[1];
 
     const response = await proxy(request, middlewareEvent);
 
-    expect(authProtectMock).toHaveBeenCalledTimes(1);
-    expect(authMock).not.toHaveBeenCalled();
-    expect(response).toBeUndefined();
+    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(redirectToSignInMock).toHaveBeenCalledWith({
+      returnBackUrl: new URL(
+        "/subscribe/success?redirect=/dashboard",
+        "http://localhost:3000",
+      ),
+    });
+    expect(response).toBe(clerkRedirect);
   });
 });


### PR DESCRIPTION
## Summary

- returns a same-origin 404/no-store response for unauthenticated protected RSC requests instead of redirecting them to Clerk sign-in
- keeps unauthenticated document navigations on Clerk sign-in handling with returnBackUrl
- covers dashboard RSC, document navigation, onboarding, subscribe-success, and public route behavior in proxy tests

## Clerk docs basis

- Clerk documents `auth.protect()` for automatic protection and `auth().isAuthenticated` when the app needs more control: https://clerk.com/docs/reference/nextjs/clerk-middleware
- Clerk documents `redirectToSignIn({ returnBackUrl })` as the server-side sign-in redirect helper: https://clerk.com/docs/reference/nextjs/app-router/auth
- Clerk documents that `auth.protect()` returns 404 for unauthenticated non-document requests with session-token auth: https://clerk.com/docs/reference/nextjs/app-router/auth
- Clerk's default pending-session behavior treats pending sessions as signed out, so this PR intentionally does not pass `treatPendingAsSignedOut: false`: https://clerk.com/docs/guides/configure/session-tasks

## Validation

- pnpm exec vitest run tests/proxy-seller-funnel.test.ts tests/proxy-matcher.test.ts
- pnpm typecheck
- pnpm exec eslint src/proxy.ts tests/proxy-seller-funnel.test.ts
- prod-like local Docker smoke through https://dev.daylilycatalog.com/
- codex review --uncommitted
