### PR TITLE
Cut Docker build time and runtime size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ temp
 temp_pages
 temp_pages_*
 apps/*/.next
+apps/*/Dockerfile
 apps/*/.turbo
 apps/*/coverage
 apps/*/downloads

--- a/.github/workflows/pr-docker-image.yml
+++ b/.github/workflows/pr-docker-image.yml
@@ -89,7 +89,7 @@ jobs:
           BUILD_TURSO_DATABASE_AUTH_TOKEN: ${{ secrets.TURSO_DATABASE_AUTH_TOKEN }}
           BUILD_STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           BUILD_STRIPE_PRICE_ID: ${{ vars.STRIPE_PRICE_ID }}
-          BUILD_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          BUILD_SENTRY_AUTH_TOKEN: ${{ github.event_name != 'pull_request' && secrets.SENTRY_AUTH_TOKEN || '' }}
         run: |
           BUILD_ENV_FILE="$RUNNER_TEMP/daylilycatalog-build.env"
 
@@ -125,6 +125,10 @@ jobs:
             echo "SENTRY_AUTH_TOKEN=$BUILD_SENTRY_AUTH_TOKEN" >> "$BUILD_ENV_FILE"
           fi
 
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "SENTRY_SOURCEMAPS_DISABLED=1" >> "$BUILD_ENV_FILE"
+          fi
+
           BUILD_ENV_FINGERPRINT="$(sha256sum "$BUILD_ENV_FILE" | cut -d' ' -f1)"
 
           echo "profile=$BUILD_ENVIRONMENT_NAME" >> "$GITHUB_OUTPUT"
@@ -132,6 +136,21 @@ jobs:
           echo "fingerprint=$BUILD_ENV_FINGERPRINT" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3
+
+      - name: Restore Next Docker compiler cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/daylily-next-cache
+          key: ${{ runner.os }}-docker-next-${{ github.event_name == 'pull_request' && 'preview' || 'production' }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-docker-next-${{ github.event_name == 'pull_request' && 'preview' || 'production' }}-
+
+      # BuildKit's gha exporter does not preserve RUN cache mounts by itself.
+      - name: Inject Next compiler cache into BuildKit
+        uses: reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810 # v2.1.4
+        with:
+          cache-source: ${{ runner.temp }}/daylily-next-cache
+          cache-target: /app/apps/main/.next/cache
 
       - name: Log in to GHCR
         if: steps.meta.outputs.should_push == 'true'

--- a/.github/workflows/pr-docker-image.yml
+++ b/.github/workflows/pr-docker-image.yml
@@ -26,7 +26,7 @@ jobs:
       immutable_tag: ${{ steps.meta.outputs.immutable_tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Compute image metadata
         id: meta
@@ -38,15 +38,18 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             IMMUTABLE_TAG="pr-${{ github.event.pull_request.number }}-${SHORT_SHA}"
             SHOULD_PUSH="false"
+            CACHE_TO=""
           else
             IMMUTABLE_TAG="main-${SHORT_SHA}"
             SHOULD_PUSH="true"
+            CACHE_TO="type=gha,mode=max"
           fi
 
           {
             echo "image_repo=${IMAGE_REPO}"
             echo "immutable_tag=${IMMUTABLE_TAG}"
             echo "should_push=${SHOULD_PUSH}"
+            echo "cache_to=${CACHE_TO}"
             echo "alias_tags<<EOF"
             if [ "$SHOULD_PUSH" = "true" ]; then
               echo "latest"
@@ -135,22 +138,7 @@ jobs:
           echo "path=$BUILD_ENV_FILE" >> "$GITHUB_OUTPUT"
           echo "fingerprint=$BUILD_ENV_FINGERPRINT" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Restore Next Docker compiler cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/daylily-next-cache
-          key: ${{ runner.os }}-docker-next-${{ github.event_name == 'pull_request' && 'preview' || 'production' }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-docker-next-${{ github.event_name == 'pull_request' && 'preview' || 'production' }}-
-
-      # BuildKit's gha exporter does not preserve RUN cache mounts by itself.
-      - name: Inject Next compiler cache into BuildKit
-        uses: reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810 # v2.1.4
-        with:
-          cache-source: ${{ runner.temp }}/daylily-next-cache
-          cache-target: /app/apps/main/.next/cache
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: steps.meta.outputs.should_push == 'true'
@@ -161,7 +149,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/main/Dockerfile
@@ -173,7 +161,9 @@ jobs:
           secret-files: |
             app_env=${{ steps.build-env.outputs.path }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # PRs consume the last main cache without paying to export throwaway app layers.
+          # Main refreshes the complete cache after merge for future builds.
+          cache-to: ${{ steps.meta.outputs.cache_to }}
 
       - name: Summarize image tags
         run: |

--- a/apps/main/Dockerfile
+++ b/apps/main/Dockerfile
@@ -18,9 +18,19 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY patches ./patches
 COPY apps/main/package.json ./apps/main/package.json
+COPY packages/standalone-runtime/package.json ./packages/standalone-runtime/package.json
 COPY apps/main/prisma ./apps/main/prisma
 
-RUN pnpm install --frozen-lockfile --filter @daylily-catalog/main...
+RUN pnpm install --frozen-lockfile \
+    --filter @daylily-catalog/main... \
+    --filter @daylily-catalog/standalone-runtime...
+
+FROM deps AS runtime-deps
+
+RUN pnpm --filter @daylily-catalog/standalone-runtime --prod deploy /runtime \
+    && source_modules="$(dirname "$(dirname "$(readlink -f /app/apps/main/node_modules/@prisma/client)")")" \
+    && runtime_modules="$(dirname "$(dirname "$(readlink -f /runtime/node_modules/@prisma/client)")")" \
+    && cp -a "$source_modules/.prisma" "$runtime_modules/.prisma"
 
 FROM base AS builder
 
@@ -34,6 +44,7 @@ ENV NODE_ENV=production
 ARG BUILD_ENV_FINGERPRINT
 
 RUN --mount=type=secret,id=app_env \
+    --mount=type=cache,target=/app/apps/main/.next/cache,sharing=locked \
     : "${BUILD_ENV_FINGERPRINT:?BUILD_ENV_FINGERPRINT is required for Docker builds}" \
     && printf '%s' "$BUILD_ENV_FINGERPRINT" >/dev/null \
     && set -a \
@@ -61,9 +72,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/main/public ./apps/main/publ
 COPY --from=builder --chown=nextjs:nodejs /app/apps/main/scripts/build-public-search-index.mjs ./apps/main/scripts/build-public-search-index.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/apps/main/scripts/build-public-parentage-index.mjs ./apps/main/scripts/build-public-parentage-index.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/apps/main/.next/standalone ./
-COPY --from=deps --chown=nextjs:nodejs /app/node_modules ./node_modules
-COPY --from=deps --chown=nextjs:nodejs /app/apps/main/node_modules ./apps/main/node_modules
+COPY --from=runtime-deps --chown=nextjs:nodejs /runtime/node_modules ./apps/main/node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/apps/main/.next/static ./apps/main/.next/static
+
+RUN cd /app/apps/main \
+    && node -e 'for (const dependency of ["sharp", "@aws-sdk/client-s3", "@prisma/client", "@prisma/adapter-libsql", "@libsql/client"]) require(dependency)'
 
 USER nextjs
 

--- a/apps/main/Dockerfile
+++ b/apps/main/Dockerfile
@@ -44,7 +44,6 @@ ENV NODE_ENV=production
 ARG BUILD_ENV_FINGERPRINT
 
 RUN --mount=type=secret,id=app_env \
-    --mount=type=cache,target=/app/apps/main/.next/cache,sharing=locked \
     : "${BUILD_ENV_FINGERPRINT:?BUILD_ENV_FINGERPRINT is required for Docker builds}" \
     && printf '%s' "$BUILD_ENV_FINGERPRINT" >/dev/null \
     && set -a \

--- a/apps/main/docs/deploy-vps.md
+++ b/apps/main/docs/deploy-vps.md
@@ -12,6 +12,9 @@ Immutable image tags are the deploy unit.
 - The VPS should deploy by setting `IMAGE_TAG` in `.env`, not by relying on `latest`.
 - After a successful image push on `main`, GitHub Actions calls the deploy webhook at `https://deploy.makon.dev/deploy/daylilycatalog`.
 - Pull requests still run Docker image verification in the `preview` GitHub Environment, but server config sync and deploy stay gated to `push` on `main`.
+- Docker builds persist the environment-scoped Next compiler cache across GitHub-hosted runners. The normal `type=gha` layer cache remains enabled, while cache-mount contents use the cache-dance workaround because the GHA exporter does not preserve them directly.
+- Non-pushed pull-request verification images skip Sentry sourcemap processing and do not receive `SENTRY_AUTH_TOKEN`. Main images retain source-map upload behavior.
+- The runner combines Next standalone output with a lockfile-backed production closure from `packages/standalone-runtime`. That manifest contains only the image-processing, S3, Prisma, and libsql packages imported by current externalized server code; Prisma's generated client is copied separately from the app build. The Docker build loads every declared external inside the final runner before emitting an image. A local production-shaped build measured 868 MB versus 1.76 GB for the prior production image, and both `/` and database-backed `/catalogs` returned 200.
 
 ## GitHub Actions Environments
 

--- a/apps/main/docs/deploy-vps.md
+++ b/apps/main/docs/deploy-vps.md
@@ -12,7 +12,7 @@ Immutable image tags are the deploy unit.
 - The VPS should deploy by setting `IMAGE_TAG` in `.env`, not by relying on `latest`.
 - After a successful image push on `main`, GitHub Actions calls the deploy webhook at `https://deploy.makon.dev/deploy/daylilycatalog`.
 - Pull requests still run Docker image verification in the `preview` GitHub Environment, but server config sync and deploy stay gated to `push` on `main`.
-- Docker builds persist the environment-scoped Next compiler cache across GitHub-hosted runners. The normal `type=gha` layer cache remains enabled, while cache-mount contents use the cache-dance workaround because the GHA exporter does not preserve them directly.
+- Docker builds consume the latest GitHub Actions layer cache. Pull-request builds skip exporting throwaway cache layers, while successful `main` builds refresh the complete cache for later builds.
 - Non-pushed pull-request verification images skip Sentry sourcemap processing and do not receive `SENTRY_AUTH_TOKEN`. Main images retain source-map upload behavior.
 - The runner combines Next standalone output with a lockfile-backed production closure from `packages/standalone-runtime`. That manifest contains only the image-processing, S3, Prisma, and libsql packages imported by current externalized server code; Prisma's generated client is copied separately from the app build. The Docker build loads every declared external inside the final runner before emitting an image. A local production-shaped build measured 868 MB versus 1.76 GB for the prior production image, and both `/` and database-backed `/catalogs` returned 200.
 

--- a/apps/main/next.config.js
+++ b/apps/main/next.config.js
@@ -68,4 +68,7 @@ export default withSentryConfig(config, {
 
   // Keep source map uploads scoped to the default client files to avoid slower Vercel builds.
   widenClientFileUpload: false,
+  sourcemaps: {
+    disable: process.env.SENTRY_SOURCEMAPS_DISABLED === "1",
+  },
 });

--- a/apps/main/tests/docker-build-config.test.ts
+++ b/apps/main/tests/docker-build-config.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(process.cwd(), "../..");
+
+describe("Docker build cache and observability boundaries", () => {
+  it("persists an environment-scoped Next compiler cache", () => {
+    const dockerfile = readFileSync(
+      path.join(repoRoot, "apps/main/Dockerfile"),
+      "utf8",
+    );
+    const workflow = readFileSync(
+      path.join(repoRoot, ".github/workflows/pr-docker-image.yml"),
+      "utf8",
+    );
+
+    expect(dockerfile).toContain(
+      "type=cache,target=/app/apps/main/.next/cache,sharing=locked",
+    );
+    expect(workflow).toContain(
+      "reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810",
+    );
+    expect(workflow).toContain("cache-target: /app/apps/main/.next/cache");
+    expect(
+      readFileSync(path.join(repoRoot, ".dockerignore"), "utf8"),
+    ).toContain("apps/*/Dockerfile");
+  });
+
+  it("disables Sentry sourcemaps only for non-deployed PR images", () => {
+    const workflow = readFileSync(
+      path.join(repoRoot, ".github/workflows/pr-docker-image.yml"),
+      "utf8",
+    );
+    const nextConfig = readFileSync(
+      path.join(repoRoot, "apps/main/next.config.js"),
+      "utf8",
+    );
+
+    expect(workflow).toContain(
+      "github.event_name != 'pull_request' && secrets.SENTRY_AUTH_TOKEN || ''",
+    );
+    expect(workflow).toContain('echo "SENTRY_SOURCEMAPS_DISABLED=1"');
+    expect(nextConfig).toContain(
+      'process.env.SENTRY_SOURCEMAPS_DISABLED === "1"',
+    );
+  });
+
+  it("uses standalone tracing instead of copying the development dependency tree", () => {
+    const dockerfile = readFileSync(
+      path.join(repoRoot, "apps/main/Dockerfile"),
+      "utf8",
+    );
+    const appPackage = JSON.parse(
+      readFileSync(path.join(repoRoot, "apps/main/package.json"), "utf8"),
+    );
+    const runtimePackage = JSON.parse(
+      readFileSync(
+        path.join(repoRoot, "packages/standalone-runtime/package.json"),
+        "utf8",
+      ),
+    );
+    expect(dockerfile).not.toContain(
+      "COPY --from=deps --chown=nextjs:nodejs /app/node_modules",
+    );
+    expect(dockerfile).toContain(
+      'for (const dependency of ["sharp", "@aws-sdk/client-s3", "@prisma/client", "@prisma/adapter-libsql", "@libsql/client"]) require(dependency)',
+    );
+    expect(dockerfile).toContain(
+      "pnpm --filter @daylily-catalog/standalone-runtime --prod deploy /runtime",
+    );
+    expect(dockerfile).toContain(
+      'cp -a "$source_modules/.prisma" "$runtime_modules/.prisma"',
+    );
+    expect(runtimePackage.dependencies).toEqual({
+      "@aws-sdk/client-s3": appPackage.dependencies["@aws-sdk/client-s3"],
+      "@libsql/client": appPackage.dependencies["@libsql/client"],
+      "@prisma/adapter-libsql":
+        appPackage.dependencies["@prisma/adapter-libsql"],
+      "@prisma/client": appPackage.dependencies["@prisma/client"],
+      sharp: appPackage.dependencies.sharp,
+    });
+  });
+});

