### PR TITLE
test: characterize Stripe and Clerk webhooks

### DIFF
--- a/apps/main/tests/clerk-sync-user.test.ts
+++ b/apps/main/tests/clerk-sync-user.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/server/clerk/client", () => ({
+  getClerk: async () => ({ users: { getUser: mocks.getUser } }),
+}));
+
+vi.mock("@/server/db/kvStore", () => ({
+  kvStore: {
+    delete: vi.fn(),
+    get: mocks.cacheGet,
+    set: mocks.cacheSet,
+  },
+}));
+
+import { getClerkUserData, syncClerkUserToKV } from "@/server/clerk/sync-user";
+
+describe("Clerk user cache synchronization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cacheGet.mockResolvedValue(null);
+    mocks.cacheSet.mockResolvedValue(undefined);
+  });
+
+  it("stores the Clerk user with its primary email", async () => {
+    const clerkUser = {
+      id: "user_test",
+      firstName: "Ada",
+      primaryEmailAddress: { emailAddress: "ada@example.com" },
+    };
+    mocks.getUser.mockResolvedValue(clerkUser);
+
+    const result = await syncClerkUserToKV("user_test");
+
+    expect(result).toEqual({ ...clerkUser, email: "ada@example.com" });
+    expect(mocks.cacheSet).toHaveBeenCalledWith("clerk:user:user_test", result);
+  });
+
+  it("rejects users without a primary email", async () => {
+    mocks.getUser.mockResolvedValue({
+      id: "user_no_email",
+      primaryEmailAddress: null,
+    });
+
+    await expect(syncClerkUserToKV("user_no_email")).rejects.toThrow(
+      "User must have a primary email address",
+    );
+    expect(mocks.cacheSet).not.toHaveBeenCalled();
+  });
+
+  it("propagates Clerk lookup failures", async () => {
+    const error = new Error("Clerk unavailable");
+    mocks.getUser.mockRejectedValue(error);
+
+    await expect(syncClerkUserToKV("user_error")).rejects.toBe(error);
+    expect(mocks.cacheSet).not.toHaveBeenCalled();
+  });
+
+  it("returns a cached user without calling Clerk", async () => {
+    const cached = { id: "user_cached", email: "cached@example.com" };
+    mocks.cacheGet.mockResolvedValue(cached);
+
+    await expect(getClerkUserData("user_cached")).resolves.toBe(cached);
+    expect(mocks.getUser).not.toHaveBeenCalled();
+  });
+
+  it("synchronizes a user on a cache miss", async () => {
+    mocks.getUser.mockResolvedValue({
+      id: "user_miss",
+      primaryEmailAddress: { emailAddress: "miss@example.com" },
+    });
+
+    await expect(getClerkUserData("user_miss")).resolves.toMatchObject({
+      id: "user_miss",
+      email: "miss@example.com",
+    });
+    expect(mocks.cacheGet).toHaveBeenCalledWith("clerk:user:user_miss");
+    expect(mocks.getUser).toHaveBeenCalledWith("user_miss");
+  });
+});

