### PR TITLE
Fix public header and footer flow

### DIFF
--- a/apps/main/src/app/(public)/_components/home-page-client.tsx
+++ b/apps/main/src/app/(public)/_components/home-page-client.tsx
@@ -215,7 +215,7 @@ function LandingVariantTwoWithCatalogs({
     .slice(0, 6);
 
   return (
-    <div className="mx-auto -mt-16 overflow-hidden bg-[#07120e] text-white lg:-mt-20">
+    <div className="mx-auto overflow-hidden bg-[#07120e] text-white">
       <HomeHeroSection />
 
       <BuyerTestimonialsSection />

--- a/apps/main/src/app/start-membership/page.tsx
+++ b/apps/main/src/app/start-membership/page.tsx
@@ -146,7 +146,7 @@ export default async function StartMembershipPage() {
   const membershipPriceDisplay = await getMembershipPriceDisplay();
 
   return (
-    <div className="-mt-16 min-h-svh overflow-hidden lg:-mt-20">
+    <div className="min-h-svh overflow-hidden">
       <SellerLandingViewTracker />
 
       <script

--- a/apps/main/src/components/public-footer.tsx
+++ b/apps/main/src/components/public-footer.tsx
@@ -6,13 +6,12 @@ import { usePathname } from "next/navigation";
 
 export function PublicFooter() {
   const pathname = usePathname();
-  const usesDarkHeroFooter =
-    pathname === "/" || pathname === "/start-membership";
+  const usesDarkHeroFooter = pathname === "/start-membership";
 
   return (
     <footer
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 w-full bg-transparent before:pointer-events-none before:absolute before:inset-x-0 before:-top-5 before:bottom-0 before:z-[-1] before:content-[''] before:backdrop-blur-[5px] before:[mask-image:linear-gradient(to_bottom,transparent_0%,#000_20px,#000_100%)] before:[-webkit-mask-image:linear-gradient(to_bottom,transparent_0%,#000_20px,#000_100%)]",
+        "relative z-50 -mt-[calc(1.25rem+env(safe-area-inset-bottom))] w-full shrink-0 bg-transparent before:pointer-events-none before:absolute before:inset-x-0 before:-top-5 before:bottom-0 before:z-[-1] before:[mask-image:linear-gradient(to_bottom,transparent_0%,#000_20px,#000_100%)] before:backdrop-blur-[5px] before:content-[''] before:[-webkit-mask-image:linear-gradient(to_bottom,transparent_0%,#000_20px,#000_100%)]",
         usesDarkHeroFooter ? "text-white" : "text-[#142118]",
       )}
     >

--- a/apps/main/src/components/public-nav.tsx
+++ b/apps/main/src/components/public-nav.tsx
@@ -15,8 +15,7 @@ const activeNavClassName =
 export function PublicHeader() {
   const pathname = usePathname();
   const mobileNavRef = useRef<HTMLDetailsElement>(null);
-  const usesDarkHeroNav =
-    pathname === "/" || pathname === "/start-membership";
+  const usesDarkHeroNav = pathname === "/" || pathname === "/start-membership";
   const isCatalogsActive = pathname === "/catalogs";
   const isGrowersActive =
     pathname === "/start-membership" || pathname.startsWith("/onboarding");
@@ -28,7 +27,7 @@ export function PublicHeader() {
   return (
     <header
       className={cn(
-        "public-header sticky inset-x-0 top-0 z-50 flex min-h-16 w-full items-center border-none bg-transparent px-3 py-2 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:-bottom-5 before:z-[-1] before:content-[''] before:backdrop-blur-[5px] before:[mask-image:linear-gradient(to_bottom,#000_0%,#000_calc(100%_-_20px),transparent_100%)] before:[-webkit-mask-image:linear-gradient(to_bottom,#000_0%,#000_calc(100%_-_20px),transparent_100%)] lg:h-20 lg:px-8 lg:py-0",
+        "public-header relative z-50 flex min-h-16 w-full shrink-0 items-center border-none bg-transparent px-3 py-2 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:-bottom-5 before:z-[-1] before:[mask-image:linear-gradient(to_bottom,#000_0%,#000_calc(100%_-_20px),transparent_100%)] before:backdrop-blur-[5px] before:content-[''] before:[-webkit-mask-image:linear-gradient(to_bottom,#000_0%,#000_calc(100%_-_20px),transparent_100%)] lg:h-20 lg:px-8 lg:py-0",
         usesDarkHeroNav ? "text-white" : "text-[#142118]",
       )}
     >

--- a/apps/main/src/components/public-shell.tsx
+++ b/apps/main/src/components/public-shell.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import { PublicFooter } from "@/components/public-footer";
 import { PublicHeader } from "@/components/public-nav";
 import { cn } from "@/lib/utils";
+import { usePathname } from "next/navigation";
 
 interface PublicShellProps {
   children: React.ReactNode;
@@ -8,8 +11,22 @@ interface PublicShellProps {
 }
 
 export function PublicShell({ children, mainClassName }: PublicShellProps) {
+  const pathname = usePathname();
+  const overlapsHero = pathname === "/" || pathname === "/start-membership";
+  const shellBackgroundClassName =
+    pathname === "/start-membership"
+      ? "bg-[#07120e]"
+      : pathname === "/"
+        ? "bg-[#f1f4ec]"
+        : "bg-[#f6f8f3]";
+
   return (
-    <div className="flex min-h-svh flex-col bg-[#f6f8f3] text-[#142118]">
+    <div
+      className={cn(
+        "flex min-h-svh flex-col text-[#142118]",
+        shellBackgroundClassName,
+      )}
+    >
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[60] focus:rounded-md focus:bg-[#142118] focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white"
@@ -20,7 +37,8 @@ export function PublicShell({ children, mainClassName }: PublicShellProps) {
       <main
         id="main-content"
         className={cn(
-          "-mt-16 w-full flex-1 scroll-mt-24 overflow-hidden pt-16 pb-[calc(2.25rem+env(safe-area-inset-bottom))] lg:-mt-20 lg:scroll-mt-28 lg:pt-20 [&_[id]]:scroll-mt-24 lg:[&_[id]]:scroll-mt-28",
+          "w-full flex-1 scroll-mt-4 overflow-hidden [&_[id]]:scroll-mt-4",
+          overlapsHero && "-mt-16 lg:-mt-20",
           mainClassName,
         )}
       >

--- a/apps/main/tests/public-footer.test.tsx
+++ b/apps/main/tests/public-footer.test.tsx
@@ -25,7 +25,13 @@ describe("PublicFooter", () => {
     expect(termsLink).toHaveAttribute("href", "/terms");
     expect(supportLink).toHaveAttribute("href", "/support");
     expect(screen.getByRole("contentinfo")).toBeInTheDocument();
+    expect(screen.getByRole("contentinfo")).not.toHaveClass("fixed");
+    expect(screen.getByRole("contentinfo")).toHaveClass(
+      "-mt-[calc(1.25rem+env(safe-area-inset-bottom))]",
+      "before:backdrop-blur-[5px]",
+    );
     expect(footerNav).toBeVisible();
+    expect(screen.getByRole("contentinfo")).toHaveClass("text-[#142118]");
     expect(footerNav.querySelectorAll("li")).toHaveLength(3);
     expect(
       screen.queryByText("Browse daylily catalogs created by growers."),
@@ -40,6 +46,7 @@ describe("PublicFooter", () => {
     render(<PublicFooter />);
 
     expect(screen.getByRole("contentinfo")).toHaveClass("text-white");
+    expect(screen.getByRole("contentinfo")).not.toHaveClass("bg-[#07120e]");
     expect(screen.getByRole("link", { name: "Support" })).toHaveClass(
       "text-white/70",
     );

--- a/apps/main/tests/public-nav.test.tsx
+++ b/apps/main/tests/public-nav.test.tsx
@@ -23,6 +23,10 @@ describe("PublicHeader", () => {
     const growersLinks = screen.getAllByRole("link", { name: "For growers" });
 
     expect(screen.getByRole("banner")).toBeInTheDocument();
+    expect(screen.getByRole("banner")).not.toHaveClass("sticky");
+    expect(screen.getByRole("banner")).toHaveClass(
+      "before:backdrop-blur-[5px]",
+    );
     expect(catalogsLinks).toHaveLength(2);
     expect(
       catalogsLinks.every(
@@ -61,6 +65,7 @@ describe("PublicHeader", () => {
     render(<PublicHeader />);
 
     expect(screen.getByRole("banner")).toHaveClass("text-white");
+    expect(screen.getByRole("banner")).not.toHaveClass("bg-[#07120e]");
     expect(screen.getByRole("button", { name: "Dashboard" })).toHaveClass(
       "text-white",
     );

--- a/apps/main/tests/public-shell.test.tsx
+++ b/apps/main/tests/public-shell.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+const navigationState = vi.hoisted(() => ({ pathname: "/" }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => navigationState.pathname,
+}));
+
 vi.mock("@/components/public-nav", () => ({
   PublicHeader: () => <header>Public header</header>,
 }));
@@ -25,6 +31,27 @@ describe("PublicShell", () => {
     expect(skipLink).toHaveAttribute("href", "#main-content");
     const main = screen.getByRole("main");
     expect(main).toHaveAttribute("id", "main-content");
+    expect(main).toHaveClass("-mt-16", "lg:-mt-20");
+    expect(main).not.toHaveClass("pt-16");
     expect(screen.getByText("Public page content")).toBeVisible();
+    expect(main.parentElement).toHaveClass("bg-[#f1f4ec]");
+  });
+
+  it("uses the dark page background on the grower landing page", () => {
+    navigationState.pathname = "/start-membership";
+
+    render(<PublicShell>Membership</PublicShell>);
+
+    expect(screen.getByRole("main").parentElement).toHaveClass("bg-[#07120e]");
+    expect(screen.getByRole("main")).toHaveClass("-mt-16", "lg:-mt-20");
+  });
+
+  it("uses the light page background away from dark landing pages", () => {
+    navigationState.pathname = "/catalogs";
+
+    render(<PublicShell>Catalogs</PublicShell>);
+
+    expect(screen.getByRole("main").parentElement).toHaveClass("bg-[#f6f8f3]");
+    expect(screen.getByRole("main")).not.toHaveClass("-mt-16", "lg:-mt-20");
   });
 });


### PR DESCRIPTION
## Summary

- keep the public header and footer in normal document flow instead of sticky/fixed positioning
- preserve their existing visual treatment while allowing hero and final-section backgrounds to show behind them
- keep homepage and membership hero artwork beneath the header and match the homepage footer to its light final section

## Why

The floating chrome obscured page content and disconnected the header and footer from the surrounding page design. Moving positioning ownership into the shared public shell keeps the same visual styling without viewport-fixed behavior.

## Files

- `public-shell.tsx` owns route-aware hero overlap and shell backgrounds
- `public-nav.tsx` keeps the existing header styling with relative positioning
- `public-footer.tsx` overlays the final section without fixed positioning
- homepage and membership wrappers remove duplicate negative margins
- focused component tests cover positioning and route-specific backgrounds

## Validation

- `pnpm --filter @daylily-catalog/main exec vitest run tests/public-shell.test.tsx tests/public-nav.test.tsx tests/public-footer.test.tsx`
- 3 test files passed, 9 tests passed
- Codex review against `origin/main`: no actionable issues
- `git diff --check`
