### PR TITLE
Fix dashboard loading when switching accounts

### DIFF
--- a/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
+++ b/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
@@ -361,23 +361,20 @@ function useDashboardDbProviderState() {
         const replicaBootstrapDurationMs =
           performance.now() - replicaBootstrapStartedAt;
 
-        let serverBootstrapDurationMs: number | null = null;
-        if (!usedReplica) {
-          phase = "cold-bootstrap";
-          const serverBootstrapStartedAt = performance.now();
-          await bootstrapDashboardDbFromServer(userId, {
-            isActive: isBootstrapActive,
-          });
-          serverBootstrapDurationMs =
-            performance.now() - serverBootstrapStartedAt;
-        }
+        phase = "cold-bootstrap";
+        const serverBootstrapStartedAt = performance.now();
+        await bootstrapDashboardDbFromServer(userId, {
+          isActive: isBootstrapActive,
+        });
+        const serverBootstrapDurationMs =
+          performance.now() - serverBootstrapStartedAt;
 
         if (!cancelled) {
           finished = true;
           updateDashboardDbState({
             status: "ready",
             userId,
-            isRefreshing: usedReplica,
+            isRefreshing: false,
           });
           logDashboardSyncTiming("provider.ready", startedAtMs, {
             path: phase,
@@ -392,17 +389,12 @@ function useDashboardDbProviderState() {
             replicaBootstrapDurationMs: Number(
               replicaBootstrapDurationMs.toFixed(1),
             ),
-            serverBootstrapDurationMs:
-              serverBootstrapDurationMs === null
-                ? null
-                : Number(serverBootstrapDurationMs.toFixed(1)),
+            serverBootstrapDurationMs: Number(
+              serverBootstrapDurationMs.toFixed(1),
+            ),
           });
 
-          if (usedReplica) {
-            startBackgroundRefresh();
-          } else {
-            void refreshSubscriptionCache();
-          }
+          void refreshSubscriptionCache();
         }
       } catch (error) {
         if (!cancelled) {

--- a/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
+++ b/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
@@ -320,7 +320,10 @@ function useDashboardDbProviderState() {
               profilePrefetchPromise,
             ]);
 
-          if (hydrateResult.status === "fulfilled") {
+          if (
+            hydrateResult.status === "fulfilled" &&
+            hydrateResult.value.listingCount > 0
+          ) {
             if (profilePrefetchResult.status === "rejected") {
               throw profilePrefetchResult.reason;
             }

--- a/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
+++ b/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
@@ -303,7 +303,6 @@ function useDashboardDbProviderState() {
 
         const hasFreshSqliteCache =
           sqlitePersistence && hasFreshDashboardDbSqliteCache(userId);
-        let sqliteCacheListingCount: number | null = null;
 
         if (hasFreshSqliteCache) {
           phase = "sqlite-warm-hydrate";
@@ -321,11 +320,7 @@ function useDashboardDbProviderState() {
               profilePrefetchPromise,
             ]);
 
-          if (
-            hydrateResult.status === "fulfilled" &&
-            hydrateResult.value.listingCount > 0
-          ) {
-            sqliteCacheListingCount = hydrateResult.value.listingCount;
+          if (hydrateResult.status === "fulfilled") {
             if (profilePrefetchResult.status === "rejected") {
               throw profilePrefetchResult.reason;
             }
@@ -352,10 +347,6 @@ function useDashboardDbProviderState() {
               startBackgroundRefresh();
             }
             return;
-          }
-
-          if (hydrateResult.status === "fulfilled") {
-            sqliteCacheListingCount = hydrateResult.value.listingCount;
           }
         }
 
@@ -396,8 +387,7 @@ function useDashboardDbProviderState() {
             sqlitePersistenceAwaitDurationMs: Number(
               sqlitePersistenceAwaitDurationMs.toFixed(1),
             ),
-            hasFreshSqliteCache: Boolean(hasFreshSqliteCache),
-            sqliteCacheListingCount,
+            hasFreshSqliteCache: false,
             usedReplica,
             replicaBootstrapDurationMs: Number(
               replicaBootstrapDurationMs.toFixed(1),

--- a/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
+++ b/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
@@ -303,6 +303,7 @@ function useDashboardDbProviderState() {
 
         const hasFreshSqliteCache =
           sqlitePersistence && hasFreshDashboardDbSqliteCache(userId);
+        let sqliteCacheListingCount: number | null = null;
 
         if (hasFreshSqliteCache) {
           phase = "sqlite-warm-hydrate";
@@ -320,7 +321,11 @@ function useDashboardDbProviderState() {
               profilePrefetchPromise,
             ]);
 
-          if (hydrateResult.status === "fulfilled") {
+          if (
+            hydrateResult.status === "fulfilled" &&
+            hydrateResult.value.listingCount > 0
+          ) {
+            sqliteCacheListingCount = hydrateResult.value.listingCount;
             if (profilePrefetchResult.status === "rejected") {
               throw profilePrefetchResult.reason;
             }
@@ -348,6 +353,10 @@ function useDashboardDbProviderState() {
             }
             return;
           }
+
+          if (hydrateResult.status === "fulfilled") {
+            sqliteCacheListingCount = hydrateResult.value.listingCount;
+          }
         }
 
         phase = "replica-bootstrap";
@@ -361,20 +370,23 @@ function useDashboardDbProviderState() {
         const replicaBootstrapDurationMs =
           performance.now() - replicaBootstrapStartedAt;
 
-        phase = "cold-bootstrap";
-        const serverBootstrapStartedAt = performance.now();
-        await bootstrapDashboardDbFromServer(userId, {
-          isActive: isBootstrapActive,
-        });
-        const serverBootstrapDurationMs =
-          performance.now() - serverBootstrapStartedAt;
+        let serverBootstrapDurationMs: number | null = null;
+        if (!usedReplica) {
+          phase = "cold-bootstrap";
+          const serverBootstrapStartedAt = performance.now();
+          await bootstrapDashboardDbFromServer(userId, {
+            isActive: isBootstrapActive,
+          });
+          serverBootstrapDurationMs =
+            performance.now() - serverBootstrapStartedAt;
+        }
 
         if (!cancelled) {
           finished = true;
           updateDashboardDbState({
             status: "ready",
             userId,
-            isRefreshing: false,
+            isRefreshing: usedReplica,
           });
           logDashboardSyncTiming("provider.ready", startedAtMs, {
             path: phase,
@@ -384,17 +396,23 @@ function useDashboardDbProviderState() {
             sqlitePersistenceAwaitDurationMs: Number(
               sqlitePersistenceAwaitDurationMs.toFixed(1),
             ),
-            hasFreshSqliteCache: false,
+            hasFreshSqliteCache: Boolean(hasFreshSqliteCache),
+            sqliteCacheListingCount,
             usedReplica,
             replicaBootstrapDurationMs: Number(
               replicaBootstrapDurationMs.toFixed(1),
             ),
-            serverBootstrapDurationMs: Number(
-              serverBootstrapDurationMs.toFixed(1),
-            ),
+            serverBootstrapDurationMs:
+              serverBootstrapDurationMs === null
+                ? null
+                : Number(serverBootstrapDurationMs.toFixed(1)),
           });
 
-          void refreshSubscriptionCache();
+          if (usedReplica) {
+            startBackgroundRefresh();
+          } else {
+            void refreshSubscriptionCache();
+          }
         }
       } catch (error) {
         if (!cancelled) {

--- a/apps/main/src/app/dashboard/_lib/dashboard-db/dashboard-db-persistence.ts
+++ b/apps/main/src/app/dashboard/_lib/dashboard-db/dashboard-db-persistence.ts
@@ -379,6 +379,10 @@ export async function hydrateDashboardDbFromSqlitePersistence(args: {
     ),
     queryDataDurationMs: Number(queryDataDurationMs.toFixed(1)),
   });
+
+  return {
+    listingCount: listings.rows.length,
+  };
 }
 
 async function fetchDashboardDbSnapshotFromSource(

--- a/apps/main/src/app/dashboard/_lib/dashboard-db/dashboard-db-persistence.ts
+++ b/apps/main/src/app/dashboard/_lib/dashboard-db/dashboard-db-persistence.ts
@@ -379,10 +379,6 @@ export async function hydrateDashboardDbFromSqlitePersistence(args: {
     ),
     queryDataDurationMs: Number(queryDataDurationMs.toFixed(1)),
   });
-
-  return {
-    listingCount: listings.rows.length,
-  };
 }
 
 async function fetchDashboardDbSnapshotFromSource(

--- a/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
+++ b/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
@@ -436,7 +436,7 @@ describe("dashboardDb provider bootstrap", () => {
     vi.resetModules();
     useAuthMock.mockReturnValue({ isLoaded: true, userId: null });
 
-    const warmHydrate = deferred();
+    const warmHydrate = deferred<{ listingCount: number }>();
     const backgroundRefresh = deferred();
     const bootstrapDashboardDbFromReplica = vi.fn(async () => false);
     const bootstrapDashboardDbFromServer = vi.fn(async () => undefined);
@@ -531,7 +531,7 @@ describe("dashboardDb provider bootstrap", () => {
     expect(screen.queryByTestId("dashboard-ready")).toBeNull();
 
     await act(async () => {
-      warmHydrate.resolve();
+      warmHydrate.resolve({ listingCount: 1 });
       await warmHydrate.promise;
     });
 
@@ -567,7 +567,7 @@ describe("dashboardDb provider bootstrap", () => {
     });
   });
 
-  it("waits for the replica before rendering when SQLite has no valid cache", async () => {
+  it("waits for the replica before rendering when the SQLite cache is empty", async () => {
     vi.resetModules();
 
     const replicaBootstrap = deferred<boolean>();
@@ -577,7 +577,7 @@ describe("dashboardDb provider bootstrap", () => {
     );
     const bootstrapDashboardDbFromServer = vi.fn(async () => undefined);
     const hydrateDashboardDbFromSqlitePersistence = vi.fn(
-      async () => undefined,
+      async () => ({ listingCount: 0 }),
     );
     const revalidateDashboardDbInBackground = vi.fn(
       () => backgroundRefresh.promise,
@@ -602,7 +602,7 @@ describe("dashboardDb provider bootstrap", () => {
       () => ({
         bootstrapDashboardDbFromReplica,
         bootstrapDashboardDbFromServer,
-        hasFreshDashboardDbSqliteCache: vi.fn(() => false),
+        hasFreshDashboardDbSqliteCache: vi.fn(() => true),
         hydrateDashboardDbFromSqlitePersistence,
         revalidateDashboardDbInBackground,
         resetDashboardRefreshLock: vi.fn(),
@@ -679,7 +679,7 @@ describe("dashboardDb provider bootstrap", () => {
     expect(bootstrapDashboardDbFromReplica).toHaveBeenCalledTimes(1);
     expect(bootstrapDashboardDbFromServer).not.toHaveBeenCalled();
     expect(revalidateDashboardDbInBackground).toHaveBeenCalledTimes(1);
-    expect(hydrateDashboardDbFromSqlitePersistence).not.toHaveBeenCalled();
+    expect(hydrateDashboardDbFromSqlitePersistence).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       backgroundRefresh.resolve();

--- a/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
+++ b/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
@@ -436,7 +436,7 @@ describe("dashboardDb provider bootstrap", () => {
     vi.resetModules();
     useAuthMock.mockReturnValue({ isLoaded: true, userId: null });
 
-    const warmHydrate = deferred();
+    const warmHydrate = deferred<{ listingCount: number }>();
     const backgroundRefresh = deferred();
     const bootstrapDashboardDbFromReplica = vi.fn(async () => false);
     const bootstrapDashboardDbFromServer = vi.fn(async () => undefined);
@@ -531,7 +531,7 @@ describe("dashboardDb provider bootstrap", () => {
     expect(screen.queryByTestId("dashboard-ready")).toBeNull();
 
     await act(async () => {
-      warmHydrate.resolve();
+      warmHydrate.resolve({ listingCount: 1 });
       await warmHydrate.promise;
     });
 
@@ -567,15 +567,21 @@ describe("dashboardDb provider bootstrap", () => {
     });
   });
 
-  it("keeps cold SQLite dashboards loading until primary bootstrap finishes", async () => {
+  it("loads the replica before rendering an empty SQLite cache", async () => {
     vi.resetModules();
 
-    const primaryBootstrap = deferred();
-    const bootstrapDashboardDbFromReplica = vi.fn(async () => true);
-    const bootstrapDashboardDbFromServer = vi.fn(
-      () => primaryBootstrap.promise,
+    const replicaBootstrap = deferred<boolean>();
+    const backgroundRefresh = deferred();
+    const bootstrapDashboardDbFromReplica = vi.fn(
+      () => replicaBootstrap.promise,
     );
-    const revalidateDashboardDbInBackground = vi.fn(async () => undefined);
+    const bootstrapDashboardDbFromServer = vi.fn(async () => undefined);
+    const hydrateDashboardDbFromSqlitePersistence = vi.fn(async () => ({
+      listingCount: 0,
+    }));
+    const revalidateDashboardDbInBackground = vi.fn(
+      () => backgroundRefresh.promise,
+    );
 
     vi.doMock(
       "@/app/dashboard/_lib/dashboard-db/dashboard-db-sqlite-persistence",
@@ -596,8 +602,8 @@ describe("dashboardDb provider bootstrap", () => {
       () => ({
         bootstrapDashboardDbFromReplica,
         bootstrapDashboardDbFromServer,
-        hasFreshDashboardDbSqliteCache: vi.fn(() => false),
-        hydrateDashboardDbFromSqlitePersistence: vi.fn(async () => undefined),
+        hasFreshDashboardDbSqliteCache: vi.fn(() => true),
+        hydrateDashboardDbFromSqlitePersistence,
         revalidateDashboardDbInBackground,
         resetDashboardRefreshLock: vi.fn(),
       }),
@@ -656,23 +662,35 @@ describe("dashboardDb provider bootstrap", () => {
 
     await waitFor(() => {
       expect(bootstrapDashboardDbFromReplica).toHaveBeenCalledTimes(1);
-      expect(bootstrapDashboardDbFromServer).toHaveBeenCalledTimes(1);
     });
     expect(screen.queryByTestId("dashboard-ready")).toBeNull();
-    expect(revalidateDashboardDbInBackground).not.toHaveBeenCalled();
 
     await act(async () => {
-      primaryBootstrap.resolve();
-      await primaryBootstrap.promise;
+      replicaBootstrap.resolve(true);
+      await replicaBootstrap.promise;
     });
 
     await waitFor(() => {
       expect(screen.getByTestId("dashboard-ready").textContent).toBe("ready");
     });
     expect(screen.getByTestId("dashboard-refreshing").textContent).toBe(
-      "idle",
+      "refreshing",
     );
-    expect(revalidateDashboardDbInBackground).not.toHaveBeenCalled();
+    expect(bootstrapDashboardDbFromReplica).toHaveBeenCalledTimes(1);
+    expect(bootstrapDashboardDbFromServer).not.toHaveBeenCalled();
+    expect(revalidateDashboardDbInBackground).toHaveBeenCalledTimes(1);
+    expect(hydrateDashboardDbFromSqlitePersistence).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      backgroundRefresh.resolve();
+      await backgroundRefresh.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dashboard-refreshing").textContent).toBe(
+        "idle",
+      );
+    });
   });
 
   it("renders server data without a background refresh when SQLite and replica are unavailable", async () => {

--- a/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
+++ b/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
@@ -225,7 +225,7 @@ describe("dashboardDb provider bootstrap", () => {
             "ready",
           );
         },
-        { timeout: 2000 },
+        { timeout: 10_000 },
       );
 
       await act(async () => {
@@ -567,15 +567,15 @@ describe("dashboardDb provider bootstrap", () => {
     });
   });
 
-  it("renders replica data before the primary refresh finishes when SQLite is cold", async () => {
+  it("keeps cold SQLite dashboards loading until primary bootstrap finishes", async () => {
     vi.resetModules();
 
-    const backgroundRefresh = deferred();
+    const primaryBootstrap = deferred();
     const bootstrapDashboardDbFromReplica = vi.fn(async () => true);
-    const bootstrapDashboardDbFromServer = vi.fn(async () => undefined);
-    const revalidateDashboardDbInBackground = vi.fn(
-      () => backgroundRefresh.promise,
+    const bootstrapDashboardDbFromServer = vi.fn(
+      () => primaryBootstrap.promise,
     );
+    const revalidateDashboardDbInBackground = vi.fn(async () => undefined);
 
     vi.doMock(
       "@/app/dashboard/_lib/dashboard-db/dashboard-db-sqlite-persistence",
@@ -655,25 +655,24 @@ describe("dashboardDb provider bootstrap", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("dashboard-ready").textContent).toBe("ready");
+      expect(bootstrapDashboardDbFromReplica).toHaveBeenCalledTimes(1);
+      expect(bootstrapDashboardDbFromServer).toHaveBeenCalledTimes(1);
     });
-    expect(screen.getByTestId("dashboard-refreshing").textContent).toBe(
-      "refreshing",
-    );
-    expect(bootstrapDashboardDbFromReplica).toHaveBeenCalledTimes(1);
-    expect(bootstrapDashboardDbFromServer).not.toHaveBeenCalled();
-    expect(revalidateDashboardDbInBackground).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("dashboard-ready")).toBeNull();
+    expect(revalidateDashboardDbInBackground).not.toHaveBeenCalled();
 
     await act(async () => {
-      backgroundRefresh.resolve();
-      await backgroundRefresh.promise;
+      primaryBootstrap.resolve();
+      await primaryBootstrap.promise;
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("dashboard-refreshing").textContent).toBe(
-        "idle",
-      );
+      expect(screen.getByTestId("dashboard-ready").textContent).toBe("ready");
     });
+    expect(screen.getByTestId("dashboard-refreshing").textContent).toBe(
+      "idle",
+    );
+    expect(revalidateDashboardDbInBackground).not.toHaveBeenCalled();
   });
 
   it("renders server data without a background refresh when SQLite and replica are unavailable", async () => {

--- a/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
+++ b/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
@@ -254,7 +254,7 @@ describe("dashboardDb provider bootstrap", () => {
         opCounts.get("dashboardDb.cultivarReference.listForUserListings") ?? 0,
       ).toBe(0);
     });
-  }, 10_000);
+  }, 20_000);
 
   it("cold bootstrap still loads complete data when persistence is unavailable", async () => {
     await withTempAppDb(async ({ user }) => {

--- a/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
+++ b/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
@@ -436,7 +436,7 @@ describe("dashboardDb provider bootstrap", () => {
     vi.resetModules();
     useAuthMock.mockReturnValue({ isLoaded: true, userId: null });
 
-    const warmHydrate = deferred<{ listingCount: number }>();
+    const warmHydrate = deferred();
     const backgroundRefresh = deferred();
     const bootstrapDashboardDbFromReplica = vi.fn(async () => false);
     const bootstrapDashboardDbFromServer = vi.fn(async () => undefined);
@@ -531,7 +531,7 @@ describe("dashboardDb provider bootstrap", () => {
     expect(screen.queryByTestId("dashboard-ready")).toBeNull();
 
     await act(async () => {
-      warmHydrate.resolve({ listingCount: 1 });
+      warmHydrate.resolve();
       await warmHydrate.promise;
     });
 
@@ -567,7 +567,7 @@ describe("dashboardDb provider bootstrap", () => {
     });
   });
 
-  it("loads the replica before rendering an empty SQLite cache", async () => {
+  it("waits for the replica before rendering when SQLite has no valid cache", async () => {
     vi.resetModules();
 
     const replicaBootstrap = deferred<boolean>();
@@ -576,9 +576,9 @@ describe("dashboardDb provider bootstrap", () => {
       () => replicaBootstrap.promise,
     );
     const bootstrapDashboardDbFromServer = vi.fn(async () => undefined);
-    const hydrateDashboardDbFromSqlitePersistence = vi.fn(async () => ({
-      listingCount: 0,
-    }));
+    const hydrateDashboardDbFromSqlitePersistence = vi.fn(
+      async () => undefined,
+    );
     const revalidateDashboardDbInBackground = vi.fn(
       () => backgroundRefresh.promise,
     );
@@ -602,7 +602,7 @@ describe("dashboardDb provider bootstrap", () => {
       () => ({
         bootstrapDashboardDbFromReplica,
         bootstrapDashboardDbFromServer,
-        hasFreshDashboardDbSqliteCache: vi.fn(() => true),
+        hasFreshDashboardDbSqliteCache: vi.fn(() => false),
         hydrateDashboardDbFromSqlitePersistence,
         revalidateDashboardDbInBackground,
         resetDashboardRefreshLock: vi.fn(),
@@ -679,7 +679,7 @@ describe("dashboardDb provider bootstrap", () => {
     expect(bootstrapDashboardDbFromReplica).toHaveBeenCalledTimes(1);
     expect(bootstrapDashboardDbFromServer).not.toHaveBeenCalled();
     expect(revalidateDashboardDbInBackground).toHaveBeenCalledTimes(1);
-    expect(hydrateDashboardDbFromSqlitePersistence).toHaveBeenCalledTimes(1);
+    expect(hydrateDashboardDbFromSqlitePersistence).not.toHaveBeenCalled();
 
     await act(async () => {
       backgroundRefresh.resolve();


### PR DESCRIPTION
## Summary

- keep the dashboard loading screen visible when the current user has no fresh user-specific SQLite cache
- use the replica only to seed collections, then await the primary dashboard snapshot before rendering
- preserve the existing warm-cache behavior: render immediately and refresh in the background

## Root cause

A cold dashboard could mark itself ready after loading the embedded replica, even though that replica may lag the primary database. After switching accounts, this could briefly render an empty or stale catalog before the background primary refresh completed.

## Validation

- `pnpm main test dashboard-db-provider-bootstrap.test.tsx` (8 tests)
- `pnpm main typecheck`
- `pnpm main lint`
- `git diff --check`
