### PR TITLE
Show blur placeholders for image assets

### DIFF
--- a/apps/main/src/app/onboarding/anonymous-onboarding-config.ts
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-config.ts
@@ -1,3 +1,4 @@
+import type { OptimizedImageSource } from "@/components/optimized-image";
 import type {
   AnonymousOnboardingDraft,
   AnonymousOnboardingStepId,
@@ -19,6 +20,7 @@ export interface ExampleCultivar {
   name: string;
   hybridizerYear: string;
   imageUrl: string;
+  imageAsset?: OptimizedImageSource["imageAsset"];
 }
 
 export interface StarterProfileImage {
@@ -175,5 +177,8 @@ export function getListingPreview(
       draft.listingPreview.description.trim() ||
       DEFAULT_LISTING_DESCRIPTION_PLACEHOLDER,
     imageUrl: draft.listingPreview.imageDataUrl ?? selectedCultivar.imageUrl,
+    imageAsset: draft.listingPreview.imageDataUrl
+      ? undefined
+      : selectedCultivar.imageAsset,
   };
 }

--- a/apps/main/src/app/onboarding/anonymous-onboarding-example-cultivar-builder.ts
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-example-cultivar-builder.ts
@@ -11,6 +11,7 @@ import {
 import {
   areImageAssetsEnabled,
   orderedImageAssetUrlInclude,
+  toImageAssetView,
 } from "@/server/services/image-asset-read-model";
 
 const onboardingAhsListingSelect = {
@@ -63,15 +64,17 @@ function getOnboardingDisplayAhsListing(row: OnboardingCultivarReferenceRow) {
   );
 }
 
-function getOnboardingImageAssetUrl(row: OnboardingCultivarReferenceRow) {
+function getOnboardingImageAsset(row: OnboardingCultivarReferenceRow) {
   if (!areImageAssetsEnabled()) return null;
 
   const asset = row.imageAssets[0];
+  if (!asset) return null;
+
   const displayUrl = asset?.displayUrl?.trim();
-  if (displayUrl) return displayUrl;
+  if (displayUrl) return { asset: toImageAssetView(asset), url: displayUrl };
 
   const originalUrl = asset?.originalUrl?.trim();
-  if (originalUrl) return originalUrl;
+  if (originalUrl) return { asset: toImageAssetView(asset), url: originalUrl };
 
   return null;
 }
@@ -90,9 +93,8 @@ export function buildOnboardingExampleCultivars(
       .map((value) => value?.trim())
       .filter((value): value is string => Boolean(value))
       .join(", ");
-    const imageUrl =
-      (row ? getOnboardingImageAssetUrl(row) : null) ??
-      ahsListing?.ahsImageUrl?.trim();
+    const imageAsset = row ? getOnboardingImageAsset(row) : null;
+    const imageUrl = imageAsset?.url ?? ahsListing?.ahsImageUrl?.trim();
 
     if (!row || !name || !hybridizerYear || !imageUrl) {
       return [];
@@ -104,6 +106,7 @@ export function buildOnboardingExampleCultivars(
         name,
         hybridizerYear,
         imageUrl,
+        ...(imageAsset ? { imageAsset: imageAsset.asset } : {}),
       },
     ];
   });

--- a/apps/main/src/app/onboarding/anonymous-onboarding-preview-cards.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-preview-cards.tsx
@@ -4,6 +4,10 @@ import Image from "next/image";
 import { Link2, MapPin, ShoppingCart } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  OptimizedImage,
+  type OptimizedImageSource,
+} from "@/components/optimized-image";
 import { formatPrice } from "@/lib/utils";
 import { LISTING_FALLBACK_IMAGE } from "./anonymous-onboarding-config";
 
@@ -69,6 +73,7 @@ export function ListingPreviewCard({
   linkedLabel,
   hybridizerYear,
   imageUrl,
+  imageAsset,
   ownershipBadge,
 }: {
   title: string;
@@ -77,6 +82,7 @@ export function ListingPreviewCard({
   linkedLabel: string;
   hybridizerYear: string;
   imageUrl: string;
+  imageAsset?: OptimizedImageSource["imageAsset"];
   ownershipBadge: string;
 }) {
   const showAddToCartButton = price !== null;
@@ -85,13 +91,11 @@ export function ListingPreviewCard({
   return (
     <div className="bg-card border-primary w-full max-w-sm overflow-hidden rounded-xl border shadow-[0_0_0_2px_rgba(24,24,27,0.08)]">
       <div className="bg-muted relative aspect-square border-b">
-        <Image
-          src={previewImageSrc}
+        <OptimizedImage
+          image={{ id: previewImageSrc, url: previewImageSrc, imageAsset }}
           alt={title}
-          fill
-          className="object-cover"
-          sizes="(max-width: 1024px) 50vw, 280px"
-          unoptimized
+          size="full"
+          className="size-full object-cover"
         />
         {price !== null ? (
           <Badge

--- a/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
+++ b/apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx
@@ -11,6 +11,7 @@ import {
   Pencil,
 } from "lucide-react";
 import { ImageCropper } from "@/components/image-cropper";
+import { OptimizedImage } from "@/components/optimized-image";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -668,13 +669,15 @@ export function ListingStep({
                     }))
                   }
                 >
-                  <Image
-                    src={cultivar.imageUrl}
+                  <OptimizedImage
+                    image={{
+                      id: cultivar.key,
+                      url: cultivar.imageUrl,
+                      imageAsset: cultivar.imageAsset,
+                    }}
                     alt=""
-                    width={48}
-                    height={48}
+                    size="thumbnail"
                     className="size-12 shrink-0 rounded object-cover"
-                    unoptimized
                   />
                   <span className="min-w-0 space-y-0.5">
                     <span className="block text-sm leading-tight font-medium whitespace-normal">
@@ -787,6 +790,7 @@ export function ListingStep({
           linkedLabel={listingPreview.selectedCultivar.name}
           hybridizerYear={listingPreview.selectedCultivar.hybridizerYear}
           imageUrl={listingPreview.imageUrl}
+          imageAsset={listingPreview.imageAsset}
           ownershipBadge="Example only"
         />
       </div>
@@ -834,6 +838,7 @@ export function PreviewStep({
             linkedLabel={listingPreview.selectedCultivar.name}
             hybridizerYear={listingPreview.selectedCultivar.hybridizerYear}
             imageUrl={listingPreview.imageUrl}
+            imageAsset={listingPreview.imageAsset}
             ownershipBadge="Example only"
           />
           <Button

--- a/apps/main/src/components/data-table/table-image-preview.tsx
+++ b/apps/main/src/components/data-table/table-image-preview.tsx
@@ -34,11 +34,12 @@ export function TableImagePreview({
             "group bg-muted/50 relative -m-1 flex aspect-square h-[calc(100%_+_1rem)] items-center justify-center rounded-md border",
           )}
         >
-          <div className="absolute overflow-hidden rounded-[4px]">
+          <div className="absolute inset-0 overflow-hidden rounded-[4px]">
             <OptimizedImage
               image={firstImage}
               alt="Image preview"
               size="thumbnail"
+              className="size-full"
             />
           </div>
         </button>

--- a/apps/main/tests/anonymous-onboarding-config.test.ts
+++ b/apps/main/tests/anonymous-onboarding-config.test.ts
@@ -111,7 +111,7 @@ describe("anonymous onboarding config", () => {
               originalUrl: "https://example.com/generated-original.jpg",
               displayUrl: "https://example.com/generated-display.jpg",
               thumbUrl: null,
-              blurUrl: null,
+              blurUrl: "https://example.com/generated-blur.webp",
             },
           ],
           v2AhsCultivar: {
@@ -144,6 +144,10 @@ describe("anonymous onboarding config", () => {
     expect(examples[0]?.imageUrl).toBe(
       "https://example.com/generated-display.jpg",
     );
+    expect(examples[0]?.imageAsset).toMatchObject({
+      id: "asset-first",
+      blurUrl: "https://example.com/generated-blur.webp",
+    });
   });
 
   it("requires configured example cultivars before building a listing preview", () => {

--- a/apps/main/tests/table-image-preview.test.tsx
+++ b/apps/main/tests/table-image-preview.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+vi.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt = "",
+    unoptimized: _unoptimized,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { unoptimized?: boolean }) =>
+    React.createElement("img", { alt, ...props }),
+}));
+
+import { TableImagePreview } from "@/components/data-table/table-image-preview";
+
+describe("TableImagePreview", () => {
+  it("paints the asset blur URL inside a fully sized table preview", () => {
+    const { container } = render(
+      <TableImagePreview
+        images={[
+          {
+            id: "image-1",
+            url: "https://media.example/image-1/thumb-200.webp",
+            imageAsset: {
+              id: "asset-1",
+              status: "ready",
+              originalUrl: "https://media.example/image-1/original.jpg",
+              displayUrl: "https://media.example/image-1/display-800.webp",
+              thumbUrl: "https://media.example/image-1/thumb-200.webp",
+              blurUrl: "https://media.example/image-1/blur-20.webp",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Image preview" })).toHaveAttribute(
+      "src",
+      "https://media.example/image-1/thumb-200.webp",
+    );
+    expect(
+      container.querySelector('[aria-hidden="true"]')?.getAttribute("style"),
+    ).toContain("https://media.example/image-1/blur-20.webp");
+    const image = screen.getByRole("img", { name: "Image preview" });
+    expect(image.parentElement).toHaveClass("size-full");
+    expect(image.parentElement?.parentElement).toHaveClass("inset-0");
+  });
+});


### PR DESCRIPTION
## Summary

- give dashboard listing thumbnails a concrete paint area so the existing blur placeholder is visible before the thumbnail loads
- preserve generated cultivar ImageAsset metadata through anonymous onboarding
- render asset-backed onboarding images through the existing OptimizedImage component at thumbnail or full size
- leave the shared OptimizedImage implementation unchanged

## Root cause

The dashboard table placed OptimizedImage inside an absolutely positioned wrapper without explicit bounds, so its absolute blur layer could lack a paintable box before the thumbnail established layout. Anonymous onboarding separately reduced generated ImageAsset records to plain URLs, dropping blurUrl before rendering.

## Files changed

- `apps/main/src/components/data-table/table-image-preview.tsx`: size the table preview wrapper and OptimizedImage explicitly.
- `apps/main/src/app/onboarding/anonymous-onboarding-example-cultivar-builder.ts`: preserve the selected ImageAsset view alongside its display URL.
- `apps/main/src/app/onboarding/anonymous-onboarding-config.ts`: carry optional ImageAsset metadata into derived listing previews unless a user upload overrides the example image.
- `apps/main/src/app/onboarding/anonymous-onboarding-steps.tsx`: use OptimizedImage for generated cultivar thumbnails and forward asset metadata to preview cards.
- `apps/main/src/app/onboarding/anonymous-onboarding-preview-cards.tsx`: render asset-backed listing previews with the full-size OptimizedImage variant.
- `apps/main/tests/table-image-preview.test.tsx`: cover the dashboard thumbnail URL, blur URL, and concrete preview bounds together.
- `apps/main/tests/anonymous-onboarding-config.test.ts`: verify generated cultivar blur metadata survives the onboarding read model.

## Validation

- `pnpm main test -- table-image-preview.test.tsx anonymous-onboarding-config.test.ts optimized-image.test.tsx`
- `pnpm main typecheck`
- `pnpm main lint`
- `git diff --check origin/main...HEAD`