### PR TITLE
Fix production onboarding example cultivar IDs

### DIFF
--- a/apps/main/src/app/onboarding/anonymous-onboarding-config.ts
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-config.ts
@@ -130,9 +130,9 @@ export const ANONYMOUS_ONBOARDING_STEPS: {
 ];
 
 export const ONBOARDING_EXAMPLE_CULTIVAR_REFERENCE_IDS = [
-  "cr-v2-ahs-77248",
-  "cr-v2-ahs-71522",
-  "cr-v2-ahs-7847",
+  "cr-ahs-176320",
+  "cr-ahs-170157",
+  "cr-ahs-8527",
 ] as const;
 
 export function normalizeEmail(value: string) {

--- a/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
+++ b/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
@@ -45,7 +45,7 @@ export const DEFAULT_ANONYMOUS_ONBOARDING_PROFILE: AnonymousOnboardingProfileDra
     profileImageSource: null,
   };
 
-const DEFAULT_ANONYMOUS_ONBOARDING_CULTIVAR_KEY = "cr-v2-ahs-77248";
+const DEFAULT_ANONYMOUS_ONBOARDING_CULTIVAR_KEY = "cr-ahs-176320";
 
 export const DEFAULT_ANONYMOUS_ONBOARDING_LISTING: AnonymousOnboardingListingPreviewDraft =
   {

--- a/apps/main/tests/anonymous-onboarding-config.test.ts
+++ b/apps/main/tests/anonymous-onboarding-config.test.ts
@@ -148,9 +148,9 @@ describe("anonymous onboarding config", () => {
 
   it("requires configured example cultivars before building a listing preview", () => {
     expect(ONBOARDING_EXAMPLE_CULTIVAR_REFERENCE_IDS).toEqual([
-      "cr-v2-ahs-77248",
-      "cr-v2-ahs-71522",
-      "cr-v2-ahs-7847",
+      "cr-ahs-176320",
+      "cr-ahs-170157",
+      "cr-ahs-8527",
     ]);
 
     expect(() =>

--- a/apps/main/tests/anonymous-onboarding-draft.test.ts
+++ b/apps/main/tests/anonymous-onboarding-draft.test.ts
@@ -74,7 +74,7 @@ describe("anonymous onboarding draft storage", () => {
   it("keeps the example listing title empty until the user types one", () => {
     const draft = createAnonymousOnboardingDraft();
 
-    expect(draft.listingPreview.cultivarKey).toBe("cr-v2-ahs-77248");
+    expect(draft.listingPreview.cultivarKey).toBe("cr-ahs-176320");
     expect(draft.listingPreview.title).toBe("");
   });
 
@@ -96,7 +96,7 @@ describe("anonymous onboarding draft storage", () => {
       },
     });
 
-    expect(parsed?.listingPreview.cultivarKey).toBe("cr-v2-ahs-77248");
+    expect(parsed?.listingPreview.cultivarKey).toBe("cr-ahs-176320");
     expect(parsed?.listingPreview.title).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- point anonymous onboarding example cultivars at production cultivar reference IDs with ready generated image assets
- update the default anonymous draft cultivar key and matching tests

## Verification
- pnpm main test anonymous-onboarding-config.test.ts anonymous-onboarding-draft.test.ts
- pnpm main test onboarding-router.test.ts
- checked local production snapshot has display data and ready image assets for cr-ahs-176320, cr-ahs-170157, and cr-ahs-8527