### PR TITLE
Unblock dashboard mutations during refresh

### DIFF
--- a/apps/main/src/app/dashboard/_lib/dashboard-db/dashboard-db-persistence.ts
+++ b/apps/main/src/app/dashboard/_lib/dashboard-db/dashboard-db-persistence.ts
@@ -31,6 +31,7 @@ import {
 
 let dashboardDbRefreshQueue: Promise<void> = Promise.resolve();
 let dashboardDbRefreshGeneration = 0;
+let dashboardDbLockedWorkRevision = 0;
 
 const LISTINGS_CURSOR_BASE = "dashboard-db:listings:maxUpdatedAt";
 const LISTS_CURSOR_BASE = "dashboard-db:lists:maxUpdatedAt";
@@ -489,7 +490,11 @@ export function runWithDashboardRefreshLock<T>(work: () => Promise<T>) {
         throw new DashboardRefreshLockCancelledError();
       }
 
-      return await work();
+      try {
+        return await work();
+      } finally {
+        dashboardDbLockedWorkRevision += 1;
+      }
     })
     .finally(() => {
       release();
@@ -580,17 +585,22 @@ export async function refreshDashboardDbFromServer(
   userId: string,
   guard?: DashboardDbRefreshGuard,
 ) {
+  if (guard?.isActive && !guard.isActive()) {
+    return false;
+  }
+
+  if (getCurrentUserId() !== userId) {
+    return false;
+  }
+
+  const lockedWorkRevision = dashboardDbLockedWorkRevision;
+  const snapshot = await fetchDashboardDbSnapshotFromServer();
+
   try {
     return await runWithDashboardRefreshLock(async () => {
-      if (guard?.isActive && !guard.isActive()) {
+      if (lockedWorkRevision !== dashboardDbLockedWorkRevision) {
         return false;
       }
-
-      if (getCurrentUserId() !== userId) {
-        return false;
-      }
-
-      const snapshot = await fetchDashboardDbSnapshotFromServer();
 
       if (guard?.isActive && !guard.isActive()) {
         return false;

--- a/apps/main/tests/dashboard-db-collections.test.tsx
+++ b/apps/main/tests/dashboard-db-collections.test.tsx
@@ -561,7 +561,7 @@ describe("dashboardDb TanStack DB collections", () => {
     });
   });
 
-  it("listings: optimistic updates wait for an in-flight full refresh", async () => {
+  it("listings: optimistic updates do not wait for an in-flight full refresh", async () => {
     await withTempAppDb(async ({ user }) => {
       const { db } = await import("@/server/db");
 
@@ -598,21 +598,27 @@ describe("dashboardDb TanStack DB collections", () => {
               | undefined;
             let cancelled = false;
 
-            void (async () => {
-              if (op.path === "dashboardDb.bootstrap.roots") {
-                await bootstrapRootsGate;
-              }
+            sub = next(op).subscribe({
+              next: (value) => {
+                void (async () => {
+                  if (op.path === "dashboardDb.bootstrap.roots") {
+                    await bootstrapRootsGate;
+                  }
 
-              if (cancelled) {
-                return;
-              }
+                  if (!cancelled) emit.next(value);
+                })();
+              },
+              error: (err) => emit.error(err),
+              complete: () => {
+                void (async () => {
+                  if (op.path === "dashboardDb.bootstrap.roots") {
+                    await bootstrapRootsGate;
+                  }
 
-              sub = next(op).subscribe({
-                next: (value) => emit.next(value),
-                error: (err) => emit.error(err),
-                complete: () => emit.complete(),
-              });
-            })();
+                  if (!cancelled) emit.complete();
+                })();
+              },
+            });
 
             return () => {
               cancelled = true;
@@ -668,8 +674,8 @@ describe("dashboardDb TanStack DB collections", () => {
       });
 
       expect(refreshResolved).toBe(false);
-      expect(updateResolved).toBe(false);
-      expect(screen.getByTestId("titles").textContent).toBe("Alpha");
+      expect(updateResolved).toBe(true);
+      expect(screen.getByTestId("titles").textContent).toBe("Beta");
 
       releaseBootstrapRoots?.();
 


### PR DESCRIPTION
## Description

Unblocks dashboard listing, list, and image mutations while a warm-cache background refresh is fetching its primary snapshot.

The refresh now fetches outside the shared mutation queue and acquires the queue only to apply the completed snapshot. If any queued dashboard work completes during the fetch, the stale snapshot is discarded instead of overwriting newer local mutation state.

This addresses the production behavior where Rolling Oaks could see Save and Refresh appear frozen behind an 11–19 second full-catalog refresh.

## Files changed

- `apps/main/src/app/dashboard/_lib/dashboard-db/dashboard-db-persistence.ts`
  - Tracks completed queued work with a small revision counter.
  - Moves only the primary background snapshot fetch outside the shared queue.
  - Skips applying a snapshot when intervening mutation work makes it stale.
  - Leaves cold primary and replica bootstrap behavior unchanged.

- `apps/main/tests/dashboard-db-collections.test.tsx`
  - Updates the existing integration test to verify an optimistic listing update completes while a stale full refresh remains suspended.
  - Verifies the stale refresh does not overwrite the saved listing value.

## Verification

- `pnpm main test -- dashboard-db-collections.test.tsx` — 11 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with one pre-existing warning in `dashboard-db-provider.tsx`
- `git diff --check` — passed