### PR TITLE
Prevent reserved profile slugs

### DIFF
--- a/apps/main/src/server/api/routers/dashboard-db/user-profile.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/user-profile.ts
@@ -19,6 +19,26 @@ const profileSelect = {
   updatedAt: true,
 } as const;
 
+const reservedProfileSlugs = new Set([
+  "_next",
+  "auth-error",
+  "catalog",
+  "catalogs",
+  "cultivar",
+  "dashboard",
+  "kitchen-sink",
+  "onboarding",
+  "privacy",
+  "sign-in",
+  "sign-up",
+  "start-membership",
+  "start-onboarding",
+  "subscribe",
+  "support",
+  "terms",
+  "users",
+]);
+
 async function checkSlugAvailability(
   db: PrismaClient,
   slug: string | null,
@@ -29,7 +49,10 @@ async function checkSlugAvailability(
   }
 
   const normalizedSlug = slug.toLowerCase();
-  if (!isValidSlug(normalizedSlug)) {
+  if (
+    !isValidSlug(normalizedSlug) ||
+    reservedProfileSlugs.has(normalizedSlug)
+  ) {
     return false;
   }
 

--- a/apps/main/tests/dashboard-db-user-profile-slug-router.test.ts
+++ b/apps/main/tests/dashboard-db-user-profile-slug-router.test.ts
@@ -74,6 +74,17 @@ describe("dashboardDb.userProfile slug namespace", () => {
     });
   });
 
+  it("rejects reserved application routes before querying uniqueness", async () => {
+    const db = createMockDb();
+    const caller = createCaller(db);
+
+    await expect(caller.checkSlug({ slug: "dashboard" })).resolves.toEqual({
+      available: false,
+    });
+    expect(db.userProfile.findFirst).not.toHaveBeenCalled();
+    expect(db.user.findFirst).not.toHaveBeenCalled();
+  });
+
   it("does not allow updates to shadow another user's raw id", async () => {
     const db = createMockDb();
     db.userProfile.findFirst.mockResolvedValue(null);


### PR DESCRIPTION
## Summary

Prevent users from changing their public profile slug to an application-owned route such as `dashboard`, `catalogs`, `privacy`, or `support`.

The guard lives in the existing `checkSlugAvailability()` boundary, so both availability checks and profile updates use the same rule. Reserved values return before any database uniqueness query.

## Files

- `apps/main/src/server/api/routers/dashboard-db/user-profile.ts`: adds the reserved profile-slug set and checks it during existing slug validation.
- `apps/main/tests/dashboard-db-user-profile-slug-router.test.ts`: verifies a reserved slug is unavailable without querying profile or user uniqueness.

## Verification

- `pnpm --filter @daylily-catalog/main exec vitest run tests/dashboard-db-user-profile-slug-router.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- Prettier and `git diff --check`