--- a/apps/main/tests/docker-build-config.test.ts
+++ b/apps/main/tests/docker-build-config.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 const repoRoot = path.resolve(process.cwd(), "../..");
 
 describe("Docker build cache and observability boundaries", () => {
-  it("persists an environment-scoped Next compiler cache", () => {
+  it("keeps PR cache exports lean without moving a separate compiler cache", () => {
     const dockerfile = readFileSync(
       path.join(repoRoot, "apps/main/Dockerfile"),
       "utf8",
@@ -14,14 +14,23 @@ describe("Docker build cache and observability boundaries", () => {
       path.join(repoRoot, ".github/workflows/pr-docker-image.yml"),
       "utf8",
     );
-
+    expect(dockerfile).not.toContain(
+      "type=cache,target=/app/apps/main/.next/cache",
+    );
+    expect(dockerfile).toContain("FROM base AS builder");
     expect(dockerfile).toContain(
-      "type=cache,target=/app/apps/main/.next/cache,sharing=locked",
+      "COPY --from=deps /app/node_modules ./node_modules",
     );
+    expect(workflow).not.toContain("buildkit-cache-dance");
+    expect(workflow).not.toContain("actions/cache");
+    expect(workflow).toContain("actions/checkout@v7");
+    expect(workflow).toContain("docker/setup-buildx-action@v4");
+    expect(workflow).toContain("docker/build-push-action@v7");
+    expect(workflow).toContain('CACHE_TO=""');
+    expect(workflow).toContain('CACHE_TO="type=gha,mode=max"');
     expect(workflow).toContain(
-      "reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810",
+      "cache-to: ${{ steps.meta.outputs.cache_to }}",
     );
-    expect(workflow).toContain("cache-target: /app/apps/main/.next/cache");
     expect(
       readFileSync(path.join(repoRoot, ".dockerignore"), "utf8"),
     ).toContain("apps/*/Dockerfile");

--- a/apps/main/tests/e2e/smoke.e2e.ts
+++ b/apps/main/tests/e2e/smoke.e2e.ts
@@ -14,14 +14,15 @@ test.describe("guest user tour @preview", () => {
       /^Browse Daylily Catalogs(?: \| Daylily Catalog){0,2}$/,
     );
 
-    // Open the seeded public catalog. The preview smoke data is intentionally
-    // stable here, while catalog ordering can change as real catalogs publish.
-    const seededCatalogLink = page
-      .locator('a[href="/seeded-daylily"]')
-      .filter({ hasText: "Seeded Daylily Farm" });
-    await expect(seededCatalogLink).toBeVisible();
-    await seededCatalogLink.click();
-    await expect(page).toHaveURL(/\/seeded-daylily$/);
+    // Open one of the stage-login catalogs retained from realistic data.
+    const realisticCatalogLink = page
+      .locator('a[href="/plantfancygardens"]')
+      .filter({ hasText: "PlantFancyGardens" });
+    await expect(realisticCatalogLink).toBeVisible();
+    await Promise.all([
+      page.waitForURL(/\/plantfancygardens$/, { timeout: 60_000 }),
+      realisticCatalogLink.click(),
+    ]);
 
     // Open first listing card (opens dialog)
     const firstListingCard = page

--- a/packages/standalone-runtime/package.json
+++ b/packages/standalone-runtime/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@daylily-catalog/standalone-runtime",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.882.0",
+    "@libsql/client": "^0.17.3",
+    "@prisma/adapter-libsql": "7.8.0",
+    "@prisma/client": "7.8.0",
+    "sharp": "^0.35.1"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,24 @@ importers:
 
   packages/config: {}
 
+  packages/standalone-runtime:
+    dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.882.0
+        version: 3.882.0
+      '@libsql/client':
+        specifier: ^0.17.3
+        version: 0.17.3
+      '@prisma/adapter-libsql':
+        specifier: 7.8.0
+        version: 7.8.0
+      '@prisma/client':
+        specifier: 7.8.0
+        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.2))(typescript@5.9.2)
+      sharp:
+        specifier: ^0.35.1
+        version: 0.35.1
+
 packages:
 
   '@adobe/css-tools@4.4.4':


### PR DESCRIPTION
## Overall

Make Docker verification builds materially faster and production images smaller without changing application behavior. Pull-request builds reuse the latest main cache without exporting short-lived PR layers, omit Sentry source-map work, and supplement Next standalone output with only the external runtime dependencies the server actually requires.

## Files

- `.dockerignore`: excludes app Dockerfiles from the build context copied into the image.
- `.github/workflows/pr-docker-image.yml`: disables Sentry source maps and cache export for PR verification, preserves full source-map uploads and cache refreshes on `main`, and updates the Docker actions.
- `apps/main/Dockerfile`: creates a minimal production dependency closure, copies the generated Prisma client, and verifies every declared external in the final runner.
- `packages/standalone-runtime/package.json`: declares the five external runtime packages omitted by Next tracing.
- `pnpm-lock.yaml`: adds only the standalone runtime workspace importer.
- `apps/main/next.config.js`: honors the PR-only source-map-disable flag.
- `apps/main/tests/docker-build-config.test.ts`: locks the cache, observability, and minimal-runtime invariants.
- `apps/main/tests/e2e/smoke.e2e.ts`: uses the realistic preview catalog and tolerates its cold-preview navigation.
- `apps/main/docs/deploy-vps.md`: documents the final build, cache, source-map, and runtime dependency boundaries.

## Measurements

- Changed-code PR Docker baseline: 3m20s.
- Retained design: 2m55s and 3m04s repeated runs; latest changed-code run 2m34s.
- Final image: 868,424,047 bytes (~868 MB), versus the prior 1.76 GB image.
- Rejected Next filesystem-cache experiment: 4m04s overall despite a fast warm compile.
- Rejected inherited dependency-stage experiment: 3m11s, including ~55s to materialize the dependency snapshot.

## Verification

- Lint, typecheck, and unit/integration tests pass.
- Full E2E suite passes.
- Docker image build passes.
- Vercel deployment and realistic-data preview smoke pass.
- Cold local production-shaped image rendered `/catalogs` and a database-backed catalog.
- Independent `codex review --base origin/main`: no actionable correctness regressions.
