### PR TITLE
Document pro-gating freshness

### DIFF
--- a/apps/main/src/server/db/getProUserIdSet.ts
+++ b/apps/main/src/server/db/getProUserIdSet.ts
@@ -25,6 +25,8 @@ export async function getProUserIdSet(
     return new Set();
   }
 
+  // Public visibility accepts replica/CDN lag under the 24-hour update window;
+  // dashboard billing reads the primary KV store for immediate status.
   const records = await replicaDb.keyValue.findMany({
     where: {
       key: {


### PR DESCRIPTION
Documents why public pro-gating intentionally accepts replica/CDN lag while dashboard billing reads primary.

Validation: `pnpm lint`
