### PR TITLE
Improve start membership chrome contrast

### DIFF
--- a/apps/main/src/components/public-footer.tsx
+++ b/apps/main/src/components/public-footer.tsx
@@ -5,13 +5,15 @@ import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
 
 export function PublicFooter() {
-  const isHomepage = usePathname() === "/";
+  const pathname = usePathname();
+  const usesDarkHeroFooter =
+    pathname === "/" || pathname === "/start-membership";
 
   return (
     <footer
       className={cn(
         "fixed inset-x-0 bottom-0 z-50 w-full bg-transparent before:pointer-events-none before:absolute before:inset-x-0 before:-top-5 before:bottom-0 before:z-[-1] before:content-[''] before:backdrop-blur-[5px] before:[mask-image:linear-gradient(to_bottom,transparent_0%,#000_20px,#000_100%)] before:[-webkit-mask-image:linear-gradient(to_bottom,transparent_0%,#000_20px,#000_100%)]",
-        isHomepage ? "text-white" : "text-[#142118]",
+        usesDarkHeroFooter ? "text-white" : "text-[#142118]",
       )}
     >
       <div className="px-3 pt-1 pb-[calc(0.25rem+env(safe-area-inset-bottom))] lg:px-8">
@@ -24,7 +26,7 @@ export function PublicFooter() {
               <PublicFeedbackLink
                 className={cn(
                   "text-[11px] leading-none font-medium underline-offset-4 transition-colors hover:underline",
-                  isHomepage
+                  usesDarkHeroFooter
                     ? "text-white/70 hover:text-white"
                     : "text-[#142118]/60 hover:text-[#142118]",
                 )}

--- a/apps/main/src/components/public-nav.tsx
+++ b/apps/main/src/components/public-nav.tsx
@@ -15,7 +15,8 @@ const activeNavClassName =
 export function PublicHeader() {
   const pathname = usePathname();
   const mobileNavRef = useRef<HTMLDetailsElement>(null);
-  const isHomepage = pathname === "/";
+  const usesDarkHeroNav =
+    pathname === "/" || pathname === "/start-membership";
   const isCatalogsActive = pathname === "/catalogs";
   const isGrowersActive =
     pathname === "/start-membership" || pathname.startsWith("/onboarding");
@@ -28,7 +29,7 @@ export function PublicHeader() {
     <header
       className={cn(
         "public-header sticky inset-x-0 top-0 z-50 flex min-h-16 w-full items-center border-none bg-transparent px-3 py-2 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:-bottom-5 before:z-[-1] before:content-[''] before:backdrop-blur-[5px] before:[mask-image:linear-gradient(to_bottom,#000_0%,#000_calc(100%_-_20px),transparent_100%)] before:[-webkit-mask-image:linear-gradient(to_bottom,#000_0%,#000_calc(100%_-_20px),transparent_100%)] lg:h-20 lg:px-8 lg:py-0",
-        isHomepage ? "text-white" : "text-[#142118]",
+        usesDarkHeroNav ? "text-white" : "text-[#142118]",
       )}
     >
       <nav className="mx-auto flex w-full max-w-[1024px] items-center justify-between gap-2 py-1 lg:gap-4">
@@ -39,7 +40,7 @@ export function PublicHeader() {
           <span
             className={cn(
               "flex h-7 w-7 items-center justify-center lg:h-8 lg:w-8",
-              isHomepage ? "text-[#f4c477]" : "text-[#b7791f]",
+              usesDarkHeroNav ? "text-[#f4c477]" : "text-[#b7791f]",
             )}
           >
             <Flower2 className="h-5 w-5 lg:h-6 lg:w-6" />
@@ -58,7 +59,7 @@ export function PublicHeader() {
             aria-label="Open public navigation"
             className={cn(
               "flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-md border bg-transparent transition-colors focus-visible:ring-1 focus-visible:ring-[#f4c477] focus-visible:outline-none [&::-webkit-details-marker]:hidden",
-              isHomepage
+              usesDarkHeroNav
                 ? "border-white/30 text-white hover:bg-white/10"
                 : "border-[#142118]/20 text-[#142118] hover:bg-[#142118]/5",
             )}
@@ -129,7 +130,7 @@ export function PublicHeader() {
             <Button
               className={cn(
                 "ml-2 h-10 rounded-md border bg-transparent px-5 text-sm shadow-none disabled:opacity-100",
-                isHomepage
+                usesDarkHeroNav
                   ? "border-white/35 text-white hover:bg-white hover:text-[#142118]"
                   : "border-[#142118]/25 text-[#142118] hover:bg-[#142118] hover:text-white",
               )}

--- a/apps/main/tests/public-footer.test.tsx
+++ b/apps/main/tests/public-footer.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PublicFooter } from "@/components/public-footer";
+
+const navigationState = vi.hoisted(() => ({ pathname: "/" }));
 
 vi.mock("@/hooks/use-feedback-url", () => ({
   useFeedbackUrl: () =>
@@ -8,10 +10,14 @@ vi.mock("@/hooks/use-feedback-url", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/",
+  usePathname: () => navigationState.pathname,
 }));
 
 describe("PublicFooter", () => {
+  beforeEach(() => {
+    navigationState.pathname = "/";
+  });
+
   it("renders the single public feedback footer", () => {
     render(<PublicFooter />);
 
@@ -31,5 +37,15 @@ describe("PublicFooter", () => {
     expect(
       screen.queryByRole("link", { name: "Create your catalog" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("uses the high-contrast hero footer on the grower landing page", () => {
+    navigationState.pathname = "/start-membership";
+    render(<PublicFooter />);
+
+    expect(screen.getByRole("contentinfo")).toHaveClass("text-white");
+    expect(screen.getByRole("link", { name: "Feedback" })).toHaveClass(
+      "text-white/70",
+    );
   });
 });

--- a/apps/main/tests/public-nav.test.tsx
+++ b/apps/main/tests/public-nav.test.tsx
@@ -56,6 +56,16 @@ describe("PublicHeader", () => {
     expect(dashboardLink).toHaveAttribute("href", "/sign-in");
   });
 
+  it("uses the high-contrast hero navigation on the grower landing page", () => {
+    navigationState.pathname = "/start-membership";
+    render(<PublicHeader />);
+
+    expect(screen.getByRole("banner")).toHaveClass("text-white");
+    expect(screen.getByRole("button", { name: "Dashboard" })).toHaveClass(
+      "text-white",
+    );
+  });
+
   it("closes the mobile menu after navigation", () => {
     const { rerender } = render(<PublicHeader />);
     const mobileNav = screen.getByTestId("mobile-public-nav");


### PR DESCRIPTION
## Summary

Use the homepage’s high-contrast chrome treatment on `/start-membership` so the navigation and fixed Feedback footer remain readable over the dark hero image.

- `public-nav.tsx`: applies the white/gold header palette on `/start-membership`
- `public-footer.tsx`: applies the white Feedback treatment on `/start-membership`
- nav/footer tests: cover the grower landing route palette

## Validation

- `pnpm main test -- tests/public-footer.test.tsx tests/public-nav.test.tsx`
- `pnpm main exec eslint src/components/public-footer.tsx src/components/public-nav.tsx`
- locally reviewed at `/start-membership`