### PR TITLE
docs(billing): explain Stripe checkout safeguards

### DIFF
--- a/apps/main/src/server/api/routers/stripe.ts
+++ b/apps/main/src/server/api/routers/stripe.ts
@@ -57,6 +57,8 @@ export const stripeRouter = createTRPCRouter({
       });
     }
 
+    // Always bind Checkout to the Customer; Stripe's one-subscription setting
+    // handles concurrent sessions: https://github.com/t3dotgg/stripe-recommendations
     const session = await stripe.checkout.sessions.create({
       customer: stripeCustomerId,
       mode: "subscription",

--- a/apps/main/src/server/stripe/sync-subscription.ts
+++ b/apps/main/src/server/stripe/sync-subscription.ts
@@ -16,6 +16,8 @@ async function syncStripeSubscriptionToKVBase(
 ) {
   const subscriptions = await stripe.subscriptions.list({
     customer: customerId,
+    // Canceled subscriptions are excluded by default, so the current record
+    // is sufficient: https://docs.stripe.com/api/subscriptions/list
     limit: 1,
     expand: ["data.default_payment_method"],
   });
@@ -95,6 +97,8 @@ export const getStripeSubscription = async (
         stripeCustomerId,
       },
     });
+    // Keep checkout available; its customer binding and Stripe's setting are
+    // the final duplicate guard: https://docs.stripe.com/payments/checkout/limit-subscriptions
     return DEFAULT_SUB_DATA;
   }
   return result.data;

--- a/apps/main/tests/stripe-webhook-route.test.ts
+++ b/apps/main/tests/stripe-webhook-route.test.ts
@@ -113,7 +113,8 @@ describe("Stripe webhook route", () => {
   });
 
   it("acknowledges relevant events without a customer id", async () => {
-    // Current behavior - plan 003 changes this to fail closed.
+    // Some tracked event objects have nullable customers:
+    // https://docs.stripe.com/api/payment_intents/object
     mocks.constructEvent.mockReturnValue({
       type: "invoice.paid",
       data: { object: {} },


### PR DESCRIPTION
## What changed

- Document why Checkout is always bound to the existing Stripe Customer and relies on Stripe's one-subscription setting as the final concurrent-session guard.
- Document that subscription listing intentionally uses Stripe's default non-canceled filter with `limit: 1`.
- Document why cache-miss Stripe failures keep checkout available.
- Replace the stale Plan 003 webhook comment with Stripe's nullable-customer API source.

## Decision

No runtime behavior changes. After re-reading the original [T3 Stripe recommendations](https://github.com/t3dotgg/stripe-recommendations) and its linked Stripe documentation, we retained the existing availability-first behavior:

- return existing KV state without contacting Stripe;
- on a true cache miss plus Stripe failure, report the error and continue to customer-bound Checkout;
- let Stripe's enabled [one-subscription setting](https://docs.stripe.com/payments/checkout/limit-subscriptions) provide the final duplicate-subscription guard;
- keep `limit: 1` because Stripe [excludes canceled subscriptions by default](https://docs.stripe.com/api/subscriptions/list).

## Validation

- `pnpm main test -- tests/stripe-sync-subscription.test.ts tests/stripe-router-generate-checkout.test.ts tests/stripe-webhook-route.test.ts` (14 tests)
- `pnpm typecheck`
- `pnpm lint`
- Prettier check
- `git diff --check`
- `codex review --base origin/main` completed with no accepted/actionable findings