### PR TITLE
Fix edit listing generated cultivar thumbnail

### DIFF
--- a/apps/main/src/components/ahs-listing-link.tsx
+++ b/apps/main/src/components/ahs-listing-link.tsx
@@ -18,6 +18,7 @@ import {
   reportError,
 } from "@/lib/error-utils";
 import type { RouterOutputs } from "@/trpc/react";
+import type { OptimizedImageSource } from "@/components/optimized-image";
 import {
   linkAhs,
   syncAhsName,
@@ -30,6 +31,7 @@ type CultivarReferenceAhsListing =
 interface AhsListingLinkProps {
   listing: RouterOutputs["dashboardDb"]["listing"]["list"][number];
   linkedAhs: CultivarReferenceAhsListing | null;
+  cultivarReferenceImage?: OptimizedImageSource | null;
   onNameChange?: (name: string) => void;
   onMutationSuccess?: () => void;
 }
@@ -37,6 +39,7 @@ interface AhsListingLinkProps {
 export function AhsListingLink({
   listing,
   linkedAhs,
+  cultivarReferenceImage,
   onNameChange,
   onMutationSuccess,
 }: AhsListingLinkProps) {
@@ -163,7 +166,10 @@ export function AhsListingLink({
                 </Button>
               </div>
             </div>
-            <AhsListingDisplay ahsListing={linkedAhs} />
+            <AhsListingDisplay
+              ahsListing={linkedAhs}
+              cultivarReferenceImage={cultivarReferenceImage}
+            />
           </CardContent>
         </Card>
       ) : (

--- a/apps/main/src/components/forms/listing-form-sections.tsx
+++ b/apps/main/src/components/forms/listing-form-sections.tsx
@@ -11,6 +11,8 @@ import { type ListingCollectionItem } from "@/app/dashboard/_lib/dashboard-db/li
 import { type CultivarReferenceCollectionItem } from "@/app/dashboard/_lib/dashboard-db/cultivar-references-collection";
 
 type LinkedAhsListing = CultivarReferenceCollectionItem["ahsListing"];
+type LinkedCultivarReferenceImage =
+  CultivarReferenceCollectionItem["cultivarReferenceImage"];
 
 export function ListingMediaSection({
   images,
@@ -75,11 +77,13 @@ export function ListingListsSection({
 
 export function ListingCultivarLinkSection({
   linkedAhs,
+  linkedCultivarReferenceImage,
   listing,
   onMutationSuccess,
   onNameChange,
 }: {
   linkedAhs: LinkedAhsListing | null;
+  linkedCultivarReferenceImage: LinkedCultivarReferenceImage | null;
   listing: ListingCollectionItem;
   onMutationSuccess: () => void;
   onNameChange: (name: string) => void;
@@ -92,6 +96,7 @@ export function ListingCultivarLinkSection({
       <AhsListingLink
         listing={listing}
         linkedAhs={linkedAhs}
+        cultivarReferenceImage={linkedCultivarReferenceImage}
         onNameChange={onNameChange}
         onMutationSuccess={onMutationSuccess}
       />

--- a/apps/main/src/components/forms/listing-form.tsx
+++ b/apps/main/src/components/forms/listing-form.tsx
@@ -62,6 +62,8 @@ import {
 import { useListingEditorResource } from "@/hooks/use-listing-editor-resource";
 
 type LinkedAhsListing = CultivarReferenceCollectionItem["ahsListing"];
+type LinkedCultivarReferenceImage =
+  CultivarReferenceCollectionItem["cultivarReferenceImage"];
 
 interface ListingFormProps {
   listingId: string;
@@ -105,6 +107,7 @@ function useListingFormController({
   listingId,
   listing,
   linkedAhs,
+  linkedCultivarReferenceImage,
   images,
   selectedListIds,
   onDelete,
@@ -113,6 +116,7 @@ function useListingFormController({
   listingId: string;
   listing: ListingCollectionItem;
   linkedAhs: LinkedAhsListing | null;
+  linkedCultivarReferenceImage: LinkedCultivarReferenceImage | null;
   images: Image[];
   selectedListIds: string[];
   onDelete: () => void;
@@ -282,6 +286,7 @@ function useListingFormController({
     isBusy,
     isDeleteDialogOpen,
     linkedAhs,
+    linkedCultivarReferenceImage,
     listing,
     listingId,
     markNeedsParentCommit,
@@ -312,6 +317,7 @@ function ListingFormFields({
   isBusy,
   isDeleteDialogOpen,
   linkedAhs,
+  linkedCultivarReferenceImage,
   listing,
   listingId,
   markNeedsParentCommit,
@@ -462,6 +468,7 @@ function ListingFormFields({
         <ListingCultivarLinkSection
           listing={listing}
           linkedAhs={linkedAhs}
+          linkedCultivarReferenceImage={linkedCultivarReferenceImage}
           onNameChange={(name) => {
             form.setValue("title", name);
           }}
@@ -499,8 +506,14 @@ function ListingFormFields({
 }
 
 function ListingFormLive({ listingId, onDelete, formRef }: ListingFormProps) {
-  const { images, isReady, linkedAhs, listing, selectedListIds } =
-    useListingEditorResource(listingId);
+  const {
+    images,
+    isReady,
+    linkedAhs,
+    linkedCultivarReferenceImage,
+    listing,
+    selectedListIds,
+  } = useListingEditorResource(listingId);
 
   if (!isReady || !listing) {
     return <ListingFormSkeleton />;
@@ -511,6 +524,7 @@ function ListingFormLive({ listingId, onDelete, formRef }: ListingFormProps) {
       listingId={listingId}
       listing={listing}
       linkedAhs={linkedAhs}
+      linkedCultivarReferenceImage={linkedCultivarReferenceImage}
       images={images}
       selectedListIds={selectedListIds}
       onDelete={onDelete}

--- a/apps/main/src/hooks/use-listing-editor-resource.ts
+++ b/apps/main/src/hooks/use-listing-editor-resource.ts
@@ -14,11 +14,14 @@ import { imagesCollection } from "@/app/dashboard/_lib/dashboard-db/images-colle
 import { listsCollection } from "@/app/dashboard/_lib/dashboard-db/lists-collection";
 
 type LinkedAhsListing = CultivarReferenceCollectionItem["ahsListing"];
+type LinkedCultivarReferenceImage =
+  CultivarReferenceCollectionItem["cultivarReferenceImage"];
 
 export interface ListingEditorResource {
   images: Image[];
   isReady: boolean;
   linkedAhs: LinkedAhsListing | null;
+  linkedCultivarReferenceImage: LinkedCultivarReferenceImage | null;
   listing: ListingCollectionItem | null;
   selectedListIds: string[];
 }
@@ -59,10 +62,14 @@ export function useListingEditorResource(
     .filter((list) => list.listings.some(({ id }) => id === listingId))
     .map((list) => list.id);
 
-  const linkedAhs = listing?.cultivarReferenceId
-    ? (cultivarReferences.find((row) => row.id === listing.cultivarReferenceId)
-        ?.ahsListing ?? null)
+  const linkedCultivarReference = listing?.cultivarReferenceId
+    ? (cultivarReferences.find(
+        (row) => row.id === listing.cultivarReferenceId,
+      ) ?? null)
     : null;
+  const linkedAhs = linkedCultivarReference?.ahsListing ?? null;
+  const linkedCultivarReferenceImage =
+    linkedCultivarReference?.cultivarReferenceImage ?? null;
 
   return {
     images,
@@ -73,6 +80,7 @@ export function useListingEditorResource(
       isListsReady &&
       !!listing,
     linkedAhs,
+    linkedCultivarReferenceImage,
     listing,
     selectedListIds,
   };


### PR DESCRIPTION
## Summary
- derive the linked cultivar reference once in the listing editor resource hook
- pass its resolved cultivar reference image through the edit listing form
- render the linked AHS listing display with that image so generated cultivar assets are used when enabled

## Verification
- reset cleanly from refreshed origin/main before changes
- attempted local `pnpm main typecheck` and `pnpm main lint`; both ran silently for several minutes and were stopped so CI can run the checks on the PR