### PR TITLE
Validate public inquiry cart items

### DIFF
--- a/apps/main/src/server/services/public-inquiry.ts
+++ b/apps/main/src/server/services/public-inquiry.ts
@@ -5,6 +5,7 @@ import type { CartItem } from "@/types";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { db } from "@/server/db";
 import { getClerkUserData } from "@/server/clerk/sync-user";
+import { isPublished } from "@/server/db/public-visibility/filters";
 import { enforcePublicInquiryRateLimit } from "@/server/services/public-inquiry-rate-limit";
 
 export interface SendPublicInquiryInput {
@@ -25,6 +26,7 @@ interface PublicInquiryContext {
   customerName: string | undefined;
   customerEmail: string;
   formattedItems: string;
+  hadOmittedItems: boolean;
   hasCartItems: boolean;
   sellerEmail: string;
   sellerNameForSellerEmail: string;
@@ -97,6 +99,37 @@ function formatCartItems(items: CartItem[] | undefined) {
   };
 }
 
+async function resolveCartItems(input: SendPublicInquiryInput) {
+  if (!input.items?.length) {
+    return { items: input.items, hadOmittedItems: false };
+  }
+
+  const listings = await db.listing.findMany({
+    where: {
+      id: { in: [...new Set(input.items.map((item) => item.listingId))] },
+      userId: input.userId,
+      ...isPublished(),
+    },
+    select: { id: true, title: true, price: true },
+  });
+  const listingById = new Map(listings.map((listing) => [listing.id, listing]));
+  const items = input.items.flatMap((item) => {
+    const listing = listingById.get(item.listingId);
+    return listing
+      ? [{ ...item, title: listing.title, price: listing.price }]
+      : [];
+  });
+
+  if (items.length === 0) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Cart items could not be verified.",
+    });
+  }
+
+  return { items, hadOmittedItems: items.length !== input.items.length };
+}
+
 async function loadPublicInquiryContext(
   input: SendPublicInquiryInput,
 ): Promise<PublicInquiryContext> {
@@ -132,9 +165,8 @@ async function loadPublicInquiryContext(
   }
 
   const customerDisplayName = getCustomerDisplayName(input);
-  const { formattedItems, hasCartItems, subtotal } = formatCartItems(
-    input.items,
-  );
+  const { items, hadOmittedItems } = await resolveCartItems(input);
+  const { formattedItems, hasCartItems, subtotal } = formatCartItems(items);
   const catalogUrl = `${getCanonicalBaseUrl()}/${user.profile?.slug ?? user.id}`;
 
   return {
@@ -143,6 +175,7 @@ async function loadPublicInquiryContext(
     customerName: input.customerName,
     customerEmail: input.customerEmail,
     formattedItems,
+    hadOmittedItems,
     hasCartItems,
     sellerEmail,
     sellerNameForSellerEmail: user.profile?.title ?? "Seller",
@@ -174,7 +207,7 @@ ${formattedMessage}`
 ${
   context.hasCartItems
     ? `Customer's Selected Items:
-${context.formattedItems}
+${context.formattedItems}${context.hadOmittedItems ? "\n\nOne or more unavailable items were omitted." : ""}
 
 Subtotal: $${context.subtotal.toFixed(2)}
 Note: Final pricing, shipping, and handling are at your discretion.`
@@ -214,7 +247,7 @@ ${formattedMessage}`
 ${
   context.hasCartItems
     ? `Items you're interested in:
-${context.formattedItems}
+${context.formattedItems}${context.hadOmittedItems ? "\n\nOne or more unavailable items were omitted." : ""}
 
 Subtotal: $${context.subtotal.toFixed(2)}
 (Note: Final pricing, shipping, and handling may vary at the discretion of the seller.)`

--- a/apps/main/tests/public-inquiry.test.ts
+++ b/apps/main/tests/public-inquiry.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment node
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CartItem } from "@/types";
+
+const mocks = vi.hoisted(() => ({
+  findListings: vi.fn(),
+  findUser: vi.fn(),
+  getClerkUserData: vi.fn(),
+  sendEmail: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-ses", () => ({
+  SESClient: class {
+    send = mocks.sendEmail;
+  },
+  SendEmailCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+vi.mock("@/env", () => ({ env: {}, requireEnv: () => "test" }));
+vi.mock("@/server/db", () => ({
+  db: {
+    listing: { findMany: mocks.findListings },
+    user: { findUnique: mocks.findUser },
+  },
+}));
+vi.mock("@/server/clerk/sync-user", () => ({
+  getClerkUserData: mocks.getClerkUserData,
+}));
+vi.mock("@/server/services/public-inquiry-rate-limit", () => ({
+  enforcePublicInquiryRateLimit: vi.fn(),
+}));
+vi.mock("@/lib/utils/getBaseUrl", () => ({
+  getCanonicalBaseUrl: () => "https://daylilycatalog.com",
+}));
+
+type InquiryModule = typeof import("@/server/services/public-inquiry");
+let sendPublicInquiry: InquiryModule["sendPublicInquiry"];
+
+beforeAll(async () => {
+  ({ sendPublicInquiry } = await import("@/server/services/public-inquiry"));
+});
+
+const baseItem: CartItem = {
+  id: "cart-1",
+  title: "Client title",
+  price: 0.01,
+  quantity: 2,
+  listingId: "listing-1",
+  userId: "seller-1",
+};
+
+function emailBody(call: number) {
+  return (
+    mocks.sendEmail.mock.calls[call]?.[0] as {
+      input: { Message: { Body: { Text: { Data: string } } } };
+    }
+  ).input.Message.Body.Text.Data;
+}
+
+describe("public inquiry cart validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findUser.mockResolvedValue({
+      id: "seller-1",
+      clerkUserId: "clerk-1",
+      profile: { slug: "seller", title: "Seller" },
+    });
+    mocks.getClerkUserData.mockResolvedValue({ email: "seller@example.com" });
+    mocks.sendEmail.mockResolvedValue({});
+  });
+
+  it("uses current listing titles and prices in inquiry emails", async () => {
+    mocks.findListings.mockResolvedValue([
+      { id: "listing-1", title: "Database title", price: 25 },
+    ]);
+
+    await sendPublicInquiry({
+      userId: "seller-1",
+      customerEmail: "buyer@example.com",
+      message: "",
+      items: [baseItem],
+    });
+
+    expect(mocks.findListings).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["listing-1"] },
+        userId: "seller-1",
+        OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
+      },
+      select: { id: true, title: true, price: true },
+    });
+    expect(emailBody(0)).toContain("Database title – Qty: 2 ($25.00 each)");
+    expect(emailBody(0)).toContain("Subtotal: $50.00");
+    expect(emailBody(0)).not.toContain("Client title");
+  });
+
+  it("omits invalid items and discloses the omission in both emails", async () => {
+    mocks.findListings.mockResolvedValue([
+      { id: "listing-1", title: "Database title", price: null },
+    ]);
+
+    await sendPublicInquiry({
+      userId: "seller-1",
+      customerEmail: "buyer@example.com",
+      message: "Interested",
+      items: [
+        baseItem,
+        { ...baseItem, id: "cart-2", listingId: "invalid-listing" },
+      ],
+    });
+
+    expect(emailBody(0)).toContain("Database title – Qty: 2");
+    expect(emailBody(0)).toContain(
+      "One or more unavailable items were omitted.",
+    );
+    expect(emailBody(1)).toContain(
+      "One or more unavailable items were omitted.",
+    );
+  });
+
+  it("rejects a cart when none of its listings can be verified", async () => {
+    mocks.findListings.mockResolvedValue([]);
+
+    await expect(
+      sendPublicInquiry({
+        userId: "seller-1",
+        customerEmail: "buyer@example.com",
+        message: "Interested",
+        items: [baseItem],
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("leaves message-only inquiries unchanged", async () => {
+    await sendPublicInquiry({
+      userId: "seller-1",
+      customerEmail: "buyer@example.com",
+      message: "Do you ship?",
+    });
+
+    expect(mocks.findListings).not.toHaveBeenCalled();
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Resolve inquiry cart titles and prices from the seller's current published listings.
- Omit unavailable or foreign listings, disclose partial omissions in both emails, and reject carts with no valid listings.
- Leave the public request schema, client cart, and message-only inquiry behavior unchanged.

## Why

Inquiry emails previously trusted client-provided listing titles and prices, allowing fabricated catalog details to appear in official seller and buyer emails.

## Validation

- `pnpm main test -- tests/public-inquiry.test.ts tests/public-inquiry-rate-limit.test.ts tests/public-router-send-message.test.ts` (10 passed)
- `pnpm typecheck`
- `pnpm lint`
- `codex review --uncommitted` (no actionable findings)

The full `pnpm test` run reached an unrelated 5-second timeout in `dashboard-db-collections.test.tsx`; the same timeout reproduced when that dashboard file was run in isolation. All inquiry tests passed.
