### PR TITLE
chore: ignore local advisor plans directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ apps/*/next-env.d.ts
 *.pem
 
 # local operator scratch space
+/plans/
 /downloads/
 /local/
 /temp/


### PR DESCRIPTION
## Summary
- Ignore the root `/plans/` directory so local improve-skill advisor plans stay on disk without showing up in `git status` or getting committed.
- Matches the existing local operator scratch pattern (`/local/`, `/downloads/`).

## Test plan
- [ ] Confirm `git check-ignore -v plans/README.md` reports `.gitignore` matching `/plans/`
- [ ] Confirm `git status` no longer lists `plans/` as untracked after creating files there

Made with [Cursor](https://cursor.com)