### PR TITLE
Exclude non-positive Merchant feed prices

### DIFF
--- a/apps/main/src/app/api/google-merchant-feed/route.ts
+++ b/apps/main/src/app/api/google-merchant-feed/route.ts
@@ -29,7 +29,7 @@ export async function GET(_request: Request) {
 
     const proUserIds = await getProUserIds();
     const where = {
-      price: { not: null },
+      price: { gt: 0 },
       ...shouldShowToPublic(proUserIds),
     };
     const include = {

--- a/apps/main/tests/google-merchant-feed-route.test.ts
+++ b/apps/main/tests/google-merchant-feed-route.test.ts
@@ -120,7 +120,7 @@ describe("google merchant feed route", () => {
     dbMocks.getProUserIds.mockResolvedValue(["user-1"]);
   });
 
-  it("paginates listing queries to stay below database parameter limits", async () => {
+  it("filters non-positive prices while paginating listing queries", async () => {
     const firstPage = Array.from({ length: 200 }, (_, index) =>
       createFeedListing(index + 1),
     );
@@ -143,7 +143,7 @@ describe("google merchant feed route", () => {
       1,
       expect.objectContaining({
         where: {
-          price: { not: null },
+          price: { gt: 0 },
           OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
           userId: { in: ["user-1"] },
         },


### PR DESCRIPTION
## Summary

The Google Merchant feed previously selected every non-null listing price, allowing legacy zero or negative values to be advertised as in-stock products. The feed now selects only listings with a positive price.

## Files

- `apps/main/src/app/api/google-merchant-feed/route.ts`: changes the feed price predicate from non-null to greater than zero.
- `apps/main/tests/google-merchant-feed-route.test.ts`: requires the positive-price predicate in the existing route-level query contract test.

## TDD proof

The test expectation was changed first and failed because the route still queried `price: { not: null }`. The production predicate was then changed to `price: { gt: 0 }`, and the same test passed.

## Verification

- `pnpm --filter @daylily-catalog/main exec vitest run tests/google-merchant-feed-route.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec prettier --check apps/main/tests/google-merchant-feed-route.test.ts`
- `git diff --check`