--- a/apps/main/tests/clerk-webhook-route.test.ts
+++ b/apps/main/tests/clerk-webhook-route.test.ts
@@ -6,10 +6,18 @@ const mocks = vi.hoisted(() => ({
   event: {
     type: "user.deleted",
     data: { id: "user_deleted" },
-  },
+  } as { data: Record<string, unknown>; type: string },
+  captureEvent: vi.fn(),
+  headers: new Headers({
+    "svix-id": "msg_test",
+    "svix-signature": "sig_test",
+    "svix-timestamp": "1783616643",
+  }),
   keyValueDeleteMany: vi.fn(),
+  logUserAuth: vi.fn(),
   syncClerkUserToKV: vi.fn(),
   userUpsert: vi.fn(),
+  verifyError: null as Error | null,
 }));
 
 vi.mock("@/env", () => ({
@@ -18,18 +26,13 @@ vi.mock("@/env", () => ({
 }));
 
 vi.mock("next/headers", () => ({
-  headers: vi.fn(async () =>
-    new Headers({
-      "svix-id": "msg_test",
-      "svix-signature": "sig_test",
-      "svix-timestamp": "1783616643",
-    }),
-  ),
+  headers: vi.fn(async () => mocks.headers),
 }));
 
 vi.mock("svix", () => ({
   Webhook: class {
     verify() {
+      if (mocks.verifyError) throw mocks.verifyError;
       return mocks.event;
     }
   },
@@ -47,28 +50,120 @@ vi.mock("@/server/clerk/sync-user", () => ({
 }));
 
 vi.mock("@/server/analytics/posthog-server", () => ({
-  captureServerPosthogEvent: vi.fn(),
+  captureServerPosthogEvent: mocks.captureEvent,
 }));
 
 vi.mock("@/server/audit/user-action-audit", () => ({
-  logUserAuth: vi.fn(),
+  logUserAuth: mocks.logUserAuth,
 }));
+
+function request() {
+  return new Request("https://daylilycatalog.com/api/clerk-webhook", {
+    method: "POST",
+    body: JSON.stringify(mocks.event),
+  });
+}
 
 describe("Clerk webhook route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.event = { type: "user.deleted", data: { id: "user_deleted" } };
+    mocks.headers = new Headers({
+      "svix-id": "msg_test",
+      "svix-signature": "sig_test",
+      "svix-timestamp": "1783616643",
+    });
+    mocks.verifyError = null;
     mocks.keyValueDeleteMany.mockResolvedValue({ count: 1 });
+    mocks.syncClerkUserToKV.mockResolvedValue({ email: "user@example.com" });
+    mocks.userUpsert.mockResolvedValue({ id: "app_user" });
+  });
+
+  it("rejects requests without the Svix headers", async () => {
+    mocks.headers = new Headers();
+    const { POST } = await import("@/app/api/clerk-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Error occurred -- no svix headers",
+    });
+    expect(mocks.userUpsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects events that fail Svix verification", async () => {
+    mocks.verifyError = new Error("invalid signature");
+    const { POST } = await import("@/app/api/clerk-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Error occurred",
+    });
+    expect(mocks.userUpsert).not.toHaveBeenCalled();
+  });
+
+  it("creates and synchronizes a new user", async () => {
+    mocks.event = { type: "user.created", data: { id: "user_created" } };
+    const { POST } = await import("@/app/api/clerk-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.userUpsert).toHaveBeenCalledWith({
+      where: { clerkUserId: "user_created" },
+      create: { clerkUserId: "user_created" },
+      update: {},
+    });
+    expect(mocks.syncClerkUserToKV).toHaveBeenCalledWith("user_created");
+    expect(mocks.logUserAuth).toHaveBeenCalledWith({
+      action: "signup",
+      appUserId: "app_user",
+      clerkUserId: "user_created",
+      email: "user@example.com",
+      source: "clerk-webhook",
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      distinctId: "user_created",
+      event: "signup_completed",
+      properties: {
+        source: "clerk-webhook",
+        source_page: "/api/clerk-webhook",
+        user_id: "app_user",
+      },
+    });
+  });
+
+  it("uses the session user id for sign-in events", async () => {
+    mocks.event = {
+      type: "session.created",
+      data: { id: "session_test", user_id: "user_session" },
+    };
+    const { POST } = await import("@/app/api/clerk-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.userUpsert).toHaveBeenCalledWith({
+      where: { clerkUserId: "user_session" },
+      create: { clerkUserId: "user_session" },
+      update: {},
+    });
+    expect(mocks.logUserAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "signin",
+        clerkUserId: "user_session",
+      }),
+    );
+    expect(mocks.captureEvent).not.toHaveBeenCalled();
   });
 
   it("acknowledges a deleted user without recreating or refetching it", async () => {
     const { POST } = await import("@/app/api/clerk-webhook/route");
 
-    const response = await POST(
-      new Request("https://daylilycatalog.com/api/clerk-webhook", {
-        method: "POST",
-        body: JSON.stringify(mocks.event),
-      }),
-    );
+    const response = await POST(request());
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
@@ -76,6 +171,33 @@ describe("Clerk webhook route", () => {
     });
     expect(mocks.keyValueDeleteMany).toHaveBeenCalledWith({
       where: { key: "clerk:user:user_deleted" },
+    });
+    expect(mocks.userUpsert).not.toHaveBeenCalled();
+    expect(mocks.syncClerkUserToKV).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when user processing fails", async () => {
+    mocks.event = { type: "user.updated", data: { id: "user_error" } };
+    mocks.userUpsert.mockRejectedValue(new Error("database unavailable"));
+    const { POST } = await import("@/app/api/clerk-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Error processing user",
+    });
+  });
+
+  it("acknowledges irrelevant events without processing a user", async () => {
+    mocks.event = { type: "organization.created", data: { id: "org_test" } };
+    const { POST } = await import("@/app/api/clerk-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      message: "Webhook received",
     });
     expect(mocks.userUpsert).not.toHaveBeenCalled();
     expect(mocks.syncClerkUserToKV).not.toHaveBeenCalled();

--- a/apps/main/tests/stripe-sync-subscription.test.ts
+++ b/apps/main/tests/stripe-sync-subscription.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
+  listSubscriptions: vi.fn(),
+  reportError: vi.fn(),
+}));
+
+vi.mock("@/server/stripe/client", () => ({
+  getStripeClient: () => ({
+    subscriptions: { list: mocks.listSubscriptions },
+  }),
+}));
+
+vi.mock("@/server/db/kvStore", () => ({
+  kvStore: {
+    delete: vi.fn(),
+    get: mocks.cacheGet,
+    set: mocks.cacheSet,
+  },
+}));
+
+vi.mock("@/lib/error-utils", () => ({
+  reportError: mocks.reportError,
+}));
+
+import {
+  getStripeSubscription,
+  syncStripeSubscriptionToKV,
+} from "@/server/stripe/sync-subscription";
+
+describe("Stripe subscription cache synchronization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cacheGet.mockResolvedValue(null);
+    mocks.cacheSet.mockResolvedValue(undefined);
+  });
+
+  it("stores a none status when the customer has no subscriptions", async () => {
+    mocks.listSubscriptions.mockResolvedValue({ data: [] });
+
+    await expect(syncStripeSubscriptionToKV("cus_none")).resolves.toEqual({
+      status: "none",
+    });
+    expect(mocks.listSubscriptions).toHaveBeenCalledWith({
+      customer: "cus_none",
+      limit: 1,
+      expand: ["data.default_payment_method"],
+    });
+    expect(mocks.cacheSet).toHaveBeenCalledWith("stripe:customer:cus_none", {
+      status: "none",
+    });
+  });
+
+  it("stores the mapped subscription and payment method", async () => {
+    mocks.listSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_test",
+          status: "trialing",
+          current_period_end: 200,
+          current_period_start: 100,
+          cancel_at_period_end: false,
+          default_payment_method: {
+            card: { brand: "visa", last4: "4242" },
+          },
+          items: {
+            data: [
+              {
+                price: { id: "price_test" },
+                current_period_end: 201,
+                current_period_start: 101,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await syncStripeSubscriptionToKV("cus_test");
+
+    expect(result).toEqual({
+      subscriptionId: "sub_test",
+      status: "trialing",
+      priceId: "price_test",
+      currentPeriodEnd: 200,
+      currentPeriodStart: 100,
+      cancelAtPeriodEnd: false,
+      paymentMethod: { brand: "visa", last4: "4242" },
+    });
+    expect(mocks.cacheSet).toHaveBeenCalledWith(
+      "stripe:customer:cus_test",
+      result,
+    );
+  });
+
+  it("returns a cached subscription without calling Stripe", async () => {
+    const cached = { subscriptionId: "sub_cached", status: "active" };
+    mocks.cacheGet.mockResolvedValue(cached);
+
+    await expect(getStripeSubscription("cus_cached")).resolves.toBe(cached);
+    expect(mocks.listSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it("reports a cache-miss sync failure and returns none", async () => {
+    mocks.listSubscriptions.mockRejectedValue(new Error("Stripe unavailable"));
+
+    await expect(getStripeSubscription("cus_error")).resolves.toEqual({
+      status: "none",
+    });
+    expect(mocks.reportError).toHaveBeenCalledOnce();
+    const report = mocks.reportError.mock.calls[0]?.[0] as {
+      context: Record<string, unknown>;
+      error: Error;
+    };
+    expect(report.error.message).toContain(
+      "Error fetching stripe subscription for user cus_error",
+    );
+    expect(report.context).toEqual({
+      source: "getStripeSubscription",
+      stripeCustomerId: "cus_error",
+    });
+  });
+});

--- a/apps/main/tests/stripe-webhook-route.test.ts
+++ b/apps/main/tests/stripe-webhook-route.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  captureEvent: vi.fn(),
+  constructEvent: vi.fn(),
+  findUser: vi.fn(),
+  funnelEvents: vi.fn(),
+  syncSubscription: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: { STRIPE_WEBHOOK_SECRET: "stripe_webhook_secret" },
+  requireEnv: (_name: string, value: string) => value,
+}));
+
+vi.mock("@/server/stripe/client", () => ({
+  getStripeClient: () => ({
+    webhooks: { constructEvent: mocks.constructEvent },
+  }),
+}));
+
+vi.mock("@/server/stripe/sync-subscription", () => ({
+  syncStripeSubscriptionToKV: mocks.syncSubscription,
+}));
+
+vi.mock("@/server/db", () => ({
+  db: { user: { findUnique: mocks.findUser } },
+}));
+
+vi.mock("@/server/analytics/posthog-server", () => ({
+  captureServerPosthogEvent: mocks.captureEvent,
+}));
+
+vi.mock("@/server/stripe/stripe-funnel-events", () => ({
+  getStripeFunnelEvents: mocks.funnelEvents,
+}));
+
+function request(signature = "sig_test") {
+  return new Request("https://daylilycatalog.com/api/stripe-webhook", {
+    method: "POST",
+    headers: signature ? { "stripe-signature": signature } : undefined,
+    body: JSON.stringify({ id: "evt_test" }),
+  });
+}
+
+describe("Stripe webhook route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findUser.mockResolvedValue({ clerkUserId: "user_test" });
+    mocks.funnelEvents.mockReturnValue([]);
+    mocks.syncSubscription.mockResolvedValue({ status: "active" });
+  });
+
+  it("rejects requests without a Stripe signature", async () => {
+    const { POST } = await import("@/app/api/stripe-webhook/route");
+
+    const response = await POST(request(""));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Missing stripe-signature header",
+    });
+    expect(mocks.constructEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid Stripe signature", async () => {
+    mocks.constructEvent.mockImplementation(() => {
+      throw new Error("invalid signature");
+    });
+    const { POST } = await import("@/app/api/stripe-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid signature",
+    });
+    expect(mocks.syncSubscription).not.toHaveBeenCalled();
+  });
+
+  it("syncs relevant customer events and records funnel events", async () => {
+    const event = {
+      type: "customer.subscription.created",
+      data: { object: { customer: "cus_test" } },
+    };
+    mocks.constructEvent.mockReturnValue(event);
+    mocks.funnelEvents.mockReturnValue([
+      { event: "trial_started", properties: { trigger: event.type } },
+    ]);
+    const { POST } = await import("@/app/api/stripe-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.syncSubscription).toHaveBeenCalledWith("cus_test");
+    expect(mocks.findUser).toHaveBeenCalledWith({
+      where: { stripeCustomerId: "cus_test" },
+      select: { clerkUserId: true },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      distinctId: "user_test",
+      event: "trial_started",
+      properties: {
+        trigger: event.type,
+        source_page: "/api/stripe-webhook",
+        stripe_customer_id: "cus_test",
+        synced_subscription_status: "active",
+      },
+    });
+  });
+
+  it("acknowledges relevant events without a customer id", async () => {
+    // Current behavior - plan 003 changes this to fail closed.
+    mocks.constructEvent.mockReturnValue({
+      type: "invoice.paid",
+      data: { object: {} },
+    });
+    const { POST } = await import("@/app/api/stripe-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.syncSubscription).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when subscription synchronization fails", async () => {
+    mocks.constructEvent.mockReturnValue({
+      type: "invoice.paid",
+      data: { object: { customer: "cus_test" } },
+    });
+    mocks.syncSubscription.mockRejectedValue(new Error("Stripe unavailable"));
+    const { POST } = await import("@/app/api/stripe-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Webhook processing failed",
+    });
+  });
+
+  it("acknowledges irrelevant events without synchronizing", async () => {
+    mocks.constructEvent.mockReturnValue({
+      type: "customer.created",
+      data: { object: { customer: "cus_test" } },
+    });
+    const { POST } = await import("@/app/api/stripe-webhook/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.syncSubscription).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed

- Add route-level characterization coverage for Stripe webhook signature, event-routing, synchronization, analytics, and failure paths.
- Extend the Clerk webhook route suite across signature verification, user creation, session sign-in, processing failures, irrelevant events, and the fixed `user.deleted` behavior from #252.
- Add focused tests for Stripe subscription and Clerk user cache synchronization, including cache hits, cache misses, mapping, and upstream failures.

## Why

These webhook and synchronization paths control authentication and paid membership state but had little direct boundary coverage. The characterization suite pins current behavior before the Stripe hardening work in Plan 003. No application source code changes in this PR.

## Validation

- `pnpm main test -- tests/stripe-webhook-route.test.ts tests/clerk-webhook-route.test.ts tests/stripe-sync-subscription.test.ts tests/clerk-sync-user.test.ts` (22 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- Prettier check
- `git diff --check`