### PR TITLE
Remove unused cultivar route endpoint

### DIFF
--- a/apps/main/src/server/api/routers/public.ts
+++ b/apps/main/src/server/api/routers/public.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "../trpc";
-import {
-  getCultivarRouteSegments,
-  getPublicCultivarPage,
-} from "@/server/db/public-cultivar-read-model";
+import { getPublicCultivarPage } from "@/server/db/public-cultivar-read-model";
 import {
   getListings,
   getPublicListingDetail,
@@ -89,10 +86,6 @@ export const publicRouter = createTRPCRouter({
       }),
     )
     .query(({ input }) => getPublicCultivarPage(input.cultivarNormalizedName)),
-
-  getCultivarRouteSegments: publicProcedure.query(() =>
-    getCultivarRouteSegments(),
-  ),
 
   sendMessage: publicProcedure
     .input(publicInquiryInputSchema)

--- a/apps/main/src/server/db/public-cultivar-context.ts
+++ b/apps/main/src/server/db/public-cultivar-context.ts
@@ -91,26 +91,6 @@ async function findCultivarReferenceByNormalizedName(
   return row ? withResolvedDisplayAhsListing(row) : null;
 }
 
-export async function getCultivarRouteSegments(): Promise<string[]> {
-  const cultivars = await replicaDb.cultivarReference.findMany({
-    where: getCultivarReferenceLookupWhereClause(),
-    select: {
-      normalizedName: true,
-    },
-  });
-
-  const uniqueSegments = new Set<string>();
-
-  cultivars.forEach((cultivar) => {
-    const segment = toCultivarRouteSegment(cultivar.normalizedName);
-    if (segment) {
-      uniqueSegments.add(segment);
-    }
-  });
-
-  return Array.from(uniqueSegments).sort();
-}
-
 export async function getCultivarSitemapEntries(): Promise<
   Array<{
     segment: string;

--- a/apps/main/src/server/db/public-cultivar-read-model.ts
+++ b/apps/main/src/server/db/public-cultivar-read-model.ts
@@ -1,7 +1,4 @@
-export {
-  getCultivarRouteSegments,
-  getCultivarSitemapEntries,
-} from "./public-cultivar-context";
+export { getCultivarSitemapEntries } from "./public-cultivar-context";
 export {
   buildPublicCultivarGardenPhotosFromListingCards,
   buildPublicCultivarOffersFromListingCards,


### PR DESCRIPTION
## Summary

- Remove the unused `public.getCultivarRouteSegments` tRPC procedure.
- Remove its read-model re-export and unbounded database helper.
- Keep the live cultivar page and sitemap paths unchanged.

## Why

The helper originally supported `generateStaticParams` before cultivar pages moved to on-demand ISR. Nothing calls it now, but the public endpoint still allowed an unauthenticated request to load, transform, deduplicate, and sort every cultivar reference.

## Validation

- `pnpm main test -- tests/get-public-cultivars.test.ts tests/sitemap-host-selection.test.ts` (13 passed)
- `pnpm typecheck`
- `pnpm lint`
- `rg -n "getCultivarRouteSegments" apps/main/src apps/main/tests` (no matches)

The full suite completed with 434 passing tests and 13 unrelated failures under heavy parallel load, primarily existing test timeouts. The focused cultivar and sitemap tests pass.
