### PR TITLE
Enforce listing entitlements at the server boundary

### DIFF
--- a/apps/main/src/components/contact-form.tsx
+++ b/apps/main/src/components/contact-form.tsx
@@ -111,10 +111,10 @@ function ContactFormContent({ userId, onSubmitSuccess }: ContactFormProps) {
   // Update form when customerInfo changes (on initial load)
   useEffect(() => {
     if (customerInfo.email) {
-      form.setValue("email", customerInfo.email);
+      form.setValue("email", customerInfo.email, { shouldValidate: true });
     }
     if (customerInfo.name) {
-      form.setValue("name", customerInfo.name);
+      form.setValue("name", customerInfo.name, { shouldValidate: true });
     }
   }, [customerInfo, form]);
 

--- a/apps/main/src/lib/utils/slugify-server.ts
+++ b/apps/main/src/lib/utils/slugify-server.ts
@@ -6,7 +6,7 @@ export async function generateUniqueSlug(
   title: string,
   userId: string,
   currentId?: string,
-  dbClient: PrismaClient = db,
+  dbClient: Pick<PrismaClient, "listing"> = db,
 ): Promise<string> {
   const slug = slugify(title);
   let counter = 0;

--- a/apps/main/src/lib/utils/slugify.ts
+++ b/apps/main/src/lib/utils/slugify.ts
@@ -1,5 +1,5 @@
 // Regex patterns for slug validation
-export const SLUG_INPUT_PATTERN = /^[a-z0-9-_\s]*$/;
+export const SLUG_INPUT_PATTERN = /^[a-z0-9_\s\-]*$/;
 const SLUG_FINAL_PATTERN = /^[a-z0-9-_]+$/;
 const SLUG_MIN_LENGTH = 5;
 const SLUG_MAX_LENGTH = 50;

--- a/apps/main/src/server/api/routers/dashboard-db/listing.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/listing.ts
@@ -10,6 +10,9 @@ import {
   dashboardSyncInputSchema,
   parseDashboardSyncSince,
 } from "./dashboard-db-router-helpers";
+import { APP_CONFIG } from "@/config/constants";
+import { getStripeSubscriptionResult } from "@/server/stripe/sync-subscription";
+import { hasActiveSubscription } from "@/server/stripe/subscription-utils";
 
 const listingSelect = {
   id: true,
@@ -34,6 +37,9 @@ export const dashboardDbListingRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const subscriptionResult = await getStripeSubscriptionResult(
+        ctx.user.stripeCustomerId,
+      );
       if (input.cultivarReferenceId) {
         const cultivarReference = await ctx.db.cultivarReference.findUnique({
           where: { id: input.cultivarReferenceId },
@@ -49,21 +55,37 @@ export const dashboardDbListingRouter = createTRPCRouter({
         }
       }
 
-      const slug = await generateUniqueSlug(
-        input.title,
-        ctx.user.id,
-        undefined,
-        ctx.db,
-      );
+      const listing = await ctx.db.$transaction(async (tx) => {
+        if (
+          subscriptionResult.confirmed &&
+          !hasActiveSubscription(subscriptionResult.subscription.status)
+        ) {
+          const listingCount = await tx.listing.count({
+            where: { userId: ctx.user.id },
+          });
+          if (listingCount >= APP_CONFIG.LISTING.FREE_TIER_MAX_LISTINGS) {
+            throw new TRPCError({
+              code: "FORBIDDEN",
+              message: "Upgrade to Pro to create more listings.",
+            });
+          }
+        }
 
-      const listing = await ctx.db.listing.create({
-        data: {
-          userId: ctx.user.id,
-          title: input.title,
-          slug,
-          cultivarReferenceId: input.cultivarReferenceId ?? null,
-        },
-        select: listingSelect,
+        const slug = await generateUniqueSlug(
+          input.title,
+          ctx.user.id,
+          undefined,
+          tx,
+        );
+        return tx.listing.create({
+          data: {
+            userId: ctx.user.id,
+            title: input.title,
+            slug,
+            cultivarReferenceId: input.cultivarReferenceId ?? null,
+          },
+          select: listingSelect,
+        });
       });
 
       return listing;

--- a/apps/main/src/server/stripe/sync-subscription.ts
+++ b/apps/main/src/server/stripe/sync-subscription.ts
@@ -69,11 +69,11 @@ export async function syncStripeSubscriptionToKV(customerId: string) {
   );
 }
 
-export const getStripeSubscription = async (
+export const getStripeSubscriptionResult = async (
   stripeCustomerId: string | null | undefined,
 ) => {
   if (!stripeCustomerId) {
-    return DEFAULT_SUB_DATA;
+    return { subscription: DEFAULT_SUB_DATA, confirmed: true } as const;
   }
 
   // Try to get from cache first
@@ -82,7 +82,7 @@ export const getStripeSubscription = async (
   );
 
   if (cachedData) {
-    return cachedData;
+    return { subscription: cachedData, confirmed: true } as const;
   }
 
   // If not in cache, sync from Stripe and cache it
@@ -99,10 +99,14 @@ export const getStripeSubscription = async (
     });
     // Keep checkout available; its customer binding and Stripe's setting are
     // the final duplicate guard: https://docs.stripe.com/payments/checkout/limit-subscriptions
-    return DEFAULT_SUB_DATA;
+    return { subscription: DEFAULT_SUB_DATA, confirmed: false } as const;
   }
-  return result.data;
+  return { subscription: result.data, confirmed: true } as const;
 };
+
+export const getStripeSubscription = async (
+  stripeCustomerId: string | null | undefined,
+) => (await getStripeSubscriptionResult(stripeCustomerId)).subscription;
 
 export type StripeSubCache = Awaited<
   ReturnType<typeof syncStripeSubscriptionToKV>

--- a/apps/main/tests/contact-form.test.tsx
+++ b/apps/main/tests/contact-form.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { ContactForm } from "@/components/contact-form";
 
@@ -18,8 +24,9 @@ const mockUseCart = vi.fn(() => ({
   total: 0,
 }));
 
+let customerInfo = { email: "", name: "" };
 const mockUseCustomerInfo = vi.fn(() => ({
-  customerInfo: { email: "", name: "" },
+  customerInfo,
   updateCustomerInfo: vi.fn(),
 }));
 
@@ -111,6 +118,7 @@ describe("ContactForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cartItems = [];
+    customerInfo = { email: "", name: "" };
   });
 
   it("invalid email shows field error and does not trigger unhandled rejection", async () => {
@@ -169,6 +177,19 @@ describe("ContactForm", () => {
     }
 
     expect(t.reasons).toHaveLength(0);
+  });
+
+  it("enables submission for a cart when valid remembered customer info is restored", async () => {
+    cartItems = [{ id: "item-1" }];
+    customerInfo = { email: "remembered@example.com", name: "Buyer" };
+
+    render(<ContactForm userId="test-user-id" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Send Message" }),
+      ).toBeEnabled(),
+    );
   });
 
   it("does not report expected BAD_REQUEST validation errors", async () => {

--- a/apps/main/tests/dashboard-db-listing-entitlements.integration.test.ts
+++ b/apps/main/tests/dashboard-db-listing-entitlements.integration.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TRPCInternalContext } from "@/server/api/trpc";
+import { APP_CONFIG } from "@/config/constants";
+import { withTempAppDb } from "@/lib/test-utils/app-test-db";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL ??=
+  "file:./tests/.tmp/dashboard-db-listing-entitlements.sqlite";
+
+const getStripeSubscriptionResult = vi.hoisted(() => vi.fn());
+
+vi.mock("@/server/stripe/sync-subscription", () => ({
+  getStripeSubscriptionResult,
+}));
+
+async function createAuthedCaller(userId: string) {
+  const { db } = await import("@/server/db");
+  const { createCaller } = await import("@/server/api/root");
+  const caller = createCaller(async () => {
+    const user = await db.user.findUniqueOrThrow({ where: { id: userId } });
+    return {
+      db,
+      headers: new Headers(),
+      _authUser: user as unknown as TRPCInternalContext["_authUser"],
+    } satisfies TRPCInternalContext;
+  });
+
+  return { caller, db } satisfies {
+    caller: ReturnType<typeof createCaller>;
+    db: TRPCInternalContext["db"];
+  };
+}
+
+async function seedFreeTierLimit(
+  db: TRPCInternalContext["db"],
+  userId: string,
+) {
+  await db.listing.createMany({
+    data: Array.from(
+      { length: APP_CONFIG.LISTING.FREE_TIER_MAX_LISTINGS },
+      (_, index) => ({
+        userId,
+        title: `Listing ${index + 1}`,
+        slug: `listing-${index + 1}`,
+      }),
+    ),
+  });
+}
+
+describe("dashboard listing creation entitlements", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("blocks a confirmed free account at the server-side listing limit", async () => {
+    getStripeSubscriptionResult.mockResolvedValue({
+      subscription: { status: "none" },
+      confirmed: true,
+    });
+
+    await withTempAppDb(async ({ user }) => {
+      const { caller, db } = await createAuthedCaller(user.id);
+      await seedFreeTierLimit(db, user.id);
+
+      await expect(
+        caller.dashboardDb.listing.create({ title: "One Too Many" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      await expect(
+        db.listing.count({ where: { userId: user.id } }),
+      ).resolves.toBe(APP_CONFIG.LISTING.FREE_TIER_MAX_LISTINGS);
+    });
+  });
+
+  it.each([
+    {
+      name: "active Pro account",
+      result: {
+        subscription: { status: "active" },
+        confirmed: true,
+      },
+    },
+    {
+      name: "temporarily unconfirmed Stripe lookup",
+      result: {
+        subscription: { status: "none" },
+        confirmed: false,
+      },
+    },
+  ])("allows creation for an $name", async ({ result }) => {
+    getStripeSubscriptionResult.mockResolvedValue(result);
+
+    await withTempAppDb(async ({ user }) => {
+      const { caller, db } = await createAuthedCaller(user.id);
+      await seedFreeTierLimit(db, user.id);
+
+      await expect(
+        caller.dashboardDb.listing.create({ title: "Allowed Listing" }),
+      ).resolves.toMatchObject({ title: "Allowed Listing" });
+      await expect(
+        db.listing.count({ where: { userId: user.id } }),
+      ).resolves.toBe(APP_CONFIG.LISTING.FREE_TIER_MAX_LISTINGS + 1);
+    });
+  });
+});

--- a/apps/main/tests/dashboard-db-listing-entitlements.integration.test.ts
+++ b/apps/main/tests/dashboard-db-listing-entitlements.integration.test.ts
@@ -10,8 +10,10 @@ process.env.DATABASE_URL ??=
   "file:./tests/.tmp/dashboard-db-listing-entitlements.sqlite";
 
 const getStripeSubscriptionResult = vi.hoisted(() => vi.fn());
+const getStripeSubscription = vi.hoisted(() => vi.fn());
 
 vi.mock("@/server/stripe/sync-subscription", () => ({
+  getStripeSubscription,
   getStripeSubscriptionResult,
 }));
 

--- a/apps/main/tests/e2e/smoke.e2e.ts
+++ b/apps/main/tests/e2e/smoke.e2e.ts
@@ -19,8 +19,10 @@ test.describe("guest user tour @preview", () => {
       .locator('a[href="/plantfancygardens"]')
       .filter({ hasText: "PlantFancyGardens" });
     await expect(realisticCatalogLink).toBeVisible();
-    await realisticCatalogLink.click();
-    await expect(page).toHaveURL(/\/plantfancygardens$/);
+    await Promise.all([
+      page.waitForURL(/\/plantfancygardens$/, { timeout: 60_000 }),
+      realisticCatalogLink.click(),
+    ]);
 
     // Open first listing card (opens dialog)
     const firstListingCard = page

--- a/apps/main/tests/e2e/smoke.e2e.ts
+++ b/apps/main/tests/e2e/smoke.e2e.ts
@@ -14,14 +14,13 @@ test.describe("guest user tour @preview", () => {
       /^Browse Daylily Catalogs(?: \| Daylily Catalog){0,2}$/,
     );
 
-    // Open the seeded public catalog. The preview smoke data is intentionally
-    // stable here, while catalog ordering can change as real catalogs publish.
-    const seededCatalogLink = page
-      .locator('a[href="/seeded-daylily"]')
-      .filter({ hasText: "Seeded Daylily Farm" });
-    await expect(seededCatalogLink).toBeVisible();
-    await seededCatalogLink.click();
-    await expect(page).toHaveURL(/\/seeded-daylily$/);
+    // Open one of the stage-login catalogs retained from realistic data.
+    const realisticCatalogLink = page
+      .locator('a[href="/plantfancygardens"]')
+      .filter({ hasText: "PlantFancyGardens" });
+    await expect(realisticCatalogLink).toBeVisible();
+    await realisticCatalogLink.click();
+    await expect(page).toHaveURL(/\/plantfancygardens$/);
 
     // Open first listing card (opens dialog)
     const firstListingCard = page

--- a/apps/main/tests/profile-slug-rules.test.ts
+++ b/apps/main/tests/profile-slug-rules.test.ts
@@ -18,6 +18,10 @@ describe("profile slug rules", () => {
     expect(SLUG_INPUT_PATTERN.test("GracefulPetals")).toBe(false);
   });
 
+  it("is valid for the browser pattern attribute", () => {
+    expect(() => new RegExp(SLUG_INPUT_PATTERN.source, "v")).not.toThrow();
+  });
+
   it("applies profile form schema constraints", () => {
     expect(
       profileFormSchema.safeParse({

--- a/apps/main/tests/stripe-sync-subscription.test.ts
+++ b/apps/main/tests/stripe-sync-subscription.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/lib/error-utils", () => ({
 
 import {
   getStripeSubscription,
+  getStripeSubscriptionResult,
   syncStripeSubscriptionToKV,
 } from "@/server/stripe/sync-subscription";
 
@@ -122,6 +123,15 @@ describe("Stripe subscription cache synchronization", () => {
     expect(report.context).toEqual({
       source: "getStripeSubscription",
       stripeCustomerId: "cus_error",
+    });
+  });
+
+  it("marks a cache-miss sync failure as unconfirmed for entitlements", async () => {
+    mocks.listSubscriptions.mockRejectedValue(new Error("Stripe unavailable"));
+
+    await expect(getStripeSubscriptionResult("cus_error")).resolves.toEqual({
+      subscription: { status: "none" },
+      confirmed: false,
     });
   });
 });


### PR DESCRIPTION
## Overall

Move the free-tier listing limit to the server transaction boundary so direct API callers cannot bypass it, while preserving availability when Stripe cannot confirm status. Also fixes remembered contact-form validation and browser-compatible profile slug validation.

## Files

- `apps/main/src/server/api/routers/dashboard-db/listing.ts`: checks confirmed subscription status and listing count inside the create transaction.
- `apps/main/src/server/stripe/sync-subscription.ts`: exposes whether subscription state was confirmed or unavailable so callers can fail open deliberately.
- `apps/main/src/lib/utils/slugify-server.ts`: accepts transaction-shaped Prisma clients for atomic slug generation.
- `apps/main/src/lib/utils/slugify.ts`: emits a browser `pattern` compatible with the modern `v` regex flag.
- `apps/main/src/components/contact-form.tsx`: validates remembered email/message values before enabling submission.
- `apps/main/tests/dashboard-db-listing-entitlements.integration.test.ts`: proves free, Pro, and Stripe-outage listing-create behavior against real SQLite and tRPC.
- `apps/main/tests/stripe-sync-subscription.test.ts`: covers confirmed and unconfirmed subscription results.
- `apps/main/tests/contact-form.test.tsx`: covers remembered-value validation.
- `apps/main/tests/profile-slug-rules.test.ts`: covers browser-safe slug pattern behavior.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 136 files, 477 tests
- In-app browser: public catalog -> catalog -> Contact Seller, field validation and enabled state verified without sending email
- Independent `codex review --base origin/main`: clean

Draft only; do not merge until reviewed.
