### PR TITLE
Document generated image catch-up import policy

### DIFF
--- a/apps/main/docs/generated-cultivar-image-catchup.md
+++ b/apps/main/docs/generated-cultivar-image-catchup.md
@@ -159,6 +159,16 @@ Export only the new local `ImageAsset` rows, inspect the SQL, and apply to
 production Turso only after explicit approval. This should remain a separate
 review step from generation/upload.
 
+For small catch-up batches where the SQL is only additive `ImageAsset` inserts,
+a Turso checkpoint branch is optional. The rollback path is deleting those exact
+new `ImageAsset.id` rows from production; uploaded R2 objects can be left
+orphaned or cleaned later. Still create a checkpoint branch for larger batches,
+schema changes, updates/deletes, manually edited SQL, or any import that is not
+trivially inspectable.
+
+Always keep the exported SQL path and exact imported `ImageAsset.id` values in
+the terminal/log output.
+
 After a production import, refresh or mirror the local prod copy before running
 `sync.mjs`; queue bookkeeping is based on the local DB.
 
@@ -217,6 +227,18 @@ a cleanup manifest under:
   `source_invalid` rows remain.
 - Cleaned imported generated/candidate artifacts, deleting 78 files and
   reclaiming 167.1 MB. Source originals were intentionally left untouched.
+
+## Import Record: 2026-07-04
+
+- Created Turso checkpoint branch
+  `daylily-catalog-pre-imgcatch-20260704-0809`.
+- Imported 13 generated cultivar `ImageAsset` rows to production.
+- Verification passed: 13 asset ids present, 13 ready cultivar assets, zero
+  duplicate ready cultivar-reference rows, and no foreign-key violations.
+- Review queue was synced afterward: 8734 `imported` rows and 3 known
+  `source_invalid` rows remain.
+- After this run, checkpoint branches are considered optional for small,
+  additive-only generated cultivar image imports.
 
 ## Related V2 Data Refresh
 

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/codex-native-image-generation.md
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/codex-native-image-generation.md
@@ -349,23 +349,33 @@ only after the image has been uploaded to R2 and a ready production `ImageAsset`
 row has been created.
 
 The generated cultivar backfill reads rows from the review DB where
-`status IN ('review', 'approved')` and `editedPath IS NOT NULL`. It uploads the
-edited image and variants to R2, then writes the production `ImageAsset`.
-
-With limited disk space, run the production import at low concurrency:
+`status IN ('review', 'approved')` and `editedPath IS NOT NULL`. The mature
+workflow is local-first:
 
 ```bash
-pnpm main env:prod node --input-type=module -e 'process.env.DATABASE_URL = process.env.TURSO_DATABASE_URL; process.env.IMAGE_ASSET_BACKFILL_CONCURRENCY = "1"; process.env.IMAGE_ASSET_BACKFILL_BATCH_SIZE = "50"; process.argv = [process.argv[0], "scripts/image-assets/backfill-generated-cultivar-images-to-r2.mjs", "--allow-remote-db", "--limit", "50"]; await import("./scripts/image-assets/backfill-generated-cultivar-images-to-r2.mjs");'
+cd apps/main
+
+set -a
+source ../../.env.production
+set +a
+
+DATABASE_URL=file:./prisma/local-prod-copy-daylily-catalog.db \
+IMAGE_ASSET_BACKFILL_CONCURRENCY=1 \
+  node scripts/image-assets/backfill-generated-cultivar-images-to-r2.mjs
 ```
 
 Notes:
 
-- `.env.production` may define `TURSO_DATABASE_URL` without `DATABASE_URL`; the
-  wrapper above maps it for the backfill script.
-- Keep `IMAGE_ASSET_BACKFILL_CONCURRENCY=1` when disk is almost full.
-- Record the exact `cultivarReferenceId` values printed as
-  `[backfilled-generated-cultivar]`.
-- Only delete local files for those exact imported ids.
+- The script uploads R2 objects and creates ready `ImageAsset` rows in the local
+  prod-copy database.
+- Export only those new local `ImageAsset` rows, inspect the SQL, then apply the
+  additive insert transaction to production Turso after approval.
+- A Turso checkpoint branch is optional for small additive-only `ImageAsset`
+  batches. Create one for larger batches, schema changes, updates/deletes,
+  manually edited SQL, or anything not trivially inspectable.
+- Record the exact `ImageAsset.id` and `cultivarReferenceId` values imported.
+- Only delete local files for those exact imported ids after production verify
+  and queue sync.
 
 After successful production import, either refresh the local prod-copy DB and
 run `sync.mjs`, or mark the exact imported ids as `imported` in


### PR DESCRIPTION
## Summary\n- document that Turso checkpoint branches are optional for small additive-only generated image imports\n- update Codex-native image generation notes to use the local-first R2/local DB backfill path\n- record the 2026-07-04 generated cultivar image import\n\n## Testing\n- not run; docs-only change