### PR TITLE
Unify public navigation and footer

### DIFF
--- a/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-nav.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-nav.tsx
@@ -1,104 +1,41 @@
 "use client";
 
 import Link from "next/link";
-import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
-import { cn } from "@/lib/utils";
 
 interface CatalogNavProps {
   canonicalUserSlug: string;
   currentPage: number;
 }
 
-function getCatalogSearchHref(canonicalUserSlug: string, page: number) {
-  if (page > 1) {
-    return `/${canonicalUserSlug}/search?page=${page}`;
-  }
-
-  return `/${canonicalUserSlug}/search`;
-}
-
-export function CatalogNav({ canonicalUserSlug, currentPage }: CatalogNavProps) {
-  const searchHref = getCatalogSearchHref(canonicalUserSlug, currentPage);
+export function CatalogNav({
+  canonicalUserSlug,
+  currentPage,
+}: CatalogNavProps) {
+  const searchHref = `/${canonicalUserSlug}/search${
+    currentPage > 1 ? `?page=${currentPage}` : ""
+  }`;
   const sections = [
-    {
-      name: "Images",
-      href: "#images",
-    },
-    {
-      name: "About",
-      href: "#about",
-    },
-    {
-      name: "Lists",
-      href: "#lists",
-    },
-    {
-      name: "Listings",
-      href: "#listings",
-    },
-    {
-      name: "Search/filter",
-      href: searchHref,
-    },
+    { name: "Images", href: "#images" },
+    { name: "About", href: "#about" },
+    { name: "Lists", href: "#lists" },
+    { name: "Listings", href: "#listings" },
+    { name: "Search/filter", href: searchHref },
   ] as const;
 
-  const handleClick = (
-    e: React.MouseEvent<HTMLAnchorElement>,
-    href: string,
-  ) => {
-    if (!href.startsWith("#")) {
-      return;
-    }
-
-    e.preventDefault();
-    const sectionId = href.replace("#", "");
-    const section = document.getElementById(sectionId);
-    section?.scrollIntoView({ behavior: "smooth" });
-  };
-
   return (
-    <div className="relative">
-      <ScrollArea className="max-w-[600px] lg:max-w-none">
-        <div className={cn("flex items-center gap-4")}>
-          {sections.map((section) => {
-            return (
-              <NavLink
-                key={section.href}
-                section={section}
-                isActive={false}
-                onClick={(e) => handleClick(e, section.href)}
-              />
-            );
-          })}
-        </div>
-        <ScrollBar orientation="horizontal" className="invisible" />
-      </ScrollArea>
-    </div>
-  );
-}
-
-function NavLink({
-  section,
-  isActive,
-  onClick,
-}: {
-  section: { name: string; href: string };
-  isActive: boolean;
-  onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
-}) {
-  return (
-    <Link
-      href={section.href}
-      className={cn(
-        "flex h-7 items-center justify-center rounded-full",
-        "text-center text-sm font-medium",
-        "text-muted-foreground hover:text-primary transition-colors",
-        "data-[active=true]:bg-muted data-[active=true]:text-primary",
-      )}
-      data-active={isActive}
-      onClick={onClick}
-    >
-      {section.name}
-    </Link>
+    <nav aria-label="Catalog sections" className="overflow-x-auto">
+      <ul className="flex min-w-max items-center gap-4">
+        {sections.map((section) => (
+          <li key={section.href}>
+            <Link
+              href={section.href}
+              className="text-muted-foreground hover:text-primary text-sm font-medium transition-colors"
+            >
+              {section.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 }

--- a/apps/main/src/app/(public)/[userSlugOrId]/_components/profile-content.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_components/profile-content.tsx
@@ -27,7 +27,7 @@ export function ProfileContent({
         <div className="order-1 sm:order-2 sm:col-span-7">
           <ProfileSection profile={initialProfile} />
         </div>
-        <div className="order-2 sm:col-span-12 sm:hidden">
+        <div className="order-2 sm:order-3 sm:col-span-12">
           <CatalogNav
             canonicalUserSlug={canonicalUserSlug}
             currentPage={currentPage}
@@ -39,12 +39,6 @@ export function ProfileContent({
             profileTitle={initialProfile.title ?? undefined}
           />
         </div>
-      </div>
-      <div className="hidden sm:block">
-        <CatalogNav
-          canonicalUserSlug={canonicalUserSlug}
-          currentPage={currentPage}
-        />
       </div>
       <ContentSection content={initialProfile.content} />
     </>

--- a/apps/main/src/app/(public)/_components/home-page-client.tsx
+++ b/apps/main/src/app/(public)/_components/home-page-client.tsx
@@ -215,7 +215,7 @@ function LandingVariantTwoWithCatalogs({
     .slice(0, 6);
 
   return (
-    <div className="mx-auto overflow-hidden bg-[#07120e] text-white">
+    <div className="mx-auto -mt-16 overflow-hidden bg-[#07120e] text-white lg:-mt-20">
       <HomeHeroSection />
 
       <BuyerTestimonialsSection />
@@ -239,7 +239,7 @@ export default function HomePageClient({
 
 function HomeHeroSection() {
   return (
-    <section className="relative isolate overflow-hidden px-4 pt-24 pb-36 lg:px-8 lg:pt-20 lg:pb-32">
+    <section className="relative isolate overflow-hidden px-4 pt-24 pb-36 lg:px-8 lg:pt-24 lg:pb-32">
       <div className="absolute inset-0 -z-10 bg-[#07120e]" aria-hidden="true">
         <Image
           src="/assets/home-redesign/daylily-hero-grid.webp"

--- a/apps/main/src/app/(public)/layout.tsx
+++ b/apps/main/src/app/(public)/layout.tsx
@@ -1,7 +1,7 @@
-import { PublicHeader } from "@/components/public-nav";
 import { type Metadata } from "next";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
-import { PublicFooter } from "@/components/public-footer";
+import { PublicShell } from "@/components/public-shell";
+
 export const metadata: Metadata = {
   metadataBase: new URL(getCanonicalBaseUrl()),
 };
@@ -11,19 +11,5 @@ export default async function PublicLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div className="flex min-h-svh flex-col bg-[#f6f8f3] text-[#142118]">
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-[#142118] focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white"
-      >
-        Skip to content
-      </a>
-      <PublicHeader />
-      <main id="main-content" className="w-full flex-1 overflow-hidden">
-        {children}
-      </main>
-      <PublicFooter showMarketing />
-    </div>
-  );
+  return <PublicShell>{children}</PublicShell>;
 }

--- a/apps/main/src/app/auth-error/auth-error-page-client.tsx
+++ b/apps/main/src/app/auth-error/auth-error-page-client.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 import { SignInButton, SignOutButton, useAuth } from "@clerk/nextjs";
-import { Flower2 } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
@@ -16,14 +15,7 @@ function AuthErrorContent() {
   const isSignedIn = isLoaded && Boolean(userId);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-4 text-center">
-      <div className="mb-6 flex items-center gap-2">
-        <Flower2 className="size-8" />
-        <Link href="/" className="text-xl font-semibold">
-          Daylily Catalog
-        </Link>
-      </div>
-
+    <div className="flex min-h-[calc(100svh-12rem)] flex-col items-center justify-center p-4 text-center">
       <div className="bg-card mx-auto max-w-md space-y-6 rounded-lg border p-8 shadow-sm">
         <h1 className="text-3xl font-semibold">
           {isSignedIn ? "Something Went Wrong" : "Authentication Required"}

--- a/apps/main/src/app/auth-error/layout.tsx
+++ b/apps/main/src/app/auth-error/layout.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from "react";
 import { type Metadata } from "next";
 import { AuthProviders } from "@/components/auth-providers";
+import { PublicShell } from "@/components/public-shell";
 
 export const metadata: Metadata = {
   robots: {
@@ -16,5 +17,9 @@ export const metadata: Metadata = {
 };
 
 export default function AuthErrorLayout({ children }: { children: ReactNode }) {
-  return <AuthProviders>{children}</AuthProviders>;
+  return (
+    <AuthProviders>
+      <PublicShell mainClassName="bg-muted/30">{children}</PublicShell>
+    </AuthProviders>
+  );
 }

--- a/apps/main/src/app/onboarding/anonymous-onboarding-layout.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-layout.tsx
@@ -69,7 +69,7 @@ export function AnonymousOnboardingPageClient(
 
         <div
           ref={stepContentRef}
-          className="scroll-mt-4 lg:scroll-mt-6"
+          className="scroll-mt-20 lg:scroll-mt-24"
           data-testid="anonymous-onboarding-step-content"
         >
           {draft.step === "email" ? (

--- a/apps/main/src/app/onboarding/layout.tsx
+++ b/apps/main/src/app/onboarding/layout.tsx
@@ -1,6 +1,5 @@
-import { PublicFooter } from "@/components/public-footer";
-import { PublicNav } from "@/components/public-nav";
 import { AuthProviders } from "@/components/auth-providers";
+import { PublicShell } from "@/components/public-shell";
 
 export default function OnboardingLayout({
   children,
@@ -9,13 +8,7 @@ export default function OnboardingLayout({
 }) {
   return (
     <AuthProviders>
-      <div className="flex min-h-svh flex-col">
-        <header className="flex h-16 items-center border-b px-4">
-          <PublicNav />
-        </header>
-        <main className="bg-muted/20 flex-1">{children}</main>
-        <PublicFooter />
-      </div>
+      <PublicShell mainClassName="bg-muted/20">{children}</PublicShell>
     </AuthProviders>
   );
 }

--- a/apps/main/src/app/sign-in/layout.tsx
+++ b/apps/main/src/app/sign-in/layout.tsx
@@ -1,10 +1,15 @@
 import { type ReactNode } from "react";
 import { AuthProviders } from "@/components/auth-providers";
+import { PublicShell } from "@/components/public-shell";
 
 export default function SignInLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  return <AuthProviders>{children}</AuthProviders>;
+  return (
+    <AuthProviders>
+      <PublicShell mainClassName="bg-muted/30">{children}</PublicShell>
+    </AuthProviders>
+  );
 }

--- a/apps/main/src/app/sign-in/sign-in-page-client.tsx
+++ b/apps/main/src/app/sign-in/sign-in-page-client.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { SignIn, useAuth } from "@clerk/nextjs";
-import { Flower2 } from "lucide-react";
-import Link from "next/link";
 import { useEffect } from "react";
 
 const DASHBOARD_PATH = "/dashboard";
@@ -17,15 +15,7 @@ export function SignInPageClient() {
   }, [isLoaded, userId]);
 
   return (
-    <main className="bg-muted/30 flex min-h-svh flex-col items-center px-4 py-8">
-      <Link
-        href="/"
-        className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-2 text-sm font-medium transition-colors"
-      >
-        <Flower2 className="text-primary size-4" aria-hidden="true" />
-        <span>Daylily Catalog</span>
-      </Link>
-
+    <div className="flex min-h-[calc(100svh-12rem)] flex-col items-center justify-center px-4 py-12">
       {!isLoaded || userId ? null : (
         <SignIn
           routing="hash"
@@ -34,6 +24,6 @@ export function SignInPageClient() {
           withSignUp={false}
         />
       )}
-    </main>
+    </div>
   );
 }

--- a/apps/main/src/app/sign-up/layout.tsx
+++ b/apps/main/src/app/sign-up/layout.tsx
@@ -1,10 +1,15 @@
 import { type ReactNode } from "react";
 import { AuthProviders } from "@/components/auth-providers";
+import { PublicShell } from "@/components/public-shell";
 
 export default function SignUpLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  return <AuthProviders>{children}</AuthProviders>;
+  return (
+    <AuthProviders>
+      <PublicShell mainClassName="bg-muted/30">{children}</PublicShell>
+    </AuthProviders>
+  );
 }

--- a/apps/main/src/app/start-membership/layout.tsx
+++ b/apps/main/src/app/start-membership/layout.tsx
@@ -1,16 +1,9 @@
-import { PublicHeader } from "@/components/public-nav";
-import { PublicFooter } from "@/components/public-footer";
+import { PublicShell } from "@/components/public-shell";
 
 export default function StartMembershipLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div className="flex min-h-svh flex-col">
-      <PublicHeader />
-      <main className="flex-1">{children}</main>
-      <PublicFooter />
-    </div>
-  );
+  return <PublicShell>{children}</PublicShell>;
 }

--- a/apps/main/src/app/start-membership/page.tsx
+++ b/apps/main/src/app/start-membership/page.tsx
@@ -146,7 +146,7 @@ export default async function StartMembershipPage() {
   const membershipPriceDisplay = await getMembershipPriceDisplay();
 
   return (
-    <div className="min-h-svh overflow-hidden">
+    <div className="-mt-16 min-h-svh overflow-hidden lg:-mt-20">
       <SellerLandingViewTracker />
 
       <script
@@ -179,7 +179,7 @@ function StartMembershipHero({
   const trialPriceText = `Membership is ${membershipPriceDisplay.amount}${membershipPriceDisplay.interval} after the trial.`;
 
   return (
-    <section className="relative isolate overflow-hidden bg-[#07120e] px-4 pt-24 pb-36 text-white lg:px-8 lg:pt-20 lg:pb-32">
+    <section className="relative isolate overflow-hidden bg-[#07120e] px-4 pt-24 pb-36 text-white lg:px-8 lg:pt-24 lg:pb-32">
       <div className="absolute inset-0 -z-10 bg-[#07120e]" aria-hidden="true">
         <Image
           src="/assets/home-redesign/daylily-hero-grid.webp"

--- a/apps/main/src/components/floating-cart-button.tsx
+++ b/apps/main/src/components/floating-cart-button.tsx
@@ -51,7 +51,7 @@ export function FloatingCartButton({
       <DialogTrigger asChild>
         <Button
           type="button"
-          className="fixed right-4 bottom-4 z-50 flex items-center gap-2 rounded-full shadow-md"
+          className="fixed right-4 bottom-[calc(2.5rem+env(safe-area-inset-bottom))] z-50 flex items-center gap-2 rounded-full shadow-md"
           variant="default"
           onClick={onContactClick}
           aria-label={

--- a/apps/main/src/components/public-catalog-search/public-catalog-search-content.tsx
+++ b/apps/main/src/components/public-catalog-search/public-catalog-search-content.tsx
@@ -126,7 +126,7 @@ function PublicCatalogSearchContentView({
               : "lg:grid-cols-[320px_minmax(0,1fr)]",
           )}
         >
-          <div className="lg:sticky lg:top-4">
+          <div className="lg:sticky lg:top-24">
             <PublicCatalogSearchAdvancedPanel
               table={table}
               listOptions={listOptions}

--- a/apps/main/src/components/public-footer.tsx
+++ b/apps/main/src/components/public-footer.tsx
@@ -1,57 +1,39 @@
-import Link from "next/link";
-import { Flower2 } from "lucide-react";
+"use client";
+
 import { PublicFeedbackLink } from "@/components/public-feedback-link";
-import { SellerIntentLink } from "@/components/seller-intent-link";
+import { cn } from "@/lib/utils";
+import { usePathname } from "next/navigation";
 
-interface PublicFooterProps {
-  showMarketing?: boolean;
-}
+export function PublicFooter() {
+  const isHomepage = usePathname() === "/";
 
-export function PublicFooter({ showMarketing = false }: PublicFooterProps) {
   return (
-    <footer className="w-full border-t border-[#d8dfd2] bg-[#fbfaf4] text-[#142118]">
-      {showMarketing ? (
-        <div className="px-4 py-8 lg:px-8">
-          <div className="mx-auto flex w-full max-w-[1024px] flex-col gap-6 text-sm lg:flex-row lg:items-center lg:justify-between">
-            <div className="max-w-xl">
-              <Link
-                href="/"
-                className="inline-flex items-center gap-3 font-semibold hover:opacity-80"
+    <footer
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 w-full bg-transparent before:pointer-events-none before:absolute before:inset-x-0 before:-top-5 before:bottom-0 before:z-[-1] before:content-[''] before:backdrop-blur-[5px] before:[mask-image:linear-gradient(to_bottom,transparent_0%,#000_20px,#000_100%)] before:[-webkit-mask-image:linear-gradient(to_bottom,transparent_0%,#000_20px,#000_100%)]",
+        isHomepage ? "text-white" : "text-[#142118]",
+      )}
+    >
+      <div className="px-3 pt-1 pb-[calc(0.25rem+env(safe-area-inset-bottom))] lg:px-8">
+        <nav
+          aria-label="Public footer"
+          className="mx-auto flex w-full max-w-[1024px] justify-end"
+        >
+          <ul className="flex items-center justify-end gap-4 text-right">
+            <li>
+              <PublicFeedbackLink
+                className={cn(
+                  "text-[11px] leading-none font-medium underline-offset-4 transition-colors hover:underline",
+                  isHomepage
+                    ? "text-white/70 hover:text-white"
+                    : "text-[#142118]/60 hover:text-[#142118]",
+                )}
               >
-                <Flower2 className="size-5 text-[#a94e38]" />
-                <span className="text-base">Daylily Catalog</span>
-              </Link>
-              <p className="mt-2 leading-6 text-[#536357]">
-                Browse daylily catalogs created by growers.
-              </p>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-2 font-semibold">
-              <Link
-                href="/catalogs"
-                className="inline-flex h-10 items-center border border-[#d8dfd2] bg-white px-4 text-[#142118] transition-colors hover:border-[#173126] hover:bg-[#173126] hover:text-white"
-              >
-                Browse catalogs
-              </Link>
-              <SellerIntentLink
-                className="inline-flex h-10 items-center border border-[#d8dfd2] bg-white px-4 text-[#142118] transition-colors hover:border-[#173126] hover:bg-[#173126] hover:text-white"
-                entrySurface="public_footer"
-                ctaId="public-footer-create-catalog"
-                ctaLabel="Create your catalog"
-              >
-                Create your catalog
-              </SellerIntentLink>
-            </div>
-          </div>
-        </div>
-      ) : null}
-
-      <div className="border-t border-[#d8dfd2] px-4 py-2 lg:px-8">
-        <div className="mx-auto flex w-full max-w-[1024px] justify-center lg:justify-end">
-          <PublicFeedbackLink className="text-xs font-medium text-[#6f7c72] underline-offset-4 transition-colors hover:text-[#142118] hover:underline">
-            Feedback
-          </PublicFeedbackLink>
-        </div>
+                Feedback
+              </PublicFeedbackLink>
+            </li>
+          </ul>
+        </nav>
       </div>
     </footer>
   );

--- a/apps/main/src/components/public-nav.tsx
+++ b/apps/main/src/components/public-nav.tsx
@@ -2,164 +2,145 @@
 
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Flower2 } from "lucide-react";
+import { Flower2, Menu } from "lucide-react";
 import { Small } from "@/components/typography";
 import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { SUBSCRIPTION_CONFIG } from "@/config/subscription-config";
 
-type PublicNavTheme = "light" | "dark";
-
-function getNavThemeClasses(theme: PublicNavTheme) {
-  return {
-    brand: theme === "dark" ? "text-white" : "text-[#142118]",
-    logo: theme === "dark" ? "text-[#f4c477]" : "text-[#173126]",
-    link:
-      theme === "dark"
-        ? "text-white hover:bg-white/10 hover:text-white"
-        : "text-[#142118] hover:bg-[#e9efe3] hover:text-[#142118]",
-    active: theme === "dark" ? "bg-white/10 text-white" : "bg-[#e9efe3]",
-    dashboard:
-      theme === "dark"
-        ? "ml-2 h-10 rounded-md border border-white/25 bg-transparent px-5 text-sm text-white shadow-none hover:bg-white hover:text-[#07120e] disabled:opacity-100"
-        : "ml-2 h-10 rounded-md border border-[#c8d4c1] bg-white px-5 text-sm text-[#142118] shadow-none hover:bg-[#173126] hover:text-white disabled:opacity-100",
-    mobileDashboard:
-      theme === "dark"
-        ? "h-9 rounded-lg bg-white px-3 text-xs text-[#07120e] shadow-none hover:bg-[#f4c477] disabled:opacity-100"
-        : "h-9 rounded-lg bg-[#173126] px-3 text-xs text-white shadow-none hover:bg-[#274835] disabled:opacity-100",
-  };
-}
+const activeNavClassName =
+  "font-semibold underline decoration-current/35 underline-offset-8";
 
 export function PublicHeader() {
   const pathname = usePathname();
-  const isHeroOverlayPage =
-    pathname === "/" || pathname === "/start-membership";
-  const theme = isHeroOverlayPage ? "dark" : "light";
+  const mobileNavRef = useRef<HTMLDetailsElement>(null);
+  const isHomepage = pathname === "/";
+  const isCatalogsActive = pathname === "/catalogs";
+  const isGrowersActive =
+    pathname === "/start-membership" || pathname.startsWith("/onboarding");
+
+  useEffect(() => {
+    mobileNavRef.current?.removeAttribute("open");
+  }, [pathname]);
 
   return (
     <header
       className={cn(
-        "z-50 flex w-full items-center px-3 py-1 backdrop-blur-xl lg:px-8",
-        isHeroOverlayPage
-          ? "fixed inset-x-0 top-0 border-none bg-black/6"
-          : "min-h-20 border-b border-[#d8dfd2] bg-[#fbfaf4]/92 lg:h-20 lg:py-0",
+        "public-header sticky inset-x-0 top-0 z-50 flex min-h-16 w-full items-center border-none bg-transparent px-3 py-2 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:-bottom-5 before:z-[-1] before:content-[''] before:backdrop-blur-[5px] before:[mask-image:linear-gradient(to_bottom,#000_0%,#000_calc(100%_-_20px),transparent_100%)] before:[-webkit-mask-image:linear-gradient(to_bottom,#000_0%,#000_calc(100%_-_20px),transparent_100%)] lg:h-20 lg:px-8 lg:py-0",
+        isHomepage ? "text-white" : "text-[#142118]",
       )}
     >
-      <div
-        className={cn(
-          "mx-auto w-full",
-          isHeroOverlayPage ? "max-w-[1024px]" : "max-w-[1600px]",
-        )}
-      >
-        <PublicNav theme={theme} />
-      </div>
+      <nav className="mx-auto flex w-full max-w-[1024px] items-center justify-between gap-2 py-1 lg:gap-4">
+        <Link
+          href="/"
+          className="flex shrink-0 items-center gap-1.5 text-current transition-opacity hover:opacity-80 focus-visible:ring-1 focus-visible:ring-[#f4c477] focus-visible:outline-none lg:gap-3"
+        >
+          <span
+            className={cn(
+              "flex h-7 w-7 items-center justify-center lg:h-8 lg:w-8",
+              isHomepage ? "text-[#f4c477]" : "text-[#b7791f]",
+            )}
+          >
+            <Flower2 className="h-5 w-5 lg:h-6 lg:w-6" />
+          </span>
+          <Small className="text-sm leading-none font-semibold whitespace-nowrap text-current lg:text-base">
+            Daylily Catalog
+          </Small>
+        </Link>
+
+        <details
+          ref={mobileNavRef}
+          className="group relative shrink-0 lg:hidden"
+          data-testid="mobile-public-nav"
+        >
+          <summary
+            aria-label="Open public navigation"
+            className={cn(
+              "flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-md border bg-transparent transition-colors focus-visible:ring-1 focus-visible:ring-[#f4c477] focus-visible:outline-none [&::-webkit-details-marker]:hidden",
+              isHomepage
+                ? "border-white/30 text-white hover:bg-white/10"
+                : "border-[#142118]/20 text-[#142118] hover:bg-[#142118]/5",
+            )}
+          >
+            <Menu className="size-4" />
+            <span className="sr-only">Open public navigation</span>
+          </summary>
+          <ul className="absolute top-[calc(100%+0.25rem)] right-0 w-56 overflow-hidden rounded-md border border-[#142118]/10 bg-white/85 p-1 text-sm text-[#142118] shadow-md backdrop-blur-xl">
+            <li>
+              <Link
+                href="/catalogs"
+                aria-current={isCatalogsActive ? "page" : undefined}
+                className={cn(
+                  "block rounded-sm px-2 py-1.5 hover:bg-[#142118]/8",
+                  isCatalogsActive && activeNavClassName,
+                )}
+              >
+                Browse catalogs
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/start-membership"
+                aria-current={isGrowersActive ? "page" : undefined}
+                className={cn(
+                  "block rounded-sm px-2 py-1.5 hover:bg-[#142118]/8",
+                  isGrowersActive && activeNavClassName,
+                )}
+              >
+                For growers
+              </Link>
+            </li>
+            <li className="mt-1 border-t border-[#142118]/10 pt-1">
+              <Link
+                href={SUBSCRIPTION_CONFIG.DASHBOARD_SIGN_IN_PATH}
+                className="block rounded-sm px-2 py-1.5 hover:bg-[#142118]/8"
+              >
+                Dashboard
+              </Link>
+            </li>
+          </ul>
+        </details>
+
+        <div className="hidden items-center gap-4 lg:ml-auto lg:flex">
+          <Link
+            href="/catalogs"
+            aria-current={isCatalogsActive ? "page" : undefined}
+            className={cn(
+              "px-3 py-2 text-base text-current transition-opacity hover:opacity-70 focus-visible:ring-1 focus-visible:ring-current focus-visible:outline-none",
+              isCatalogsActive && activeNavClassName,
+            )}
+          >
+            Browse catalogs
+          </Link>
+
+          <Link
+            href="/start-membership"
+            aria-current={isGrowersActive ? "page" : undefined}
+            className={cn(
+              "px-3 py-2 text-base text-current transition-opacity hover:opacity-70 focus-visible:ring-1 focus-visible:ring-current focus-visible:outline-none",
+              isGrowersActive && activeNavClassName,
+            )}
+          >
+            For growers
+          </Link>
+
+          <form action={SUBSCRIPTION_CONFIG.DASHBOARD_SIGN_IN_PATH}>
+            <Button
+              className={cn(
+                "ml-2 h-10 rounded-md border bg-transparent px-5 text-sm shadow-none disabled:opacity-100",
+                isHomepage
+                  ? "border-white/35 text-white hover:bg-white hover:text-[#142118]"
+                  : "border-[#142118]/25 text-[#142118] hover:bg-[#142118] hover:text-white",
+              )}
+              size="sm"
+              type="submit"
+            >
+              Dashboard
+            </Button>
+          </form>
+        </div>
+      </nav>
     </header>
-  );
-}
-
-export function PublicNav({ theme = "light" }: { theme?: PublicNavTheme }) {
-  const pathname = usePathname();
-  const isHeroOverlayPage =
-    pathname === "/" || pathname === "/start-membership";
-  const isCatalogsActive = pathname === "/catalogs";
-  const classes = getNavThemeClasses(theme);
-
-  return (
-    <nav className="flex w-full items-center justify-between gap-2 py-1 lg:gap-4">
-      <Link
-        href="/"
-        className={cn(
-          "flex shrink-0 items-center gap-1.5 transition-opacity hover:opacity-80 focus-visible:ring-1 focus-visible:ring-[#f4c477] focus-visible:outline-none lg:gap-3",
-          classes.brand,
-        )}
-      >
-        <span
-          className={cn(
-            "flex h-7 w-7 items-center justify-center lg:h-8 lg:w-8",
-            classes.logo,
-          )}
-        >
-          <Flower2 className="h-5 w-5 lg:h-6 lg:w-6" />
-        </span>
-        <Small
-          className={cn(
-            "text-xs leading-none font-semibold whitespace-nowrap min-[390px]:text-sm lg:text-base",
-            classes.brand,
-          )}
-        >
-          Daylily Catalog
-        </Small>
-      </Link>
-
-      <div
-        className={cn(
-          "min-w-0 flex-1 items-center justify-center gap-1 lg:hidden",
-          isHeroOverlayPage ? "hidden" : "flex",
-        )}
-      >
-        <Button
-          variant="ghost"
-          asChild
-          size="sm"
-          className={cn(
-            "h-8 px-1 text-[10.5px] whitespace-nowrap min-[390px]:px-1.5 min-[390px]:text-[11px]",
-            classes.link,
-            isCatalogsActive && classes.active,
-          )}
-        >
-          <Link href="/catalogs">Browse catalogs</Link>
-        </Button>
-
-        <Button
-          variant="ghost"
-          asChild
-          size="sm"
-          className={cn(
-            "h-8 px-1 text-[10.5px] whitespace-nowrap min-[390px]:px-1.5 min-[390px]:text-[11px]",
-            classes.link,
-          )}
-        >
-          <Link href="/start-membership">For growers</Link>
-        </Button>
-      </div>
-
-      <div className="shrink-0 lg:hidden">
-        <form action={SUBSCRIPTION_CONFIG.DASHBOARD_SIGN_IN_PATH}>
-          <Button className={classes.mobileDashboard} size="sm" type="submit">
-            Dashboard
-          </Button>
-        </form>
-      </div>
-
-      <div className="hidden items-center gap-4 lg:ml-auto lg:flex">
-        <Button
-          variant="ghost"
-          asChild
-          size="sm"
-          className={cn(
-            "text-base",
-            classes.link,
-            isCatalogsActive && classes.active,
-          )}
-        >
-          <Link href="/catalogs">Browse catalogs</Link>
-        </Button>
-
-        <Button
-          variant="ghost"
-          asChild
-          size="sm"
-          className={cn("text-base", classes.link)}
-        >
-          <Link href="/start-membership">For growers</Link>
-        </Button>
-
-        <form action={SUBSCRIPTION_CONFIG.DASHBOARD_SIGN_IN_PATH}>
-          <Button className={classes.dashboard} size="sm" type="submit">
-            Dashboard
-          </Button>
-        </form>
-      </div>
-    </nav>
   );
 }

--- a/apps/main/src/components/public-shell.tsx
+++ b/apps/main/src/components/public-shell.tsx
@@ -1,0 +1,32 @@
+import { PublicFooter } from "@/components/public-footer";
+import { PublicHeader } from "@/components/public-nav";
+import { cn } from "@/lib/utils";
+
+interface PublicShellProps {
+  children: React.ReactNode;
+  mainClassName?: string;
+}
+
+export function PublicShell({ children, mainClassName }: PublicShellProps) {
+  return (
+    <div className="flex min-h-svh flex-col bg-[#f6f8f3] text-[#142118]">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[60] focus:rounded-md focus:bg-[#142118] focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white"
+      >
+        Skip to content
+      </a>
+      <PublicHeader />
+      <main
+        id="main-content"
+        className={cn(
+          "-mt-16 w-full flex-1 scroll-mt-24 overflow-hidden pt-16 pb-[calc(2.25rem+env(safe-area-inset-bottom))] lg:-mt-20 lg:scroll-mt-28 lg:pt-20 [&_[id]]:scroll-mt-24 lg:[&_[id]]:scroll-mt-28",
+          mainClassName,
+        )}
+      >
+        {children}
+      </main>
+      <PublicFooter />
+    </div>
+  );
+}

--- a/apps/main/tests/onboarding-layout.test.tsx
+++ b/apps/main/tests/onboarding-layout.test.tsx
@@ -3,12 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 import OnboardingLayout from "@/app/onboarding/layout";
 
-vi.mock("@/components/public-nav", () => ({
-  PublicNav: () => <nav>Public nav</nav>,
-}));
-
-vi.mock("@/components/public-footer", () => ({
-  PublicFooter: () => <footer>Feedback footer</footer>,
+vi.mock("@/components/public-shell", () => ({
+  PublicShell: ({ children }: { children: ReactNode }) => (
+    <div data-testid="public-shell">{children}</div>
+  ),
 }));
 
 vi.mock("@/components/auth-providers", () => ({
@@ -18,7 +16,7 @@ vi.mock("@/components/auth-providers", () => ({
 }));
 
 describe("OnboardingLayout", () => {
-  it("wraps onboarding and checkout interstitial pages with the feedback footer", () => {
+  it("wraps onboarding and checkout interstitial pages with the shared public shell", () => {
     render(
       <OnboardingLayout>
         <div>Onboarding content</div>
@@ -26,8 +24,7 @@ describe("OnboardingLayout", () => {
     );
 
     expect(screen.getByTestId("auth-providers")).toBeVisible();
-    expect(screen.getByText("Public nav")).toBeVisible();
+    expect(screen.getByTestId("public-shell")).toBeInTheDocument();
     expect(screen.getByText("Onboarding content")).toBeVisible();
-    expect(screen.getByText("Feedback footer")).toBeVisible();
   });
 });

--- a/apps/main/tests/profile-content.test.tsx
+++ b/apps/main/tests/profile-content.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/app/(public)/[userSlugOrId]/_components/catalog-nav", () => ({
     canonicalUserSlug: string;
     currentPage: number;
   }) => (
-    <div
+    <nav
       data-testid="catalog-nav"
       data-slug={canonicalUserSlug}
       data-page={currentPage}
@@ -32,7 +32,7 @@ vi.mock("@/app/(public)/[userSlugOrId]/_components/catalog-nav", () => ({
 }));
 
 describe("ProfileContent", () => {
-  it("keeps image panel visible in mobile layout classes", () => {
+  it("renders the catalog section navigation", () => {
     const profile: RouterOutputs["public"]["getProfile"] = {
       id: "user-1",
       slug: "seeded-daylily",
@@ -52,13 +52,13 @@ describe("ProfileContent", () => {
       content: null,
     };
 
-    render(<ProfileContent initialProfile={profile} currentPage={1} />);
+    render(<ProfileContent initialProfile={profile} currentPage={3} />);
 
-    const imageWrapper = screen.getByTestId("images-section").parentElement;
-
-    expect(imageWrapper).not.toBeNull();
-    expect(imageWrapper).toHaveClass("order-3");
-    expect(imageWrapper).not.toHaveClass("hidden");
-    expect(screen.getAllByTestId("catalog-nav")).toHaveLength(2);
+    expect(screen.getByTestId("images-section")).toBeInTheDocument();
+    expect(screen.getByTestId("catalog-nav")).toHaveAttribute(
+      "data-slug",
+      "seeded-daylily",
+    );
+    expect(screen.getByTestId("catalog-nav")).toHaveAttribute("data-page", "3");
   });
 });

--- a/apps/main/tests/public-footer.test.tsx
+++ b/apps/main/tests/public-footer.test.tsx
@@ -1,71 +1,35 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { ReactNode } from "react";
 import { PublicFooter } from "@/components/public-footer";
-
-vi.mock("@/components/seller-intent-link", () => ({
-  SellerIntentLink: ({
-    children,
-    className,
-    href = "/start-membership",
-  }: {
-    children: ReactNode;
-    className?: string;
-    href?: string;
-  }) => (
-    <a className={className} href={href}>
-      {children}
-    </a>
-  ),
-}));
 
 vi.mock("@/hooks/use-feedback-url", () => ({
   useFeedbackUrl: () =>
     "https://coda.io/form/Ideas-Bugs_dWgu2I2WTqJ?board-slug=daylily-catalog",
 }));
 
-vi.mock("next/link", () => ({
-  default: ({
-    children,
-    href,
-    ...props
-  }: {
-    children: ReactNode;
-    href: string;
-  }) => (
-    <a href={href} {...props}>
-      {children}
-    </a>
-  ),
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
 }));
 
 describe("PublicFooter", () => {
-  it("renders a feedback-only bar by default", () => {
+  it("renders the single public feedback footer", () => {
     render(<PublicFooter />);
 
+    const footerNav = screen.getByRole("navigation", { name: "Public footer" });
     const feedbackLink = screen.getByRole("link", { name: "Feedback" });
+
     expect(feedbackLink).toHaveAttribute(
       "href",
       "https://coda.io/form/Ideas-Bugs_dWgu2I2WTqJ?board-slug=daylily-catalog",
     );
-    expect(feedbackLink).toHaveClass("text-xs");
+    expect(screen.getByRole("contentinfo")).toBeInTheDocument();
+    expect(footerNav).toBeVisible();
+    expect(footerNav.querySelectorAll("li")).toHaveLength(1);
     expect(
       screen.queryByText("Browse daylily catalogs created by growers."),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Create your catalog" }),
     ).not.toBeInTheDocument();
-  });
-
-  it("can include the existing marketing footer when requested", () => {
-    render(<PublicFooter showMarketing />);
-
-    expect(
-      screen.getByText("Browse daylily catalogs created by growers."),
-    ).toBeVisible();
-    expect(
-      screen.getByRole("link", { name: "Create your catalog" }),
-    ).toBeVisible();
-    expect(screen.getByRole("link", { name: "Feedback" })).toBeVisible();
   });
 });

--- a/apps/main/tests/public-nav.test.tsx
+++ b/apps/main/tests/public-nav.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PublicHeader } from "@/components/public-nav";
+
+const navigationState = vi.hoisted(() => ({ pathname: "/" }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => navigationState.pathname,
+}));
+
+describe("PublicHeader", () => {
+  beforeEach(() => {
+    navigationState.pathname = "/";
+  });
+
+  it("renders the public destinations and marks the current page active", () => {
+    navigationState.pathname = "/catalogs";
+    render(<PublicHeader />);
+
+    const catalogsLinks = screen.getAllByRole("link", {
+      name: "Browse catalogs",
+    });
+    const growersLinks = screen.getAllByRole("link", { name: "For growers" });
+
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+    expect(catalogsLinks).toHaveLength(2);
+    expect(
+      catalogsLinks.every(
+        (link) =>
+          link.getAttribute("href") === "/catalogs" &&
+          link.getAttribute("aria-current") === "page",
+      ),
+    ).toBe(true);
+    expect(growersLinks).toHaveLength(2);
+    expect(
+      growersLinks.every(
+        (link) => link.getAttribute("href") === "/start-membership",
+      ),
+    ).toBe(true);
+    expect(screen.getByRole("button", { name: "Dashboard" })).toBeVisible();
+  });
+
+  it("renders mobile destinations without requiring hydration", () => {
+    navigationState.pathname = "/onboarding";
+    render(<PublicHeader />);
+
+    const mobileNav = screen.getByTestId("mobile-public-nav");
+    const catalogsLink = mobileNav.querySelector('a[href="/catalogs"]');
+    const growersLink = mobileNav.querySelector('a[href="/start-membership"]');
+    const dashboardLink = mobileNav.querySelector('a[href="/sign-in"]');
+
+    expect(screen.getByText("Open public navigation")).toBeInTheDocument();
+    expect(catalogsLink).toHaveAttribute("href", "/catalogs");
+    expect(growersLink).toHaveAttribute("href", "/start-membership");
+    expect(growersLink).toHaveAttribute("aria-current", "page");
+    expect(dashboardLink).toHaveAttribute("href", "/sign-in");
+  });
+
+  it("closes the mobile menu after navigation", () => {
+    const { rerender } = render(<PublicHeader />);
+    const mobileNav = screen.getByTestId("mobile-public-nav");
+    mobileNav.setAttribute("open", "");
+
+    navigationState.pathname = "/catalogs";
+    rerender(<PublicHeader />);
+
+    expect(mobileNav).not.toHaveAttribute("open");
+  });
+});

--- a/apps/main/tests/public-shell.test.tsx
+++ b/apps/main/tests/public-shell.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/public-nav", () => ({
+  PublicHeader: () => <header>Public header</header>,
+}));
+
+vi.mock("@/components/public-footer", () => ({
+  PublicFooter: () => <footer>Public footer</footer>,
+}));
+
+import { PublicShell } from "@/components/public-shell";
+
+describe("PublicShell", () => {
+  it("renders the shared public header, main content, skip link, and footer", () => {
+    render(
+      <PublicShell>
+        <div>Public page content</div>
+      </PublicShell>,
+    );
+
+    expect(screen.getByText("Public header")).toBeVisible();
+    expect(screen.getByText("Public footer")).toBeVisible();
+    const skipLink = screen.getByText("Skip to content");
+    expect(skipLink).toHaveAttribute("href", "#main-content");
+    const main = screen.getByRole("main");
+    expect(main).toHaveAttribute("id", "main-content");
+    expect(screen.getByText("Public page content")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- route public and public-auth pages through one shared public shell
- use a transparent header with a 5px backdrop blur that fades out 20px below it
- mirror that treatment on the compact transparent footer, fading 20px upward
- switch navigation and footer ink between white on the dark homepage hero and dark on light public pages
- provide desktop links and a native mobile menu that works before hydration
- retain the catalog-local section navigation as one simplified responsive instance
- centralize fixed-header anchor clearance in the public shell

## Scope
- one commit rebased onto current `main`
- 23 changed files, down from 38 in the initial PR
- 367 additions / 412 deletions
- no CSS-class assertions added to tests

## Verification
- focused behavioral Vitest coverage passed
- `pnpm main lint`
- `pnpm main typecheck`
- Chrome verification against a fresh local build on dark and light pages
- computed header and footer `::before` verification: 5px blur, 20px faded extension, `z-index: -1`, and no pointer events
- prior Chrome desktop/mobile checks for mobile navigation, catalog nav, anchor clearance, route-change menu closing, and compatibility-warning positioning
- final Codex review against `origin/main`: no findings