### PR TITLE
Make Stripe customer creation idempotent

### DIFF
--- a/apps/main/src/server/api/routers/stripe.ts
+++ b/apps/main/src/server/api/routers/stripe.ts
@@ -43,12 +43,15 @@ export const stripeRouter = createTRPCRouter({
     }
 
     if (!stripeCustomerId) {
-      const customer = await stripe.customers.create({
-        email: user.clerk?.email,
-        metadata: {
-          userId: user.id,
+      const customer = await stripe.customers.create(
+        {
+          email: user.clerk?.email,
+          metadata: {
+            userId: user.id,
+          },
         },
-      });
+        { idempotencyKey: `customer:user:${user.id}` },
+      );
       stripeCustomerId = customer.id;
 
       await ctx.db.user.update({

--- a/apps/main/tests/stripe-router-generate-checkout.test.ts
+++ b/apps/main/tests/stripe-router-generate-checkout.test.ts
@@ -137,7 +137,7 @@ describe("stripe.generateCheckout", () => {
     );
   });
 
-  it("creates a Stripe customer when needed and still applies the trial period", async () => {
+  it("creates a Stripe customer idempotently and still applies the trial period", async () => {
     stripeMocks.customersCreate.mockResolvedValue({
       id: "cus_new",
     });
@@ -150,12 +150,15 @@ describe("stripe.generateCheckout", () => {
 
     await caller.generateCheckout();
 
-    expect(stripeMocks.customersCreate).toHaveBeenCalledWith({
-      email: "new-user@example.com",
-      metadata: {
-        userId: "user-2",
+    expect(stripeMocks.customersCreate).toHaveBeenCalledWith(
+      {
+        email: "new-user@example.com",
+        metadata: {
+          userId: "user-2",
+        },
       },
-    });
+      { idempotencyKey: "customer:user:user-2" },
+    );
     expect(db.user.update).toHaveBeenCalledWith({
       where: { id: "user-2" },
       data: { stripeCustomerId: "cus_new" },

--- a/apps/main/tests/stripe-router.integration.test.ts
+++ b/apps/main/tests/stripe-router.integration.test.ts
@@ -80,6 +80,7 @@ describe("stripe router integration", () => {
         expect.objectContaining({
           metadata: { userId: user.id },
         }),
+        { idempotencyKey: `customer:user:${user.id}` },
       );
 
       expect(mockStripeCheckoutSessionsCreate).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Concurrent checkout requests for an app user without a stored Stripe customer could create different Stripe customers before the database update completed. Customer creation now uses a stable, non-PII Stripe idempotency key derived from the app user ID, so concurrent requests resolve to the same customer and the existing one-subscription-per-customer protection remains effective.

## Files

- `apps/main/src/server/api/routers/stripe.ts`: passes `customer:user:<appUserId>` as the idempotency key for Stripe customer creation.
- `apps/main/tests/stripe-router-generate-checkout.test.ts`: verifies customer creation uses that stable key while preserving the existing trial and Checkout Session behavior.
- `apps/main/tests/stripe-router.integration.test.ts`: keeps the real-database checkout integration assertion aligned with the Stripe request contract.

## TDD proof

The focused test was changed first and failed because `customers.create` received no idempotency options. The implementation was then added and the same test passed.

## Verification

- `pnpm --filter @daylily-catalog/main exec vitest run tests/stripe-router-generate-checkout.test.ts tests/stripe-router.integration.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with one existing warning in `dashboard-db-provider.tsx`)
- `pnpm exec prettier --check apps/main/src/server/api/routers/stripe.ts apps/main/tests/stripe-router-generate-checkout.test.ts`
- `git diff --check`
