### PR TITLE
[codex] Add opt-in memory telemetry

### DIFF
--- a/apps/main/docs/vps-memory-first-principles.md
+++ b/apps/main/docs/vps-memory-first-principles.md
@@ -1,0 +1,25 @@
+# VPS Memory First Principles
+
+## Opt-in memory telemetry
+
+Production memory telemetry is disabled by default. To turn it on for the VPS
+container, set:
+
+```sh
+MEMORY_TELEMETRY_ENABLED=1
+```
+
+The server logs single-line JSON from the long-lived Next Node process:
+
+- `v8_heap_limit`: emitted once at process boot with the V8 heap size limit.
+- `process_memory`: emitted every 60 seconds with `rss`, `heapTotal`,
+  `heapUsed`, `external`, and `arrayBuffers`.
+
+Interpretation:
+
+- `heapUsed` rising monotonically means JavaScript heap growth.
+- `external` or `arrayBuffers` rising while `heapUsed` is stable suggests
+  off-heap, native, or Next response-buffer growth.
+- `rss` rising while `heapUsed`, `external`, and `arrayBuffers` are stable
+  suggests allocator behavior, page cache, or pressure outside these Node
+  memory fields.

--- a/apps/main/src/instrumentation.ts
+++ b/apps/main/src/instrumentation.ts
@@ -5,6 +5,13 @@ import { getRuntimeSentryEnabled } from "@/lib/observability-env";
 const isSentryEnabled = getRuntimeSentryEnabled();
 
 export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { startMemoryTelemetry } = await import(
+      "@/server/observability/memory-telemetry"
+    );
+    startMemoryTelemetry();
+  }
+
   if (!isSentryEnabled) {
     return;
   }

--- a/apps/main/src/server/observability/memory-telemetry.ts
+++ b/apps/main/src/server/observability/memory-telemetry.ts
@@ -1,0 +1,136 @@
+import "server-only";
+
+import v8 from "node:v8";
+
+const MEMORY_TELEMETRY_ENABLED_ENV = "MEMORY_TELEMETRY_ENABLED";
+const MEMORY_TELEMETRY_STARTED_KEY = Symbol.for(
+  "daylily-catalog.memory-telemetry-started",
+);
+const MEMORY_TELEMETRY_INTERVAL_MS = 60_000;
+
+type MemoryTelemetryEnv = Record<string, string | undefined>;
+
+interface MemoryTelemetryGlobal {
+  [MEMORY_TELEMETRY_STARTED_KEY]?: boolean;
+}
+
+interface MemoryTelemetryTimer {
+  unref?: () => void;
+}
+
+interface MemoryTelemetryDeps {
+  env?: MemoryTelemetryEnv;
+  globalState?: MemoryTelemetryGlobal;
+  getHeapSizeLimit?: () => number;
+  getMemoryUsage?: () => NodeJS.MemoryUsage;
+  getNodeVersion?: () => string;
+  getPid?: () => number;
+  getTimestamp?: () => string;
+  getUptimeSeconds?: () => number;
+  log?: (message: string) => void;
+  setIntervalFn?: (
+    callback: () => void,
+    delayMs: number,
+  ) => MemoryTelemetryTimer;
+}
+
+export function isMemoryTelemetryEnabled(env: MemoryTelemetryEnv = process.env) {
+  return env[MEMORY_TELEMETRY_ENABLED_ENV] === "1";
+}
+
+export function createV8HeapLimitEvent({
+  heapSizeLimit,
+  nodeVersion,
+  pid,
+  timestamp,
+}: {
+  heapSizeLimit: number;
+  nodeVersion: string;
+  pid: number;
+  timestamp: string;
+}) {
+  return {
+    event: "v8_heap_limit",
+    timestamp,
+    pid,
+    nodeVersion,
+    heap_size_limit: heapSizeLimit,
+  };
+}
+
+export function createProcessMemoryEvent({
+  memoryUsage,
+  pid,
+  timestamp,
+  uptimeSeconds,
+}: {
+  memoryUsage: NodeJS.MemoryUsage;
+  pid: number;
+  timestamp: string;
+  uptimeSeconds: number;
+}) {
+  return {
+    event: "process_memory",
+    timestamp,
+    pid,
+    uptimeSeconds,
+    rss: memoryUsage.rss,
+    heapTotal: memoryUsage.heapTotal,
+    heapUsed: memoryUsage.heapUsed,
+    external: memoryUsage.external,
+    arrayBuffers: memoryUsage.arrayBuffers,
+  };
+}
+
+export function startMemoryTelemetry(deps: MemoryTelemetryDeps = {}) {
+  const env = deps.env ?? process.env;
+  if (!isMemoryTelemetryEnabled(env)) {
+    return false;
+  }
+
+  const globalState =
+    deps.globalState ?? (globalThis as unknown as MemoryTelemetryGlobal);
+  if (globalState[MEMORY_TELEMETRY_STARTED_KEY]) {
+    return false;
+  }
+
+  globalState[MEMORY_TELEMETRY_STARTED_KEY] = true;
+
+  const getTimestamp = deps.getTimestamp ?? (() => new Date().toISOString());
+  const getPid = deps.getPid ?? (() => process.pid);
+  const log = deps.log ?? console.log;
+
+  log(
+    JSON.stringify(
+      createV8HeapLimitEvent({
+        heapSizeLimit:
+          deps.getHeapSizeLimit?.() ?? v8.getHeapStatistics().heap_size_limit,
+        nodeVersion: deps.getNodeVersion?.() ?? process.version,
+        pid: getPid(),
+        timestamp: getTimestamp(),
+      }),
+    ),
+  );
+
+  const logProcessMemory = () => {
+    log(
+      JSON.stringify(
+        createProcessMemoryEvent({
+          memoryUsage: deps.getMemoryUsage?.() ?? process.memoryUsage(),
+          pid: getPid(),
+          timestamp: getTimestamp(),
+          uptimeSeconds: deps.getUptimeSeconds?.() ?? process.uptime(),
+        }),
+      ),
+    );
+  };
+
+  const timer = (
+    deps.setIntervalFn ??
+    ((callback, delayMs) =>
+      setInterval(callback, delayMs) as unknown as MemoryTelemetryTimer)
+  )(logProcessMemory, MEMORY_TELEMETRY_INTERVAL_MS);
+
+  timer.unref?.();
+  return true;
+}

