### PR TITLE
Fix preview dashboard loading failures

### DIFF
--- a/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
+++ b/apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx
@@ -203,6 +203,15 @@ function useDashboardDbProviderState() {
       return;
     }
 
+    if (isError && !user) {
+      updateDashboardDbState({
+        status: "error",
+        userId: null,
+        isRefreshing: false,
+      });
+      return;
+    }
+
     if (!userId) {
       initializedUserIdRef.current = null;
       resetDashboardRefreshLock();
@@ -224,10 +233,6 @@ function useDashboardDbProviderState() {
         userId: null,
         isRefreshing: false,
       });
-      return;
-    }
-
-    if (isError) {
       return;
     }
 

--- a/apps/main/src/server/api/routers/dashboard-db/image.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/image.ts
@@ -6,7 +6,6 @@ import { APP_CONFIG } from "@/config/constants";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import crypto from "node:crypto";
-import sharp from "sharp";
 import { imageContentTypeSchema, imageTypeSchema } from "@/types/image";
 import type { db } from "@/server/db";
 import {
@@ -143,6 +142,7 @@ function decodeImageDataUrl(
 async function requestImageModeration(image: Buffer) {
   const apiKey = process.env.OPENAI_IMAGE_MODERATION_API_KEY?.trim();
   if (!apiKey) throw new Error("OPENAI_IMAGE_MODERATION_API_KEY is missing");
+  const { default: sharp } = await import("sharp");
 
   let moderationImage: Buffer;
   try {

--- a/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
+++ b/apps/main/tests/dashboard-db-provider-bootstrap.test.tsx
@@ -158,6 +158,46 @@ function getBootstrapTestResult(path: string) {
 }
 
 describe("dashboardDb provider bootstrap", () => {
+  it("shows an error when the current user lookup fails", async () => {
+    const failure = new Error("current user lookup failed");
+    const links: TRPCLink<AppRouter>[] = [
+      () =>
+        ({ op }) =>
+          observable((emit) => {
+            emit.error(
+              (op.path === "dashboardDb.user.getCurrentUserId"
+                ? failure
+                : new Error(`Unexpected operation ${op.path}`)) as Parameters<
+                typeof emit.error
+              >[0],
+            );
+          }),
+    ];
+    const trpcClient = api.createClient({ links });
+    const queryClient = getQueryClient();
+    queryClient.setDefaultOptions({ queries: { retry: false } });
+    const { DashboardDbProvider } = await import(
+      "@/app/dashboard/_components/dashboard-db-provider"
+    );
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <api.Provider client={trpcClient} queryClient={queryClient}>
+          <DashboardDbProvider>
+            <DashboardReadyMarker />
+          </DashboardDbProvider>
+        </api.Provider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Unable to load dashboard data"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("dashboard-ready")).toBeNull();
+  });
+
   it("cold bootstrap fetches each dashboard collection once", async () => {
     await withTempAppDb(async ({ user }) => {
       const { db } = await import("@/server/db");


### PR DESCRIPTION
## What changed

Fix the deploy-preview dashboard failure and make the existing dashboard error state reachable when the initial user lookup fails.

The preview was returning HTML 500 responses for every tRPC procedure because the eagerly loaded dashboard image router imported Sharp at module startup. Vercel could not load Sharp's native `libvips-cpp.so.8.18.3` dependency, so even the unrelated `dashboardDb.user.getCurrentUserId` request failed. React Query eventually exhausted its retries, but the provider treated the missing user data as an idle signed-out state and left the loading overlay visible forever.

## File-by-file

### `apps/main/src/server/api/routers/dashboard-db/image.ts`

Move the Sharp import into `requestImageModeration()`.

This keeps the native image dependency scoped to requests that actually moderate an image. Unrelated dashboard tRPC procedures can now initialize without loading Sharp, which removes the preview-wide failure while preserving moderation behavior.

### `apps/main/src/app/dashboard/_components/dashboard-db-provider.tsx`

Set the dashboard state to `error` when the initial current-user query fails without any cached user data.

This activates the existing “Unable to load dashboard data” screen after query retries instead of leaving users on the animated loading screen indefinitely. The check intentionally requires no cached user so a background refetch failure cannot replace an already-working dashboard with the fatal screen.

### `apps/main/tests/dashboard-db-provider-bootstrap.test.tsx`

Add an integration test that makes `dashboardDb.user.getCurrentUserId` fail and verifies the provider renders the existing error UI without rendering dashboard content.

This covers the exact pre-bootstrap failure path that the existing bootstrap-failure test did not exercise.

## User impact

Deploy previews can load the dashboard again even when Vercel cannot initialize Sharp, and genuine initial dashboard lookup failures now end in a clear refresh prompt instead of an infinite loading state.

## Validation

- `pnpm --filter @daylily-catalog/main exec vitest run tests/dashboard-db-provider-bootstrap.test.tsx` — 9/9 passed
- `pnpm --filter @daylily-catalog/main exec vitest run tests/dashboard-db-image-assets.test.ts` — 9/9 passed
- `pnpm main typecheck` — passed
- `pnpm lint` — passed
- `codex review --uncommitted` — clean, no actionable findings