### PR TITLE
Polish the anonymous onboarding experience

### DIFF
--- a/apps/main/src/app/onboarding/anonymous-onboarding-config.ts
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-config.ts
@@ -83,6 +83,7 @@ export const DEFAULT_PROFILE_DESCRIPTION_PLACEHOLDER =
   "Daylily collector in Your City, ST offering healthy dormant fans, clearly labeled plants, and prompt replies with spring and fall shipping.";
 export const DEFAULT_LISTING_DESCRIPTION_PLACEHOLDER =
   "Healthy dormant fan with strong roots, clearly labeled, and ready for spring shipping or local pickup.";
+export const DEFAULT_LISTING_PRICE_PLACEHOLDER = 25;
 
 export function getListingTitlePlaceholder(cultivarName: string) {
   return `${cultivarName} Spring Fan`;
@@ -168,6 +169,8 @@ export function getListingPreview(
     selectedCultivar,
     title: draft.listingPreview.title.trim() || titlePlaceholder,
     titlePlaceholder,
+    price:
+      draft.listingPreview.price ?? DEFAULT_LISTING_PRICE_PLACEHOLDER,
     description:
       draft.listingPreview.description.trim() ||
       DEFAULT_LISTING_DESCRIPTION_PLACEHOLDER,

--- a/apps/main/src/app/onboarding/anonymous-onboarding-layout.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-layout.tsx
@@ -117,7 +117,6 @@ export function AnonymousOnboardingPageClient(
           ) : null}
           {draft.step === "preview" ? (
             <PreviewStep
-              draft={controller.draft}
               goToStep={controller.goToStep}
               listingPreview={controller.listingPreview}
               profilePreview={controller.profilePreview}

--- a/apps/main/src/app/onboarding/anonymous-onboarding-layout.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-layout.tsx
@@ -57,6 +57,7 @@ export function AnonymousOnboardingPageClient(
         <AnonymousOnboardingHeader
           currentStepIndex={controller.currentStepIndex}
           draft={controller.draft}
+          furthestStepIndex={controller.furthestStepIndex}
           goToStep={controller.goToStep}
           progressValue={controller.progressValue}
         />
@@ -157,12 +158,17 @@ export function AnonymousOnboardingPageClient(
 
 type AnonymousOnboardingHeaderProps = Pick<
   AnonymousOnboardingController,
-  "currentStepIndex" | "draft" | "goToStep" | "progressValue"
+  | "currentStepIndex"
+  | "draft"
+  | "furthestStepIndex"
+  | "goToStep"
+  | "progressValue"
 >;
 
 function AnonymousOnboardingHeader({
   currentStepIndex,
   draft,
+  furthestStepIndex,
   goToStep,
   progressValue,
 }: AnonymousOnboardingHeaderProps) {
@@ -200,8 +206,8 @@ function AnonymousOnboardingHeader({
       <div className="flex gap-2 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {ANONYMOUS_ONBOARDING_STEPS.map((step, index) => {
           const isCurrent = step.id === draft.step;
-          const isComplete = index < currentStepIndex;
-          const canOpen = index <= currentStepIndex;
+          const isComplete = index < furthestStepIndex;
+          const canOpen = index <= furthestStepIndex;
 
           return (
             <button
@@ -212,6 +218,7 @@ function AnonymousOnboardingHeader({
               className="focus-visible:ring-ring disabled:text-muted-foreground/50 data-[current=true]:border-primary data-[current=true]:bg-primary/10 data-[current=true]:text-primary shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed data-[complete=true]:border-emerald-500/40 data-[complete=true]:bg-emerald-500/10 data-[complete=true]:text-emerald-700"
               data-current={isCurrent}
               data-complete={isComplete}
+              data-testid={`anonymous-onboarding-step-${step.id}`}
               onClick={() => goToStep(step.id)}
             >
               <span className="inline-flex items-center gap-1.5">

--- a/apps/main/src/app/onboarding/anonymous-onboarding-layout.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-layout.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useRef } from "react";
 import { ArrowRight, CheckCircle2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -142,7 +141,6 @@ export function AnonymousOnboardingPageClient(
 
         {draft.step !== "email" && draft.step !== "checkout" ? (
           <AnonymousOnboardingFooter
-            clearDraft={controller.clearDraft}
             collectEmail={controller.collectEmail}
             currentStepIndex={controller.currentStepIndex}
             draft={controller.draft}
@@ -236,7 +234,6 @@ function AnonymousOnboardingHeader({
 
 type AnonymousOnboardingFooterProps = Pick<
   AnonymousOnboardingController,
-  | "clearDraft"
   | "collectEmail"
   | "currentStepIndex"
   | "draft"
@@ -246,7 +243,6 @@ type AnonymousOnboardingFooterProps = Pick<
 >;
 
 function AnonymousOnboardingFooter({
-  clearDraft,
   collectEmail,
   currentStepIndex,
   draft,
@@ -257,7 +253,7 @@ function AnonymousOnboardingFooter({
   const currentStep = ANONYMOUS_ONBOARDING_STEPS[currentStepIndex]!;
 
   return (
-    <footer className="space-y-2 border-t pt-3">
+    <footer className="border-t pt-3">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="text-muted-foreground text-sm">
           {currentStep.description}
@@ -284,22 +280,6 @@ function AnonymousOnboardingFooter({
         </div>
       </div>
 
-      <div className="flex flex-wrap justify-between gap-3">
-        <Button
-          type="button"
-          variant="link"
-          className="text-muted-foreground hover:text-foreground h-auto p-0 text-xs"
-          onClick={clearDraft}
-        >
-          Start over
-        </Button>
-        <Link
-          href="/"
-          className="text-muted-foreground hover:text-foreground text-xs underline underline-offset-2"
-        >
-          Return home
-        </Link>
-      </div>
     </footer>
   );
 }

--- a/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
@@ -129,7 +129,11 @@ export function EmailStep({
           <Label htmlFor="anonymous-onboarding-email">Email address</Label>
           <Input
             id="anonymous-onboarding-email"
+            name="email"
             data-testid="anonymous-onboarding-email"
+            data-1p-ignore="true"
+            data-bwignore="true"
+            data-lpignore="true"
             type="email"
             required
             autoComplete="email"
@@ -930,9 +934,14 @@ export function CheckoutStep({
               <Label htmlFor="anonymous-checkout-email">Account email</Label>
               <Input
                 id="anonymous-checkout-email"
+                name="email"
                 data-testid="anonymous-checkout-email"
+                data-1p-ignore="true"
+                data-bwignore="true"
+                data-lpignore="true"
                 type="email"
                 required
+                autoComplete="email"
                 value={emailInput}
                 onChange={(event) => setEmailInput(event.target.value)}
               />

--- a/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
@@ -668,6 +668,7 @@ export function ListingStep({
                     width={48}
                     height={48}
                     className="size-12 shrink-0 rounded object-cover"
+                    unoptimized
                   />
                   <span className="min-w-0 space-y-0.5">
                     <span className="block text-sm leading-tight font-medium whitespace-normal">

--- a/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
@@ -24,6 +24,8 @@ import {
 } from "./anonymous-onboarding-preview-cards";
 import {
   DEFAULT_GARDEN_NAME_PLACEHOLDER,
+  DEFAULT_LISTING_DESCRIPTION_PLACEHOLDER,
+  DEFAULT_LISTING_PRICE_PLACEHOLDER,
   DEFAULT_LOCATION_PLACEHOLDER,
   DEFAULT_PROFILE_DESCRIPTION_PLACEHOLDER,
   STARTER_PROFILE_IMAGES,
@@ -647,8 +649,9 @@ export function ListingStep({
                   key={cultivar.key}
                   type="button"
                   variant={selected ? "default" : "outline"}
-                  className="w-full justify-center overflow-hidden px-3"
+                  className="h-auto min-h-16 w-full justify-start overflow-hidden px-2 py-2 text-left"
                   title={cultivar.name}
+                  aria-label={cultivar.name}
                   onClick={() =>
                     setDraft((currentDraft) => ({
                       ...currentDraft,
@@ -659,7 +662,21 @@ export function ListingStep({
                     }))
                   }
                 >
-                  <span className="max-w-full truncate">{cultivar.name}</span>
+                  <Image
+                    src={cultivar.imageUrl}
+                    alt=""
+                    width={48}
+                    height={48}
+                    className="size-12 shrink-0 rounded object-cover"
+                  />
+                  <span className="min-w-0 space-y-0.5">
+                    <span className="block text-sm leading-tight font-medium whitespace-normal">
+                      {cultivar.name}
+                    </span>
+                    <span className="block text-xs leading-tight font-normal whitespace-normal opacity-80">
+                      {cultivar.hybridizerYear}
+                    </span>
+                  </span>
                 </Button>
               );
             })}
@@ -688,6 +705,7 @@ export function ListingStep({
             data-testid="anonymous-listing-price"
             inputMode="decimal"
             value={draft.listingPreview.price ?? ""}
+            placeholder={String(DEFAULT_LISTING_PRICE_PLACEHOLDER)}
             onChange={(event) =>
               updateListingPreviewDraft(setDraft, {
                 price: parseListingPriceInput(event.target.value),
@@ -703,6 +721,7 @@ export function ListingStep({
             data-testid="anonymous-listing-description"
             rows={4}
             value={draft.listingPreview.description}
+            placeholder={DEFAULT_LISTING_DESCRIPTION_PLACEHOLDER}
             onChange={(event) =>
               updateListingPreviewDraft(setDraft, {
                 description: event.target.value,
@@ -719,19 +738,12 @@ export function ListingStep({
               title={listingPreview.title}
             />
             <div className="space-y-3">
-              <OnboardingImageUploadCropper
-                dropzoneTestId="anonymous-listing-image-dropzone"
-                inputId="anonymous-listing-image"
-                inputLabel="Upload listing image"
-                inputTestId="anonymous-listing-image"
-                setImageError={setImageError}
-                updateImage={updateListingImage}
-              />
               {draft.listingPreview.imageDataUrl ? (
                 <Button
                   type="button"
                   size="sm"
                   variant="outline"
+                  data-testid="anonymous-listing-image-reset"
                   onClick={() => {
                     setImageError(null);
                     updateListingPreviewDraft(setDraft, {
@@ -741,7 +753,16 @@ export function ListingStep({
                 >
                   Reset
                 </Button>
-              ) : null}
+              ) : (
+                <OnboardingImageUploadCropper
+                  dropzoneTestId="anonymous-listing-image-dropzone"
+                  inputId="anonymous-listing-image"
+                  inputLabel="Upload listing image"
+                  inputTestId="anonymous-listing-image"
+                  setImageError={setImageError}
+                  updateImage={updateListingImage}
+                />
+              )}
               {imageError ? (
                 <p className="text-destructive text-sm">{imageError}</p>
               ) : null}
@@ -755,7 +776,7 @@ export function ListingStep({
         <ListingPreviewCard
           title={listingPreview.title}
           description={listingPreview.description}
-          price={draft.listingPreview.price}
+          price={listingPreview.price}
           linkedLabel={listingPreview.selectedCultivar.name}
           hybridizerYear={listingPreview.selectedCultivar.hybridizerYear}
           imageUrl={listingPreview.imageUrl}
@@ -803,7 +824,7 @@ export function PreviewStep({
           <ListingPreviewCard
             title={listingPreview.title}
             description={listingPreview.description}
-            price={draft.listingPreview.price}
+            price={listingPreview.price}
             linkedLabel={listingPreview.selectedCultivar.name}
             hybridizerYear={listingPreview.selectedCultivar.hybridizerYear}
             imageUrl={listingPreview.imageUrl}

--- a/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { SignInButton } from "@clerk/nextjs";
 import Image from "next/image";
+import Link from "next/link";
 import { useCallback, useState } from "react";
 import { type FileRejection, useDropzone } from "react-dropzone";
 import {
   ArrowRight,
   CheckCircle2,
   CreditCard,
-  Mail,
   Pencil,
 } from "lucide-react";
 import { ImageCropper } from "@/components/image-cropper";
@@ -102,9 +101,12 @@ export function EmailStep({
   saveEmailAndContinue,
   setEmailInput,
 }: EmailStepProps) {
+  const [emailWasBlurred, setEmailWasBlurred] = useState(false);
+  const showEmailError = emailWasBlurred && !emailIsValid;
+
   return (
     <form
-      className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]"
+      className="space-y-6"
       onSubmit={(event) => {
         event.preventDefault();
         void saveEmailAndContinue("initial");
@@ -131,8 +133,22 @@ export function EmailStep({
             autoComplete="email"
             value={emailInput}
             onChange={(event) => setEmailInput(event.target.value)}
+            onBlur={() => setEmailWasBlurred(true)}
+            aria-invalid={showEmailError}
+            aria-describedby={
+              showEmailError ? "anonymous-onboarding-email-error" : undefined
+            }
             placeholder="you@example.com"
           />
+          {showEmailError ? (
+            <p
+              id="anonymous-onboarding-email-error"
+              className="text-destructive text-sm"
+              role="alert"
+            >
+              Enter a valid email address.
+            </p>
+          ) : null}
         </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -145,21 +161,12 @@ export function EmailStep({
             <ArrowRight className="size-4" />
           </Button>
 
-          <SignInButton mode="modal" forceRedirectUrl="/dashboard">
-            <Button type="button" variant="outline">
+          <Button asChild variant="outline">
+            <Link href="/sign-in">
               Already have an account? Log in
-            </Button>
-          </SignInButton>
+            </Link>
+          </Button>
         </div>
-      </div>
-
-      <div className="bg-card h-fit space-y-3 rounded-lg border p-5">
-        <Mail className="text-primary size-6" />
-        <p className="font-medium">Why ask first?</p>
-        <p className="text-muted-foreground text-sm leading-relaxed">
-          This saves your progress in this browser and keeps the same email
-          through checkout and sign-in.
-        </p>
       </div>
     </form>
   );

--- a/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
@@ -529,25 +529,27 @@ export function ProfileStep({
                 </div>
               ) : (
                 <div className="space-y-3">
-                  <OnboardingImageUploadCropper
-                    dropzoneTestId="anonymous-profile-image-dropzone"
-                    inputId="anonymous-profile-image"
-                    inputLabel="Upload profile image"
-                    inputTestId="anonymous-profile-image"
-                    setImageError={setImageError}
-                    updateImage={updateProfileImage}
-                  />
                   {draft.profile.profileImageSource === "upload" &&
                   draft.profile.profileImageDataUrl ? (
                     <Button
                       type="button"
                       size="sm"
                       variant="outline"
+                      data-testid="anonymous-profile-image-reset"
                       onClick={clearProfileImage}
                     >
                       Reset
                     </Button>
-                  ) : null}
+                  ) : (
+                    <OnboardingImageUploadCropper
+                      dropzoneTestId="anonymous-profile-image-dropzone"
+                      inputId="anonymous-profile-image"
+                      inputLabel="Upload profile image"
+                      inputTestId="anonymous-profile-image"
+                      setImageError={setImageError}
+                      updateImage={updateProfileImage}
+                    />
+                  )}
                 </div>
               )}
 

--- a/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
@@ -322,14 +322,16 @@ function OnboardingImageUploadCropper({
 
   if (cropImageUrl) {
     return (
-      <ImageCropper
-        src={cropImageUrl}
-        confirmButtonLabel="Use cropped image"
-        onCancel={resetCropper}
-        onCropComplete={(blob) => {
-          void Promise.resolve(updateImage(blob)).then(resetCropper);
-        }}
-      />
+      <div className="max-w-sm [overflow-anchor:none]">
+        <ImageCropper
+          src={cropImageUrl}
+          confirmButtonLabel="Use cropped image"
+          onCancel={resetCropper}
+          onCropComplete={(blob) => {
+            void Promise.resolve(updateImage(blob)).then(resetCropper);
+          }}
+        />
+      </div>
     );
   }
 

--- a/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
@@ -789,11 +789,10 @@ export function ListingStep({
 
 type PreviewStepProps = Pick<
   AnonymousOnboardingController,
-  "draft" | "goToStep" | "listingPreview" | "profilePreview"
+  "goToStep" | "listingPreview" | "profilePreview"
 >;
 
 export function PreviewStep({
-  draft,
   goToStep,
   listingPreview,
   profilePreview,
@@ -844,7 +843,7 @@ export function PreviewStep({
         <p className="font-semibold">How buyers contact you</p>
         <p className="text-muted-foreground text-sm leading-relaxed">
           Buyers can contact you directly from your catalog, or add priced
-          listings to cart and send one message with selected items.
+          listings to cart and send a message with their selected items.
         </p>
         <div className="text-muted-foreground space-y-2 text-sm">
           <p className="flex items-start gap-2">
@@ -856,14 +855,19 @@ export function PreviewStep({
           <p className="flex items-start gap-2">
             <CheckCircle2 className="mt-0.5 size-4 text-emerald-600" />
             <span>
-              Path 2: Buyer adds priced listings to cart, then sends one message
+              Path 2: Buyer adds priced listings to cart, then sends a message
               with item details.
             </span>
           </p>
         </div>
         <p className="text-muted-foreground text-sm leading-relaxed">
-          Buyers do not pay on Daylily Catalog. You arrange payment and shipping
-          directly after inquiry.
+          Buyers do not pay on Daylily Catalog. You arrange payment directly
+          after inquiry using an option such as PayPal, Venmo, or Stripe, then
+          coordinate shipping with the buyer.
+        </p>
+        <p className="text-muted-foreground text-sm leading-relaxed">
+          Your personal dashboard always shows your live catalog. Public catalog
+          pages may take up to 24 hours to reflect dashboard changes.
         </p>
         <p className="text-muted-foreground text-sm leading-relaxed">
           Your catalog and listings will not be publicly discoverable until you
@@ -1001,21 +1005,10 @@ export function CheckoutStep({
         <p className="text-muted-foreground text-sm font-medium tracking-wide uppercase">
           Grower membership
         </p>
-        <div>
-          <p className="flex items-end gap-1 leading-none">
-            <span className="text-5xl font-bold tracking-tight">
-              {membershipPriceDisplay.amount}
-            </span>
-            <span className="text-2xl font-semibold tracking-tight">
-              {membershipPriceDisplay.interval}
-            </span>
-          </p>
-          {membershipPriceDisplay.monthlyEquivalent ? (
-            <p className="text-muted-foreground mt-2 text-sm">
-              {membershipPriceDisplay.monthlyEquivalent}/mo equivalent
-            </p>
-          ) : null}
-        </div>
+        <p className="text-5xl leading-none font-bold tracking-tight">
+          {membershipPriceDisplay.amount}
+          {membershipPriceDisplay.interval}
+        </p>
         <p className="text-muted-foreground text-sm leading-relaxed">
           Start with a {SUBSCRIPTION_CONFIG.FREE_TRIAL_DAYS}-day free trial. We
           will add your profile to your dashboard after you verify your email.

--- a/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
+++ b/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
@@ -30,6 +30,22 @@ function getOnboardingStepIndex(step: AnonymousOnboardingStepId) {
   return ANONYMOUS_ONBOARDING_STEPS.findIndex((item) => item.id === step);
 }
 
+function getStarterProfileImageGenerationKey({
+  applyNameOverlay,
+  baseImageUrl,
+  gardenName,
+}: {
+  applyNameOverlay: boolean;
+  baseImageUrl: string;
+  gardenName: string;
+}) {
+  return JSON.stringify([
+    baseImageUrl,
+    applyNameOverlay,
+    gardenName.trim() || DEFAULT_GARDEN_NAME_PLACEHOLDER,
+  ]);
+}
+
 export function useAnonymousOnboardingController({
   exampleCultivars,
   membershipPriceDisplay,
@@ -76,7 +92,10 @@ export function useAnonymousOnboardingController({
   const [selectedStarterProfileImageUrl, setSelectedStarterProfileImageUrl] =
     useState<string | null>(STARTER_PROFILE_IMAGES[0]?.url ?? null);
   const uploadedProfileImageDataUrlRef = useRef<string | null>(null);
-  const starterProfileImageDataUrlRef = useRef<string | null>(null);
+  const starterProfileImageCacheRef = useRef<{
+    dataUrl: string;
+    generationKey: string;
+  } | null>(null);
   const defaultStarterGenerationStartedRef = useRef(false);
   const [applyStarterNameOverlay, setApplyStarterNameOverlayState] =
     useState(true);
@@ -127,8 +146,18 @@ export function useAnonymousOnboardingController({
         uploadedProfileImageDataUrlRef.current =
           storedDraft.profile.profileImageDataUrl;
       } else if (storedDraft.profile.profileImageSource === "starter") {
-        starterProfileImageDataUrlRef.current =
-          storedDraft.profile.profileImageDataUrl;
+        const starterImageUrl = storedDraft.profile.starterImageUrl;
+        const dataUrl = storedDraft.profile.profileImageDataUrl;
+        if (starterImageUrl && dataUrl) {
+          starterProfileImageCacheRef.current = {
+            dataUrl,
+            generationKey: getStarterProfileImageGenerationKey({
+              applyNameOverlay: true,
+              baseImageUrl: starterImageUrl,
+              gardenName: storedDraft.profile.gardenName,
+            }),
+          };
+        }
       }
       setSelectedStarterProfileImageUrl(
         storedDraft.profile.starterImageUrl ??
@@ -309,7 +338,14 @@ export function useAnonymousOnboardingController({
                 return;
               }
 
-              starterProfileImageDataUrlRef.current = dataUrl;
+              starterProfileImageCacheRef.current = {
+                dataUrl,
+                generationKey: getStarterProfileImageGenerationKey({
+                  applyNameOverlay,
+                  baseImageUrl,
+                  gardenName,
+                }),
+              };
               setDraft((currentDraft) => ({
                 ...currentDraft,
                 profile: {
@@ -379,10 +415,6 @@ export function useAnonymousOnboardingController({
 
       if (mode === "upload") {
         cancelStarterProfileImageGeneration();
-        if (draftRef.current.profile.profileImageSource === "starter") {
-          starterProfileImageDataUrlRef.current =
-            draftRef.current.profile.profileImageDataUrl;
-        }
         const uploadedImageDataUrl = uploadedProfileImageDataUrlRef.current;
         setDraft((currentDraft) => ({
           ...currentDraft,
@@ -399,10 +431,21 @@ export function useAnonymousOnboardingController({
         uploadedProfileImageDataUrlRef.current =
           draftRef.current.profile.profileImageDataUrl;
       }
-      const starterImageDataUrl = starterProfileImageDataUrlRef.current;
       const baseImageUrl =
         selectedStarterProfileImageUrl ??
-        (starterImageDataUrl ? undefined : STARTER_PROFILE_IMAGES[0]?.url);
+        STARTER_PROFILE_IMAGES[0]?.url;
+      const expectedGenerationKey = baseImageUrl
+        ? getStarterProfileImageGenerationKey({
+            applyNameOverlay: applyStarterNameOverlay,
+            baseImageUrl,
+            gardenName: draftRef.current.profile.gardenName,
+          })
+        : null;
+      const starterImageDataUrl =
+        starterProfileImageCacheRef.current?.generationKey ===
+        expectedGenerationKey
+          ? starterProfileImageCacheRef.current.dataUrl
+          : null;
       if (baseImageUrl) {
         setSelectedStarterProfileImageUrl(baseImageUrl);
       }

--- a/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
+++ b/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { api } from "@/trpc/react";
 import {
   ANONYMOUS_ONBOARDING_STEPS,
@@ -34,7 +34,6 @@ export function useAnonymousOnboardingController({
   exampleCultivars,
   membershipPriceDisplay,
 }: AnonymousOnboardingPageClientProps) {
-  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [draft, setDraftState] = useState(() =>
@@ -101,9 +100,13 @@ export function useAnonymousOnboardingController({
     if (hasHydratedDraftRef.current) {
       return;
     }
-    hasHydratedDraftRef.current = true;
 
     const frame = window.requestAnimationFrame(() => {
+      if (hasHydratedDraftRef.current) {
+        return;
+      }
+      hasHydratedDraftRef.current = true;
+
       const storedDraft = readAnonymousOnboardingDraft();
       const requestedStep = readOnboardingStep(searchParams.get("step"));
       const requestedStepIndex = requestedStep
@@ -134,12 +137,12 @@ export function useAnonymousOnboardingController({
       );
       setDraftIsHydrated(true);
       if (requestedStep !== initialStep) {
-        router.replace(buildStepUrl(initialStep), { scroll: false });
+        window.history.replaceState(null, "", buildStepUrl(initialStep));
       }
     });
 
     return () => window.cancelAnimationFrame(frame);
-  }, [buildStepUrl, router, searchParams]);
+  }, [buildStepUrl, searchParams]);
 
   useEffect(() => {
     if (!hasHydratedDraftRef.current) {
@@ -156,7 +159,11 @@ export function useAnonymousOnboardingController({
       getOnboardingStepIndex(requestedStep) >
       getOnboardingStepIndex(draftRef.current.furthestStep)
     ) {
-      router.replace(buildStepUrl(draftRef.current.step), { scroll: false });
+      window.history.replaceState(
+        null,
+        "",
+        buildStepUrl(draftRef.current.step),
+      );
       return;
     }
 
@@ -164,7 +171,7 @@ export function useAnonymousOnboardingController({
       ...currentDraft,
       step: requestedStep,
     }));
-  }, [buildStepUrl, router, searchParams, setDraft]);
+  }, [buildStepUrl, searchParams, setDraft]);
 
   const stepIndex = ANONYMOUS_ONBOARDING_STEPS.findIndex(
     (step) => step.id === draft.step,
@@ -193,9 +200,9 @@ export function useAnonymousOnboardingController({
 
         return { ...currentDraft, step, furthestStep };
       });
-      router.push(buildStepUrl(step), { scroll: false });
+      window.history.pushState(null, "", buildStepUrl(step));
     },
-    [buildStepUrl, router, setDraft],
+    [buildStepUrl, setDraft],
   );
 
   const saveEmailAndContinue = useCallback(

--- a/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
+++ b/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
@@ -130,6 +130,12 @@ export function useAnonymousOnboardingController({
         starterProfileImageDataUrlRef.current =
           storedDraft.profile.profileImageDataUrl;
       }
+      setSelectedStarterProfileImageUrl(
+        storedDraft.profile.starterImageUrl ??
+          (storedDraft.profile.profileImageSource === "starter"
+            ? null
+            : (STARTER_PROFILE_IMAGES[0]?.url ?? null)),
+      );
       setProfileImageInputModeState(
         storedDraft.profile.profileImageSource === "upload"
           ? "upload"
@@ -310,6 +316,7 @@ export function useAnonymousOnboardingController({
                   ...currentDraft.profile,
                   profileImageDataUrl: dataUrl,
                   profileImageSource: "starter",
+                  starterImageUrl: baseImageUrl,
                 },
               }));
             } catch (error) {
@@ -352,6 +359,7 @@ export function useAnonymousOnboardingController({
           ...currentDraft.profile,
           profileImageDataUrl: null,
           profileImageSource: null,
+          starterImageUrl: baseImageUrl,
         },
       }));
       scheduleStarterProfileImageGeneration({
@@ -391,16 +399,21 @@ export function useAnonymousOnboardingController({
         uploadedProfileImageDataUrlRef.current =
           draftRef.current.profile.profileImageDataUrl;
       }
-      const baseImageUrl =
-        selectedStarterProfileImageUrl ?? STARTER_PROFILE_IMAGES[0]?.url;
       const starterImageDataUrl = starterProfileImageDataUrlRef.current;
-      setSelectedStarterProfileImageUrl(baseImageUrl ?? null);
+      const baseImageUrl =
+        selectedStarterProfileImageUrl ??
+        (starterImageDataUrl ? undefined : STARTER_PROFILE_IMAGES[0]?.url);
+      if (baseImageUrl) {
+        setSelectedStarterProfileImageUrl(baseImageUrl);
+      }
       setDraft((currentDraft) => ({
         ...currentDraft,
         profile: {
           ...currentDraft.profile,
           profileImageDataUrl: starterImageDataUrl,
           profileImageSource: starterImageDataUrl ? "starter" : null,
+          starterImageUrl:
+            baseImageUrl ?? currentDraft.profile.starterImageUrl,
         },
       }));
       if (!starterImageDataUrl && baseImageUrl) {

--- a/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
+++ b/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { api } from "@/trpc/react";
 import {
   ANONYMOUS_ONBOARDING_STEPS,
@@ -22,15 +22,26 @@ import {
 } from "./anonymous-onboarding-draft";
 import type { AnonymousOnboardingStepId } from "./anonymous-onboarding-draft";
 
+function readOnboardingStep(value: string | null) {
+  return ANONYMOUS_ONBOARDING_STEPS.find((step) => step.id === value)?.id;
+}
+
+function getOnboardingStepIndex(step: AnonymousOnboardingStepId) {
+  return ANONYMOUS_ONBOARDING_STEPS.findIndex((item) => item.id === step);
+}
+
 export function useAnonymousOnboardingController({
   exampleCultivars,
   membershipPriceDisplay,
 }: AnonymousOnboardingPageClientProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [draft, setDraftState] = useState(() =>
     createAnonymousOnboardingDraft(),
   );
   const draftRef = useRef(draft);
+  const hasHydratedDraftRef = useRef(false);
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
 
   const setDraft = useCallback(
@@ -80,25 +91,84 @@ export function useAnonymousOnboardingController({
   const collectEmail = api.onboarding.collectEmail.useMutation();
   const createCheckout = api.onboarding.createCheckout.useMutation();
 
+  const buildStepUrl = useCallback(
+    (step: AnonymousOnboardingStepId) => {
+      const nextSearchParams = new URLSearchParams(searchParams.toString());
+      nextSearchParams.set("step", step);
+      return `${pathname}?${nextSearchParams.toString()}`;
+    },
+    [pathname, searchParams],
+  );
+
   useEffect(() => {
+    if (hasHydratedDraftRef.current) {
+      return;
+    }
+    hasHydratedDraftRef.current = true;
+
     const frame = window.requestAnimationFrame(() => {
       const storedDraft = readAnonymousOnboardingDraft();
-      draftRef.current = storedDraft;
-      setDraftState(storedDraft);
+      const requestedStep = readOnboardingStep(searchParams.get("step"));
+      const requestedStepIndex = requestedStep
+        ? getOnboardingStepIndex(requestedStep)
+        : -1;
+      const furthestStepIndex = getOnboardingStepIndex(
+        storedDraft.furthestStep,
+      );
+      const initialStep =
+        requestedStep && requestedStepIndex <= furthestStepIndex
+          ? requestedStep
+          : storedDraft.step;
+      const hydratedDraft = { ...storedDraft, step: initialStep };
+
+      draftRef.current = hydratedDraft;
+      setDraftState(hydratedDraft);
       setProfileImageInputModeState(
         storedDraft.profile.profileImageSource === "upload"
           ? "upload"
           : "starter",
       );
+      if (requestedStep !== initialStep) {
+        router.replace(buildStepUrl(initialStep), { scroll: false });
+      }
     });
 
     return () => window.cancelAnimationFrame(frame);
-  }, []);
+  }, [buildStepUrl, router, searchParams]);
+
+  useEffect(() => {
+    if (!hasHydratedDraftRef.current) {
+      return;
+    }
+
+    const requestedStep = readOnboardingStep(searchParams.get("step"));
+    if (requestedStep === draftRef.current.step) {
+      return;
+    }
+
+    if (
+      !requestedStep ||
+      getOnboardingStepIndex(requestedStep) >
+      getOnboardingStepIndex(draftRef.current.furthestStep)
+    ) {
+      router.replace(buildStepUrl(draftRef.current.step), { scroll: false });
+      return;
+    }
+
+    setDraft((currentDraft) => ({
+      ...currentDraft,
+      step: requestedStep,
+    }));
+  }, [buildStepUrl, router, searchParams, setDraft]);
 
   const stepIndex = ANONYMOUS_ONBOARDING_STEPS.findIndex(
     (step) => step.id === draft.step,
   );
   const currentStepIndex = stepIndex >= 0 ? stepIndex : 0;
+  const furthestStepIndex = Math.max(
+    0,
+    getOnboardingStepIndex(draft.furthestStep),
+  );
   const progressValue =
     ((currentStepIndex + 1) / ANONYMOUS_ONBOARDING_STEPS.length) * 100;
   const profilePreview = getProfilePreview(draft);
@@ -109,9 +179,18 @@ export function useAnonymousOnboardingController({
   const goToStep = useCallback(
     (step: AnonymousOnboardingStepId) => {
       setImageError(null);
-      setDraft((currentDraft) => ({ ...currentDraft, step }));
+      setDraft((currentDraft) => {
+        const furthestStep =
+          getOnboardingStepIndex(step) >
+          getOnboardingStepIndex(currentDraft.furthestStep)
+            ? step
+            : currentDraft.furthestStep;
+
+        return { ...currentDraft, step, furthestStep };
+      });
+      router.push(buildStepUrl(step), { scroll: false });
     },
-    [setDraft],
+    [buildStepUrl, router, setDraft],
   );
 
   const saveEmailAndContinue = useCallback(
@@ -455,8 +534,13 @@ export function useAnonymousOnboardingController({
     setSelectedStarterProfileImageUrl(null);
     setProfileImageInputModeState("starter");
     setApplyStarterNameOverlayState(true);
-    router.replace("/onboarding", { scroll: false });
-  }, [cancelStarterProfileImageGeneration, clearStoredDraft, router]);
+    router.replace(buildStepUrl("email"), { scroll: false });
+  }, [
+    buildStepUrl,
+    cancelStarterProfileImageGeneration,
+    clearStoredDraft,
+    router,
+  ]);
 
   return {
     applyStarterNameOverlay,
@@ -469,6 +553,7 @@ export function useAnonymousOnboardingController({
     emailInput,
     emailIsValid,
     exampleCultivars,
+    furthestStepIndex,
     goBack,
     goForward,
     goToStep,

--- a/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
+++ b/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
@@ -206,6 +206,9 @@ export function useAnonymousOnboardingController({
       return;
     }
 
+    if (requestedStep === "email") {
+      setEmailInputOverride(null);
+    }
     setDraft((currentDraft) => ({
       ...currentDraft,
       step: requestedStep,
@@ -230,6 +233,9 @@ export function useAnonymousOnboardingController({
   const goToStep = useCallback(
     (step: AnonymousOnboardingStepId) => {
       setImageError(null);
+      if (step === "email") {
+        setEmailInputOverride(null);
+      }
       setDraft((currentDraft) => {
         const furthestStep =
           getOnboardingStepIndex(step) >

--- a/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
+++ b/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
@@ -152,7 +152,8 @@ export function useAnonymousOnboardingController({
           starterProfileImageCacheRef.current = {
             dataUrl,
             generationKey: getStarterProfileImageGenerationKey({
-              applyNameOverlay: true,
+              applyNameOverlay:
+                storedDraft.profile.starterImageApplyNameOverlay,
               baseImageUrl: starterImageUrl,
               gardenName: storedDraft.profile.gardenName,
             }),
@@ -169,6 +170,9 @@ export function useAnonymousOnboardingController({
         storedDraft.profile.profileImageSource === "upload"
           ? "upload"
           : "starter",
+      );
+      setApplyStarterNameOverlayState(
+        storedDraft.profile.starterImageApplyNameOverlay,
       );
       setDraftIsHydrated(true);
       if (requestedStep !== initialStep) {
@@ -353,6 +357,7 @@ export function useAnonymousOnboardingController({
                   profileImageDataUrl: dataUrl,
                   profileImageSource: "starter",
                   starterImageUrl: baseImageUrl,
+                  starterImageApplyNameOverlay: applyNameOverlay,
                 },
               }));
             } catch (error) {
@@ -515,6 +520,13 @@ export function useAnonymousOnboardingController({
   const setApplyStarterNameOverlay = useCallback(
     (enabled: boolean) => {
       setApplyStarterNameOverlayState(enabled);
+      setDraft((currentDraft) => ({
+        ...currentDraft,
+        profile: {
+          ...currentDraft.profile,
+          starterImageApplyNameOverlay: enabled,
+        },
+      }));
       if (!selectedStarterProfileImageUrl) {
         return;
       }
@@ -526,7 +538,11 @@ export function useAnonymousOnboardingController({
         gardenName: draftRef.current.profile.gardenName,
       });
     },
-    [scheduleStarterProfileImageGeneration, selectedStarterProfileImageUrl],
+    [
+      scheduleStarterProfileImageGeneration,
+      selectedStarterProfileImageUrl,
+      setDraft,
+    ],
   );
 
   const updateProfileGardenName = useCallback(

--- a/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
+++ b/apps/main/src/app/onboarding/use-anonymous-onboarding-controller.ts
@@ -6,13 +6,13 @@ import { api } from "@/trpc/react";
 import {
   ANONYMOUS_ONBOARDING_STEPS,
   DEFAULT_GARDEN_NAME_PLACEHOLDER,
+  STARTER_PROFILE_IMAGES,
   getListingPreview,
   getProfilePreview,
   normalizeEmail,
   type AnonymousOnboardingPageClientProps,
 } from "./anonymous-onboarding-config";
 import {
-  clearAnonymousOnboardingDraft,
   compressOnboardingImageBlob,
   createOnboardingProfileImageFromStarter,
   createAnonymousOnboardingDraft,
@@ -42,6 +42,7 @@ export function useAnonymousOnboardingController({
   );
   const draftRef = useRef(draft);
   const hasHydratedDraftRef = useRef(false);
+  const [draftIsHydrated, setDraftIsHydrated] = useState(false);
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
 
   const setDraft = useCallback(
@@ -65,13 +66,6 @@ export function useAnonymousOnboardingController({
     [],
   );
 
-  const clearStoredDraft = useCallback(() => {
-    clearAnonymousOnboardingDraft();
-    const nextDraft = createAnonymousOnboardingDraft();
-    draftRef.current = nextDraft;
-    setDraftState(nextDraft);
-    setStorageWarning(null);
-  }, []);
   const [emailInputOverride, setEmailInputOverride] = useState<string | null>(
     null,
   );
@@ -81,7 +75,10 @@ export function useAnonymousOnboardingController({
     "starter" | "upload"
   >("starter");
   const [selectedStarterProfileImageUrl, setSelectedStarterProfileImageUrl] =
-    useState<string | null>(null);
+    useState<string | null>(STARTER_PROFILE_IMAGES[0]?.url ?? null);
+  const uploadedProfileImageDataUrlRef = useRef<string | null>(null);
+  const starterProfileImageDataUrlRef = useRef<string | null>(null);
+  const defaultStarterGenerationStartedRef = useRef(false);
   const [applyStarterNameOverlay, setApplyStarterNameOverlayState] =
     useState(true);
   const [isGeneratingStarterProfileImage, setIsGeneratingStarterProfileImage] =
@@ -123,11 +120,19 @@ export function useAnonymousOnboardingController({
 
       draftRef.current = hydratedDraft;
       setDraftState(hydratedDraft);
+      if (storedDraft.profile.profileImageSource === "upload") {
+        uploadedProfileImageDataUrlRef.current =
+          storedDraft.profile.profileImageDataUrl;
+      } else if (storedDraft.profile.profileImageSource === "starter") {
+        starterProfileImageDataUrlRef.current =
+          storedDraft.profile.profileImageDataUrl;
+      }
       setProfileImageInputModeState(
         storedDraft.profile.profileImageSource === "upload"
           ? "upload"
           : "starter",
       );
+      setDraftIsHydrated(true);
       if (requestedStep !== initialStep) {
         router.replace(buildStepUrl(initialStep), { scroll: false });
       }
@@ -291,6 +296,7 @@ export function useAnonymousOnboardingController({
                 return;
               }
 
+              starterProfileImageDataUrlRef.current = dataUrl;
               setDraft((currentDraft) => ({
                 ...currentDraft,
                 profile: {
@@ -327,6 +333,10 @@ export function useAnonymousOnboardingController({
 
   const selectStarterProfileImage = useCallback(
     (baseImageUrl: string) => {
+      if (draftRef.current.profile.profileImageSource === "upload") {
+        uploadedProfileImageDataUrlRef.current =
+          draftRef.current.profile.profileImageDataUrl;
+      }
       setProfileImageInputModeState("starter");
       setSelectedStarterProfileImageUrl(baseImageUrl);
       setDraft((currentDraft) => ({
@@ -354,33 +364,90 @@ export function useAnonymousOnboardingController({
 
       if (mode === "upload") {
         cancelStarterProfileImageGeneration();
-        setSelectedStarterProfileImageUrl(null);
         if (draftRef.current.profile.profileImageSource === "starter") {
-          setDraft((currentDraft) => ({
-            ...currentDraft,
-            profile: {
-              ...currentDraft.profile,
-              profileImageDataUrl: null,
-              profileImageSource: null,
-            },
-          }));
+          starterProfileImageDataUrlRef.current =
+            draftRef.current.profile.profileImageDataUrl;
         }
-        return;
-      }
-
-      if (draftRef.current.profile.profileImageSource === "upload") {
+        const uploadedImageDataUrl = uploadedProfileImageDataUrlRef.current;
         setDraft((currentDraft) => ({
           ...currentDraft,
           profile: {
             ...currentDraft.profile,
-            profileImageDataUrl: null,
-            profileImageSource: null,
+            profileImageDataUrl: uploadedImageDataUrl,
+            profileImageSource: uploadedImageDataUrl ? "upload" : null,
           },
         }));
+        return;
+      }
+
+      if (draftRef.current.profile.profileImageSource === "upload") {
+        uploadedProfileImageDataUrlRef.current =
+          draftRef.current.profile.profileImageDataUrl;
+      }
+      const baseImageUrl =
+        selectedStarterProfileImageUrl ?? STARTER_PROFILE_IMAGES[0]?.url;
+      const starterImageDataUrl = starterProfileImageDataUrlRef.current;
+      setSelectedStarterProfileImageUrl(baseImageUrl ?? null);
+      setDraft((currentDraft) => ({
+        ...currentDraft,
+        profile: {
+          ...currentDraft.profile,
+          profileImageDataUrl: starterImageDataUrl,
+          profileImageSource: starterImageDataUrl ? "starter" : null,
+        },
+      }));
+      if (!starterImageDataUrl && baseImageUrl) {
+        scheduleStarterProfileImageGeneration({
+          applyNameOverlay: applyStarterNameOverlay,
+          baseImageUrl,
+          debounceMs: 0,
+          gardenName: draftRef.current.profile.gardenName,
+        });
       }
     },
-    [cancelStarterProfileImageGeneration, setDraft],
+    [
+      applyStarterNameOverlay,
+      cancelStarterProfileImageGeneration,
+      scheduleStarterProfileImageGeneration,
+      selectedStarterProfileImageUrl,
+      setDraft,
+    ],
   );
+
+  useEffect(() => {
+    if (
+      !draftIsHydrated ||
+      profileImageInputMode !== "starter" ||
+      draft.profile.profileImageDataUrl ||
+      isGeneratingStarterProfileImage ||
+      defaultStarterGenerationStartedRef.current
+    ) {
+      return;
+    }
+
+    const baseImageUrl =
+      selectedStarterProfileImageUrl ?? STARTER_PROFILE_IMAGES[0]?.url;
+    if (!baseImageUrl) {
+      return;
+    }
+
+    defaultStarterGenerationStartedRef.current = true;
+    scheduleStarterProfileImageGeneration({
+      applyNameOverlay: applyStarterNameOverlay,
+      baseImageUrl,
+      debounceMs: 0,
+      gardenName: draft.profile.gardenName,
+    });
+  }, [
+    applyStarterNameOverlay,
+    draft.profile.gardenName,
+    draft.profile.profileImageDataUrl,
+    draftIsHydrated,
+    isGeneratingStarterProfileImage,
+    profileImageInputMode,
+    scheduleStarterProfileImageGeneration,
+    selectedStarterProfileImageUrl,
+  ]);
 
   const setApplyStarterNameOverlay = useCallback(
     (enabled: boolean) => {
@@ -443,6 +510,9 @@ export function useAnonymousOnboardingController({
       try {
         setImageError(null);
         const dataUrl = await compressOnboardingImageBlob(image);
+        if (target === "profileImageDataUrl") {
+          uploadedProfileImageDataUrlRef.current = dataUrl;
+        }
         setDraft((currentDraft) =>
           target === "profileImageDataUrl"
             ? {
@@ -471,7 +541,7 @@ export function useAnonymousOnboardingController({
   const clearProfileImage = useCallback(() => {
     cancelStarterProfileImageGeneration();
     setImageError(null);
-    setSelectedStarterProfileImageUrl(null);
+    uploadedProfileImageDataUrlRef.current = null;
     setDraft((currentDraft) => ({
       ...currentDraft,
       profile: {
@@ -527,24 +597,8 @@ export function useAnonymousOnboardingController({
     }
   }, [createCheckout, draft.draftId, draft.email, goToStep]);
 
-  const clearDraft = useCallback(() => {
-    cancelStarterProfileImageGeneration();
-    clearStoredDraft();
-    setEmailInputOverride(null);
-    setSelectedStarterProfileImageUrl(null);
-    setProfileImageInputModeState("starter");
-    setApplyStarterNameOverlayState(true);
-    router.replace(buildStepUrl("email"), { scroll: false });
-  }, [
-    buildStepUrl,
-    cancelStarterProfileImageGeneration,
-    clearStoredDraft,
-    router,
-  ]);
-
   return {
     applyStarterNameOverlay,
-    clearDraft,
     clearProfileImage,
     collectEmail,
     createCheckout,
@@ -583,7 +637,6 @@ export function useAnonymousOnboardingController({
       if (image) {
         cancelStarterProfileImageGeneration();
         setProfileImageInputModeState("upload");
-        setSelectedStarterProfileImageUrl(null);
       }
 
       return updateImageDraft(image, "profileImageDataUrl");

--- a/apps/main/src/app/start-membership/page.tsx
+++ b/apps/main/src/app/start-membership/page.tsx
@@ -176,8 +176,6 @@ function StartMembershipHero({
 }: {
   membershipPriceDisplay: MembershipPriceDisplay;
 }) {
-  const trialPriceText = `Membership is ${membershipPriceDisplay.amount}${membershipPriceDisplay.interval} after the trial.`;
-
   return (
     <section className="relative isolate overflow-hidden bg-[#07120e] px-4 pt-24 pb-36 text-white lg:px-8 lg:pt-24 lg:pb-32">
       <div className="absolute inset-0 -z-10 bg-[#07120e]" aria-hidden="true">
@@ -213,7 +211,7 @@ function StartMembershipHero({
             Add photos, prices, availability, notes, and contact info. Build and
             preview your catalog first. Start a{" "}
             {SUBSCRIPTION_CONFIG.FREE_TRIAL_DAYS}-day trial before your
-            dashboard opens. {trialPriceText}
+            dashboard opens.
           </p>
 
           <div className="mt-8 flex flex-col gap-4 lg:mt-5 lg:flex-row lg:gap-5">
@@ -244,19 +242,10 @@ function StartMembershipHero({
           <p className="text-sm font-bold tracking-[0.18em] text-[#f4c477] uppercase">
             Grower membership
           </p>
-          <p className="mt-4 flex items-end gap-1 leading-none">
-            <span className="text-6xl font-bold tracking-tight text-white">
-              {membershipPriceDisplay.amount}
-            </span>
-            <span className="text-4xl font-semibold tracking-tight text-white">
-              {membershipPriceDisplay.interval}
-            </span>
+          <p className="mt-4 text-6xl leading-none font-bold tracking-tight text-white">
+            {membershipPriceDisplay.amount}
+            {membershipPriceDisplay.interval}
           </p>
-          {membershipPriceDisplay.monthlyEquivalent ? (
-            <p className="mt-3 text-base leading-6 text-[#dfe9dc]">
-              {membershipPriceDisplay.monthlyEquivalent}/mo equivalent
-            </p>
-          ) : null}
           <p className="mt-3 max-w-lg text-lg leading-7 text-[#dfe9dc]">
             Start your {SUBSCRIPTION_CONFIG.FREE_TRIAL_DAYS}-day trial before
             your paid dashboard opens.

--- a/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
+++ b/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
@@ -15,6 +15,7 @@ export interface AnonymousOnboardingProfileDraft {
   description: string;
   profileImageDataUrl: string | null;
   profileImageSource: "starter" | "upload" | null;
+  starterImageUrl: string | null;
 }
 
 export interface AnonymousOnboardingListingPreviewDraft {
@@ -44,6 +45,7 @@ export const DEFAULT_ANONYMOUS_ONBOARDING_PROFILE: AnonymousOnboardingProfileDra
     description: "",
     profileImageDataUrl: null,
     profileImageSource: null,
+    starterImageUrl: null,
   };
 
 const DEFAULT_ANONYMOUS_ONBOARDING_CULTIVAR_KEY = "cr-ahs-176320";
@@ -180,6 +182,7 @@ export function parseAnonymousOnboardingDraft(
       description: readString(profile?.description),
       profileImageDataUrl: readNullableString(profile?.profileImageDataUrl),
       profileImageSource: readProfileImageSource(profile?.profileImageSource),
+      starterImageUrl: readNullableString(profile?.starterImageUrl),
     },
     listingPreview: {
       cultivarKey: readListingCultivarKey(listingPreview?.cultivarKey),

--- a/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
+++ b/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
@@ -30,6 +30,7 @@ export interface AnonymousOnboardingDraft {
   draftId: string;
   email: string | null;
   step: AnonymousOnboardingStepId;
+  furthestStep: AnonymousOnboardingStepId;
   createdAt: string;
   updatedAt: string;
   profile: AnonymousOnboardingProfileDraft;
@@ -76,6 +77,7 @@ export function createAnonymousOnboardingDraft(
     draftId: crypto.randomUUID(),
     email: null,
     step: "email",
+    furthestStep: overrides?.step ?? "email",
     createdAt: timestamp,
     updatedAt: timestamp,
   };
@@ -170,6 +172,7 @@ export function parseAnonymousOnboardingDraft(
     draftId,
     email: readNullableString(rawDraft.email),
     step: readStep(rawDraft.step),
+    furthestStep: readStep(rawDraft.furthestStep ?? rawDraft.step),
     createdAt: readString(rawDraft.createdAt) || nowIso(),
     updatedAt: readString(rawDraft.updatedAt) || nowIso(),
     profile: {

--- a/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
+++ b/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
@@ -16,6 +16,7 @@ export interface AnonymousOnboardingProfileDraft {
   profileImageDataUrl: string | null;
   profileImageSource: "starter" | "upload" | null;
   starterImageUrl: string | null;
+  starterImageApplyNameOverlay: boolean;
 }
 
 export interface AnonymousOnboardingListingPreviewDraft {
@@ -46,6 +47,7 @@ export const DEFAULT_ANONYMOUS_ONBOARDING_PROFILE: AnonymousOnboardingProfileDra
     profileImageDataUrl: null,
     profileImageSource: null,
     starterImageUrl: null,
+    starterImageApplyNameOverlay: true,
   };
 
 const DEFAULT_ANONYMOUS_ONBOARDING_CULTIVAR_KEY = "cr-ahs-176320";
@@ -107,6 +109,10 @@ function readString(value: unknown) {
 
 function readNullableString(value: unknown) {
   return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readBoolean(value: unknown, fallback: boolean) {
+  return typeof value === "boolean" ? value : fallback;
 }
 
 function readProfileImageSource(value: unknown) {
@@ -183,6 +189,10 @@ export function parseAnonymousOnboardingDraft(
       profileImageDataUrl: readNullableString(profile?.profileImageDataUrl),
       profileImageSource: readProfileImageSource(profile?.profileImageSource),
       starterImageUrl: readNullableString(profile?.starterImageUrl),
+      starterImageApplyNameOverlay: readBoolean(
+        profile?.starterImageApplyNameOverlay,
+        true,
+      ),
     },
     listingPreview: {
       cultivarKey: readListingCultivarKey(listingPreview?.cultivarKey),

--- a/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
+++ b/apps/main/src/lib/onboarding/anonymous-onboarding-draft.ts
@@ -52,9 +52,8 @@ export const DEFAULT_ANONYMOUS_ONBOARDING_LISTING: AnonymousOnboardingListingPre
   {
     cultivarKey: DEFAULT_ANONYMOUS_ONBOARDING_CULTIVAR_KEY,
     title: "",
-    price: 25,
-    description:
-      "Healthy dormant fan with strong roots, clearly labeled, and ready for spring shipping or local pickup.",
+    price: null,
+    description: "",
     imageDataUrl: null,
   };
 

--- a/apps/main/tests/anonymous-onboarding-config.test.ts
+++ b/apps/main/tests/anonymous-onboarding-config.test.ts
@@ -192,6 +192,9 @@ describe("anonymous onboarding config", () => {
     expect(getListingPreview(blankTitleDraft, examples)).toMatchObject({
       title: "Second Bloom Spring Fan",
       titlePlaceholder: "Second Bloom Spring Fan",
+      price: 25,
+      description:
+        "Healthy dormant fan with strong roots, clearly labeled, and ready for spring shipping or local pickup.",
     });
 
     const typedTitleDraft = createAnonymousOnboardingDraft({

--- a/apps/main/tests/anonymous-onboarding-draft.test.ts
+++ b/apps/main/tests/anonymous-onboarding-draft.test.ts
@@ -65,10 +65,26 @@ describe("anonymous onboarding draft storage", () => {
     expect(readAnonymousOnboardingDraft()).toMatchObject({
       email: "lead@example.com",
       step: "profile",
+      furthestStep: "profile",
     });
 
     expect(clearAnonymousOnboardingDraft()).toBe(true);
     expect(window.localStorage.getItem(ANONYMOUS_ONBOARDING_DRAFT_KEY)).toBeNull();
+  });
+
+  it("preserves the furthest reached step when reading older drafts", () => {
+    const parsed = parseAnonymousOnboardingDraft({
+      version: 1,
+      draftId: "draft-before-step-history",
+      email: "seller@example.com",
+      step: "preview",
+      createdAt: "2026-07-09T00:00:00.000Z",
+      updatedAt: "2026-07-09T00:00:00.000Z",
+      profile: {},
+      listingPreview: {},
+    });
+
+    expect(parsed?.furthestStep).toBe("preview");
   });
 
   it("keeps the example listing title empty until the user types one", () => {

--- a/apps/main/tests/anonymous-onboarding-draft.test.ts
+++ b/apps/main/tests/anonymous-onboarding-draft.test.ts
@@ -26,6 +26,7 @@ describe("anonymous onboarding draft storage", () => {
         profileImageDataUrl: null,
         profileImageSource: null,
         starterImageUrl: null,
+        starterImageApplyNameOverlay: true,
       },
     });
 

--- a/apps/main/tests/anonymous-onboarding-draft.test.ts
+++ b/apps/main/tests/anonymous-onboarding-draft.test.ts
@@ -25,6 +25,7 @@ describe("anonymous onboarding draft storage", () => {
         description: "Example description",
         profileImageDataUrl: null,
         profileImageSource: null,
+        starterImageUrl: null,
       },
     });
 

--- a/apps/main/tests/anonymous-onboarding-draft.test.ts
+++ b/apps/main/tests/anonymous-onboarding-draft.test.ts
@@ -65,7 +65,6 @@ describe("anonymous onboarding draft storage", () => {
     expect(readAnonymousOnboardingDraft()).toMatchObject({
       email: "lead@example.com",
       step: "profile",
-      furthestStep: "profile",
     });
 
     expect(clearAnonymousOnboardingDraft()).toBe(true);
@@ -92,8 +91,6 @@ describe("anonymous onboarding draft storage", () => {
 
     expect(draft.listingPreview.cultivarKey).toBe("cr-ahs-176320");
     expect(draft.listingPreview.title).toBe("");
-    expect(draft.listingPreview.price).toBeNull();
-    expect(draft.listingPreview.description).toBe("");
   });
 
   it("normalizes the legacy generated listing title from stored drafts", () => {

--- a/apps/main/tests/anonymous-onboarding-draft.test.ts
+++ b/apps/main/tests/anonymous-onboarding-draft.test.ts
@@ -92,6 +92,8 @@ describe("anonymous onboarding draft storage", () => {
 
     expect(draft.listingPreview.cultivarKey).toBe("cr-ahs-176320");
     expect(draft.listingPreview.title).toBe("");
+    expect(draft.listingPreview.price).toBeNull();
+    expect(draft.listingPreview.description).toBe("");
   });
 
   it("normalizes the legacy generated listing title from stored drafts", () => {

--- a/apps/main/tests/anonymous-onboarding-email-step.test.tsx
+++ b/apps/main/tests/anonymous-onboarding-email-step.test.tsx
@@ -18,6 +18,11 @@ describe("EmailStep", () => {
     render(<EmailStep {...props} />);
 
     const emailInput = screen.getByLabelText("Email address");
+    expect(emailInput).toHaveAttribute("name", "email");
+    expect(emailInput).toHaveAttribute("autocomplete", "email");
+    expect(emailInput).toHaveAttribute("data-1p-ignore", "true");
+    expect(emailInput).toHaveAttribute("data-bwignore", "true");
+    expect(emailInput).toHaveAttribute("data-lpignore", "true");
     expect(emailInput).not.toHaveAttribute("aria-invalid", "true");
     expect(
       screen.queryByText("Enter a valid email address."),

--- a/apps/main/tests/anonymous-onboarding-email-step.test.tsx
+++ b/apps/main/tests/anonymous-onboarding-email-step.test.tsx
@@ -1,0 +1,38 @@
+import type { ComponentProps } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EmailStep } from "@/app/onboarding/anonymous-onboarding-steps";
+
+describe("EmailStep", () => {
+  it("shows invalid email feedback on blur and links to sign in", () => {
+    const props: ComponentProps<typeof EmailStep> = {
+      collectEmail: {
+        isPending: false,
+      } as ComponentProps<typeof EmailStep>["collectEmail"],
+      emailInput: "invalid-email",
+      emailIsValid: false,
+      saveEmailAndContinue: vi.fn(),
+      setEmailInput: vi.fn(),
+    };
+
+    render(<EmailStep {...props} />);
+
+    const emailInput = screen.getByLabelText("Email address");
+    expect(emailInput).not.toHaveAttribute("aria-invalid", "true");
+    expect(
+      screen.queryByText("Enter a valid email address."),
+    ).not.toBeInTheDocument();
+
+    fireEvent.blur(emailInput);
+
+    expect(emailInput).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Enter a valid email address.",
+    );
+    expect(screen.getByRole("button", { name: "Start setup" })).toBeDisabled();
+    expect(
+      screen.getByRole("link", { name: "Already have an account? Log in" }),
+    ).toHaveAttribute("href", "/sign-in");
+    expect(screen.queryByText("Why ask first?")).not.toBeInTheDocument();
+  });
+});

--- a/apps/main/tests/anonymous-onboarding-layout.test.tsx
+++ b/apps/main/tests/anonymous-onboarding-layout.test.tsx
@@ -45,6 +45,7 @@ function buildController(step: AnonymousOnboardingStepId) {
       step,
     },
     emailIsValid: true,
+    furthestStepIndex: currentStepIndex,
     goBack: vi.fn(),
     goForward: vi.fn(),
     goToStep: vi.fn(),

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -165,6 +165,16 @@ test.describe("anonymous onboarding checkout flow @local", () => {
         page.getByRole("heading", { name: "Edit your first listing" }),
       ).toBeVisible();
       await expect(page).toHaveURL(/\/onboarding\?step=listing/);
+      await expect(page.getByTestId("anonymous-listing-price")).toHaveAttribute(
+        "placeholder",
+        "25",
+      );
+      await expect(
+        page.getByTestId("anonymous-listing-description"),
+      ).toHaveAttribute(
+        "placeholder",
+        "Healthy dormant fan with strong roots, clearly labeled, and ready for spring shipping or local pickup.",
+      );
       await page.getByRole("button", { name: "Lemon Chiffon Cupcake" }).click();
       await page.getByTestId("anonymous-listing-title").fill(listingTitle);
       await page.getByTestId("anonymous-listing-price").fill("18");
@@ -181,6 +191,12 @@ test.describe("anonymous onboarding checkout flow @local", () => {
           return draft?.listingPreview.imageDataUrl?.startsWith("data:image/");
         })
         .toBe(true);
+      await expect(
+        page.getByTestId("anonymous-listing-image-dropzone"),
+      ).toHaveCount(0);
+      await expect(
+        page.getByTestId("anonymous-listing-image-reset"),
+      ).toBeVisible();
 
       await page.reload();
       await expect(

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -99,13 +99,11 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       const defaultStarterImage = page.getByTestId(
         "onboarding-starter-image-dew-kissed-daylily-leaf-at-dawn",
       );
+      const profileImagePreview = page
+        .getByTestId("anonymous-profile-image-inline-preview")
+        .locator("img");
       await expect(defaultStarterImage).toHaveAttribute("aria-pressed", "true");
-      await expect
-        .poll(async () => {
-          const draft = await readBrowserDraft(page);
-          return draft?.profile.profileImageSource;
-        })
-        .toBe("starter");
+      await expect(profileImagePreview).toBeVisible();
 
       await page
         .getByTestId("anonymous-profile-image-mode-upload")
@@ -114,28 +112,21 @@ test.describe("anonymous onboarding checkout flow @local", () => {
         .getByTestId("anonymous-profile-image")
         .setInputFiles(path.join(appRoot, LISTING_IMAGE_PATH));
       await page.getByRole("button", { name: "Use cropped image" }).click();
-      await expect
-        .poll(async () => {
-          const draft = await readBrowserDraft(page);
-          return draft?.profile.profileImageSource === "upload"
-            ? draft.profile.profileImageDataUrl
-            : null;
-        })
-        .not.toBeNull();
-      const uploadedProfileImage = (await readBrowserDraft(page))?.profile
-        .profileImageDataUrl;
+      await expect(profileImagePreview).toHaveAttribute("src", /data:image\//);
+      const uploadedProfileImage = await profileImagePreview.getAttribute("src");
+      expect(uploadedProfileImage).toBeTruthy();
       await page
         .getByTestId("anonymous-profile-image-mode-starter")
         .click();
       await expect(defaultStarterImage).toHaveAttribute("aria-pressed", "true");
+      await expect
+        .poll(() => profileImagePreview.getAttribute("src"))
+        .not.toBe(uploadedProfileImage);
       await page
         .getByTestId("anonymous-profile-image-mode-upload")
         .click();
       await expect
-        .poll(async () => {
-          const draft = await readBrowserDraft(page);
-          return draft?.profile.profileImageDataUrl;
-        })
+        .poll(() => profileImagePreview.getAttribute("src"))
         .toBe(uploadedProfileImage);
       await page
         .getByTestId("anonymous-profile-image-mode-starter")
@@ -222,10 +213,11 @@ test.describe("anonymous onboarding checkout flow @local", () => {
 
       await page.getByTestId("anonymous-onboarding-step-profile").click();
       await expect(page).toHaveURL(/\/onboarding\?step=profile/);
-      await expect(
-        page.getByTestId("anonymous-onboarding-step-profile"),
-      ).toHaveAttribute("data-complete", "true");
       await page.goBack();
+      await expect(page).toHaveURL(/\/onboarding\?step=preview/);
+      await page.goForward();
+      await expect(page).toHaveURL(/\/onboarding\?step=profile/);
+      await page.getByTestId("anonymous-onboarding-step-preview").click();
       await expect(page).toHaveURL(/\/onboarding\?step=preview/);
 
       await page.getByTestId("anonymous-onboarding-primary-action").click();

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -119,11 +119,23 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       await page
         .getByTestId("anonymous-profile-image-mode-upload")
         .click();
+      await expect(
+        page.getByTestId("anonymous-profile-image-dropzone"),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId("anonymous-profile-image-reset"),
+      ).toHaveCount(0);
       await page
         .getByTestId("anonymous-profile-image")
         .setInputFiles(path.join(appRoot, LISTING_IMAGE_PATH));
       await page.getByRole("button", { name: "Use cropped image" }).click();
       await expect(profileImagePreview).toHaveAttribute("src", /data:image\//);
+      await expect(
+        page.getByTestId("anonymous-profile-image-dropzone"),
+      ).toHaveCount(0);
+      await expect(
+        page.getByTestId("anonymous-profile-image-reset"),
+      ).toBeVisible();
       const uploadedProfileImage = await profileImagePreview.getAttribute("src");
       expect(uploadedProfileImage).toBeTruthy();
       await page

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -163,13 +163,28 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       await page
         .getByTestId("anonymous-profile-description")
         .fill(profileDescription);
+      const overlayCheckbox = page.getByRole("checkbox", {
+        name: "Stamp seller name onto starter image",
+      });
+      const imageWithOverlay = await profileImagePreview.getAttribute("src");
+      await overlayCheckbox.click();
+      await expect(overlayCheckbox).not.toBeChecked();
+      await expect
+        .poll(() => profileImagePreview.getAttribute("src"))
+        .not.toBe(imageWithOverlay);
       await page.reload();
       await expect(
         page.getByRole("heading", { name: "Edit your profile" }),
       ).toBeVisible();
       await expect(gardenPathStarter).toHaveAttribute("aria-pressed", "true");
+      await expect(overlayCheckbox).not.toBeChecked();
+      const imageWithoutOverlay = await profileImagePreview.getAttribute("src");
       await page.getByTestId("anonymous-profile-name").fill(profileName);
       await expect(gardenPathStarter).toHaveAttribute("aria-pressed", "true");
+      await expect(profileImagePreview).toHaveAttribute(
+        "src",
+        imageWithoutOverlay!,
+      );
 
       await page.getByTestId("anonymous-onboarding-primary-action").click();
       await expect(

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -96,6 +96,51 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       ).toBeVisible();
       await expect(page).toHaveURL(/\/onboarding\?step=profile/);
 
+      const defaultStarterImage = page.getByTestId(
+        "onboarding-starter-image-dew-kissed-daylily-leaf-at-dawn",
+      );
+      await expect(defaultStarterImage).toHaveAttribute("aria-pressed", "true");
+      await expect
+        .poll(async () => {
+          const draft = await readBrowserDraft(page);
+          return draft?.profile.profileImageSource;
+        })
+        .toBe("starter");
+
+      await page
+        .getByTestId("anonymous-profile-image-mode-upload")
+        .click();
+      await page
+        .getByTestId("anonymous-profile-image")
+        .setInputFiles(path.join(appRoot, LISTING_IMAGE_PATH));
+      await page.getByRole("button", { name: "Use cropped image" }).click();
+      await expect
+        .poll(async () => {
+          const draft = await readBrowserDraft(page);
+          return draft?.profile.profileImageSource === "upload"
+            ? draft.profile.profileImageDataUrl
+            : null;
+        })
+        .not.toBeNull();
+      const uploadedProfileImage = (await readBrowserDraft(page))?.profile
+        .profileImageDataUrl;
+      await page
+        .getByTestId("anonymous-profile-image-mode-starter")
+        .click();
+      await expect(defaultStarterImage).toHaveAttribute("aria-pressed", "true");
+      await page
+        .getByTestId("anonymous-profile-image-mode-upload")
+        .click();
+      await expect
+        .poll(async () => {
+          const draft = await readBrowserDraft(page);
+          return draft?.profile.profileImageDataUrl;
+        })
+        .toBe(uploadedProfileImage);
+      await page
+        .getByTestId("anonymous-profile-image-mode-starter")
+        .click();
+
       await page.getByTestId("anonymous-profile-name").fill(profileName);
       await page
         .getByTestId(

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -212,6 +212,12 @@ test.describe("anonymous onboarding checkout flow @local", () => {
           "Path 1: Buyer opens your catalog and sends an email immediately.",
         ),
       ).toBeVisible();
+      await expect(
+        page.getByText(/PayPal, Venmo, or Stripe/),
+      ).toBeVisible();
+      await expect(
+        page.getByText(/may take up to 24 hours/),
+      ).toBeVisible();
       await expect(page).toHaveURL(/\/onboarding\?step=preview/);
 
       await page.getByTestId("anonymous-onboarding-step-profile").click();
@@ -226,6 +232,7 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       await expect(
         page.getByRole("heading", { name: "Confirm your account email" }),
       ).toBeVisible();
+      await expect(page.getByText(/\/mo equivalent/)).toHaveCount(0);
 
       await page.getByRole("button", { name: /Edit email/i }).click();
       await page.getByTestId("anonymous-checkout-email").fill(paidEmail);

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -94,6 +94,7 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       await expect(
         page.getByRole("heading", { name: "Edit your profile" }),
       ).toBeVisible();
+      await expect(page).toHaveURL(/\/onboarding\?step=profile/);
 
       await page.getByTestId("anonymous-profile-name").fill(profileName);
       await page
@@ -118,6 +119,7 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       await expect(
         page.getByRole("heading", { name: "Edit your first listing" }),
       ).toBeVisible();
+      await expect(page).toHaveURL(/\/onboarding\?step=listing/);
       await page.getByRole("button", { name: "Lemon Chiffon Cupcake" }).click();
       await page.getByTestId("anonymous-listing-title").fill(listingTitle);
       await page.getByTestId("anonymous-listing-price").fill("18");
@@ -149,6 +151,16 @@ test.describe("anonymous onboarding checkout flow @local", () => {
           "Path 1: Buyer opens your catalog and sends an email immediately.",
         ),
       ).toBeVisible();
+      await expect(page).toHaveURL(/\/onboarding\?step=preview/);
+
+      await page.getByTestId("anonymous-onboarding-step-profile").click();
+      await expect(page).toHaveURL(/\/onboarding\?step=profile/);
+      await expect(
+        page.getByTestId("anonymous-onboarding-step-profile"),
+      ).toHaveAttribute("data-complete", "true");
+      await page.goBack();
+      await expect(page).toHaveURL(/\/onboarding\?step=preview/);
+
       await page.getByTestId("anonymous-onboarding-primary-action").click();
       await expect(
         page.getByRole("heading", { name: "Confirm your account email" }),

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -137,7 +137,20 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       const gardenPathStarter = page.getByTestId(
         "onboarding-starter-image-morning-serenity-along-the-garden-path",
       );
+      const defaultStarterImageSrc = await profileImagePreview.getAttribute(
+        "src",
+      );
       await gardenPathStarter.click();
+      await page
+        .getByTestId("anonymous-profile-image-mode-upload")
+        .click();
+      await page
+        .getByTestId("anonymous-profile-image-mode-starter")
+        .click();
+      await expect(gardenPathStarter).toHaveAttribute("aria-pressed", "true");
+      await expect
+        .poll(() => profileImagePreview.getAttribute("src"))
+        .not.toBe(defaultStarterImageSrc);
       await expect
         .poll(async () => {
           const draft = await readBrowserDraft(page);

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -97,6 +97,16 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       ).toBeVisible();
       await expect(page).toHaveURL(/\/onboarding\?step=profile/);
 
+      await page.goBack();
+      await expect(page).toHaveURL(/\/onboarding\?step=email/);
+      await expect(
+        page.getByTestId("anonymous-onboarding-email"),
+      ).toHaveValue(initialEmail);
+      await page.goForward();
+      await expect(
+        page.getByRole("heading", { name: "Edit your profile" }),
+      ).toBeVisible();
+
       const defaultStarterImage = page.getByTestId(
         "onboarding-starter-image-dew-kissed-daylily-leaf-at-dawn",
       );

--- a/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
+++ b/apps/main/tests/e2e/onboarding-full-flow.e2e.ts
@@ -65,6 +65,7 @@ test.describe("anonymous onboarding checkout flow @local", () => {
     const initialEmail = `anonymous-initial+clerk_test_${runId}@example.com`;
     const paidEmail = `anonymous-paid+clerk_test_${runId}@example.com`;
     const profileName = "Anonymous Flow Daylilies";
+    const initialProfileName = "Anonymous Flow";
     const profileLocation = "Olympia, WA";
     const profileDescription =
       "Small grower catalog focused on clear photos and seasonal availability.";
@@ -132,12 +133,11 @@ test.describe("anonymous onboarding checkout flow @local", () => {
         .getByTestId("anonymous-profile-image-mode-starter")
         .click();
 
-      await page.getByTestId("anonymous-profile-name").fill(profileName);
-      await page
-        .getByTestId(
-          "onboarding-starter-image-morning-serenity-along-the-garden-path",
-        )
-        .click();
+      await page.getByTestId("anonymous-profile-name").fill(initialProfileName);
+      const gardenPathStarter = page.getByTestId(
+        "onboarding-starter-image-morning-serenity-along-the-garden-path",
+      );
+      await gardenPathStarter.click();
       await expect
         .poll(async () => {
           const draft = await readBrowserDraft(page);
@@ -150,6 +150,13 @@ test.describe("anonymous onboarding checkout flow @local", () => {
       await page
         .getByTestId("anonymous-profile-description")
         .fill(profileDescription);
+      await page.reload();
+      await expect(
+        page.getByRole("heading", { name: "Edit your profile" }),
+      ).toBeVisible();
+      await expect(gardenPathStarter).toHaveAttribute("aria-pressed", "true");
+      await page.getByTestId("anonymous-profile-name").fill(profileName);
+      await expect(gardenPathStarter).toHaveAttribute("aria-pressed", "true");
 
       await page.getByTestId("anonymous-onboarding-primary-action").click();
       await expect(


### PR DESCRIPTION
## Summary

- show invalid-email feedback on blur, remove the redundant email card, and route existing users to the standard sign-in page
- store the active onboarding step in the URL and keep completed steps available through badges and browser history
- select a starter profile image by default, preserve starter/upload choices while switching modes, constrain cropper size, and remove redundant footer actions
- use listing price and description placeholders while retaining example preview values, improve cultivar choices on smaller screens, and simplify listing image controls
- clarify buyer contact/payment/public-update copy and show the Stripe-derived membership price once per page without a monthly equivalent

## Validation

- `pnpm test:e2e tests/e2e/onboarding-full-flow.e2e.ts` (full checkout, Clerk claim, and dashboard import)
- 20 focused unit/integration tests
- `pnpm main typecheck`
- `pnpm main lint`
- `git diff --check`