--- a/apps/main/tests/memory-telemetry.test.ts
+++ b/apps/main/tests/memory-telemetry.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+describe("memory telemetry", () => {
+  it("does not log or start an interval when disabled", async () => {
+    const { startMemoryTelemetry } = await import(
+      "@/server/observability/memory-telemetry"
+    );
+    const log = vi.fn();
+    const setIntervalFn = vi.fn();
+
+    const started = startMemoryTelemetry({
+      env: {},
+      globalState: {},
+      log,
+      setIntervalFn,
+    });
+
+    expect(started).toBe(false);
+    expect(log).not.toHaveBeenCalled();
+    expect(setIntervalFn).not.toHaveBeenCalled();
+  });
+
+  it("logs the boot event and process memory JSON shape when enabled", async () => {
+    const { startMemoryTelemetry } = await import(
+      "@/server/observability/memory-telemetry"
+    );
+    const log = vi.fn();
+    const unref = vi.fn();
+    let intervalCallback: (() => void) | undefined;
+    const setIntervalFn = vi.fn((callback: () => void) => {
+      intervalCallback = callback;
+      return { unref };
+    });
+
+    const started = startMemoryTelemetry({
+      env: { MEMORY_TELEMETRY_ENABLED: "1" },
+      getHeapSizeLimit: () => 4_294_967_296,
+      getMemoryUsage: () => ({
+        rss: 101,
+        heapTotal: 202,
+        heapUsed: 303,
+        external: 404,
+        arrayBuffers: 505,
+      }),
+      getNodeVersion: () => "v99.0.0",
+      getPid: () => 1234,
+      getTimestamp: () => "2026-07-02T20:00:00.000Z",
+      getUptimeSeconds: () => 61.5,
+      globalState: {},
+      log,
+      setIntervalFn,
+    });
+
+    expect(started).toBe(true);
+    expect(setIntervalFn).toHaveBeenCalledWith(expect.any(Function), 60_000);
+    expect(unref).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(log.mock.calls[0]?.[0] as string)).toEqual({
+      event: "v8_heap_limit",
+      timestamp: "2026-07-02T20:00:00.000Z",
+      pid: 1234,
+      nodeVersion: "v99.0.0",
+      heap_size_limit: 4_294_967_296,
+    });
+
+    intervalCallback?.();
+
+    expect(JSON.parse(log.mock.calls[1]?.[0] as string)).toEqual({
+      event: "process_memory",
+      timestamp: "2026-07-02T20:00:00.000Z",
+      pid: 1234,
+      uptimeSeconds: 61.5,
+      rss: 101,
+      heapTotal: 202,
+      heapUsed: 303,
+      external: 404,
+      arrayBuffers: 505,
+    });
+  });
+
+  it("does not create duplicate intervals for repeated initialization", async () => {
+    const { startMemoryTelemetry } = await import(
+      "@/server/observability/memory-telemetry"
+    );
+    const globalState = {};
+    const log = vi.fn();
+    const setIntervalFn = vi.fn(() => ({ unref: vi.fn() }));
+    const deps = {
+      env: { MEMORY_TELEMETRY_ENABLED: "1" },
+      getHeapSizeLimit: () => 1,
+      getMemoryUsage: () => process.memoryUsage(),
+      getNodeVersion: () => "v99.0.0",
+      getPid: () => 1234,
+      getTimestamp: () => "2026-07-02T20:00:00.000Z",
+      getUptimeSeconds: () => 1,
+      globalState,
+      log,
+      setIntervalFn,
+    };
+
+    expect(startMemoryTelemetry(deps)).toBe(true);
+    expect(startMemoryTelemetry(deps)).toBe(false);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(setIntervalFn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds opt-in server-side memory telemetry for the self-hosted Next standalone process so VPS logs can distinguish JS heap growth from off-heap/native growth.

## Changes

- Starts telemetry from `apps/main/src/instrumentation.ts` for the Node runtime only.
- Adds a server-only memory telemetry module guarded by `MEMORY_TELEMETRY_ENABLED=1` and a `globalThis` one-shot flag.
- Logs single-line JSON for `v8_heap_limit` at boot and `process_memory` every 60 seconds with an unref'd interval.
- Adds focused unit coverage for disabled mode, enabled JSON shape, `.unref()`, and duplicate initialization.
- Documents the VPS env flag and interpretation of `heapUsed`, `external`, `arrayBuffers`, and `rss`.

## Validation

- `pnpm main test -- memory-telemetry.test.ts`
- `pnpm main typecheck`
- `pnpm main lint` passed once; a later full rerun stayed silent for several minutes and was interrupted
- `pnpm --filter @daylily-catalog/main exec eslint src/instrumentation.ts src/server/observability/memory-telemetry.ts`
- Codex review found no actionable correctness issues; production build attempt was stopped due to runtime length, not a detected failure.