### PR TITLE
Add onboarding membership flow cockpit

### DIFF
--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -1,19 +1,20 @@
 // @ts-nocheck -- Directly executable Node registry, contract-tested by Vitest.
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
-const CAPTURE_SPEC = "tests/atlas/public-catalog.atlas.ts";
-const reproduce = (title) =>
-  `ATLAS_OUTPUT_DIR=local/atlas/reproduce ATLAS_CAPTURE_DIR=local/atlas/reproduce/screenshots pnpm main exec playwright test -c playwright.atlas.config.ts tests/atlas/public-catalog.atlas.ts --grep "${title}"`;
-const state = (id, title, description, url, urlReproducible = true) => ({
-  id,
-  title,
-  description,
-  capture: `${id}.png`,
-  captureSpec: CAPTURE_SPEC,
-  reproductionCommand: reproduce(title),
-  url,
-  urlReproducible,
-});
+const stateFor =
+  (captureSpec) =>
+  (id, title, description, url, urlReproducible = true) => ({
+    id,
+    title,
+    description,
+    capture: `${id}.png`,
+    captureSpec,
+    reproductionCommand: `ATLAS_OUTPUT_DIR=local/atlas/reproduce ATLAS_CAPTURE_DIR=local/atlas/reproduce/screenshots pnpm main exec playwright test -c playwright.atlas.config.ts ${captureSpec} --grep "${title}"`,
+    url,
+    urlReproducible,
+  });
+const publicState = stateFor("tests/atlas/public-catalog.atlas.ts");
+const onboardingState = stateFor("tests/atlas/onboarding-membership.atlas.ts");
 const testRef = (layer, file) => ({
   path: file,
   command:
@@ -48,13 +49,13 @@ export const ATLAS_FLOWS = [
       {
         title: "Find a grower",
         states: [
-          state(
+          publicState(
             "catalog-directory",
             "Catalog directory",
             "Public directory with realistic grower profiles and listing counts.",
             "/catalogs",
           ),
-          state(
+          publicState(
             "populated-catalog",
             "Populated catalog",
             "A real grower profile with navigation, lists, images, and listings.",
@@ -65,19 +66,19 @@ export const ATLAS_FLOWS = [
       {
         title: "Search and filter",
         states: [
-          state(
+          publicState(
             "search-results",
             "Search results",
             "A buyer query narrowed to a matching listing.",
             "/rollingoaksdaylilies/search?query=Absolute%20Ripper",
           ),
-          state(
+          publicState(
             "advanced-filters",
             "Advanced filters",
             "The complete advanced filter surface with active sale/photo filters.",
             "/rollingoaksdaylilies/search?mode=advanced&price=true&hasPhoto=true",
           ),
-          state(
+          publicState(
             "no-results",
             "No results",
             "Search feedback when no listing matches the buyer query.",
@@ -88,7 +89,7 @@ export const ATLAS_FLOWS = [
       {
         title: "Browse results",
         states: [
-          state(
+          publicState(
             "search-page-two",
             "Search page two",
             "The second page at the search table's smallest default size of 12.",
@@ -100,24 +101,170 @@ export const ATLAS_FLOWS = [
       {
         title: "Inspect a listing",
         states: [
-          state(
+          publicState(
             "listing-detail",
             "Listing detail",
             "A public listing with seller actions, cultivar data, and gallery.",
             "/plantfancygardens/woodside-debutante",
           ),
-          state(
+          publicState(
             "listing-alternate-image",
             "Alternate listing image",
             "Listing detail after the buyer chooses another gallery thumbnail.",
             "/plantfancygardens/woodside-debutante",
             false,
           ),
-          state(
+          publicState(
             "listing-unavailable",
             "Unavailable listing",
             "The public not-found state for a missing or unavailable listing.",
             "/plantfancygardens/not-a-real-listing",
+          ),
+        ],
+      },
+    ],
+  },
+  {
+    id: "onboarding-membership",
+    audience: "member",
+    title: "Create a catalog and start membership",
+    description:
+      "Understand the grower offer, build a catalog preview, and reach the trial handoff.",
+    tests: {
+      unit: [
+        testRef("unit", "tests/anonymous-onboarding-draft.test.ts"),
+        testRef("unit", "tests/anonymous-onboarding-config.test.ts"),
+      ],
+      integration: [
+        testRef("integration", "tests/anonymous-onboarding-layout.test.tsx"),
+        testRef("integration", "tests/onboarding-router.test.ts"),
+      ],
+      e2e: [testRef("e2e", "tests/e2e/onboarding-full-flow.e2e.ts")],
+    },
+    steps: [
+      {
+        title: "Understand the offer",
+        states: [
+          onboardingState(
+            "onboarding-membership-offer",
+            "Membership offer",
+            "The public grower offer before setup begins.",
+            "/start-membership",
+          ),
+        ],
+      },
+      {
+        title: "Start setup",
+        states: [
+          onboardingState(
+            "onboarding-email-empty",
+            "Email empty",
+            "The initial setup state before an account email is entered.",
+            "/onboarding?step=email",
+          ),
+          onboardingState(
+            "onboarding-email-invalid",
+            "Email invalid",
+            "An incomplete email keeps progression unavailable.",
+            "/onboarding?step=email",
+            false,
+          ),
+          onboardingState(
+            "onboarding-email-valid",
+            "Email valid",
+            "A valid account email makes setup ready to continue.",
+            "/onboarding?step=email",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Build a profile",
+        states: [
+          onboardingState(
+            "onboarding-profile-default",
+            "Profile defaults",
+            "The starter profile and live catalog-card preview.",
+            "/onboarding?step=profile",
+            false,
+          ),
+          onboardingState(
+            "onboarding-profile-custom",
+            "Profile customized",
+            "Realistic seller details with an alternate starter image.",
+            "/onboarding?step=profile",
+            false,
+          ),
+          onboardingState(
+            "onboarding-profile-upload",
+            "Profile upload",
+            "The visible image upload dropzone before a file is selected.",
+            "/onboarding?step=profile",
+            false,
+          ),
+          onboardingState(
+            "onboarding-profile-crop",
+            "Profile crop",
+            "The real crop dialog after selecting a profile image.",
+            "/onboarding?step=profile",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Build an example listing",
+        states: [
+          onboardingState(
+            "onboarding-listing-default",
+            "Listing defaults",
+            "The initial example listing with generated placeholder content.",
+            "/onboarding?step=listing",
+            false,
+          ),
+          onboardingState(
+            "onboarding-listing-custom",
+            "Listing customized",
+            "A selected cultivar with realistic title, price, and description.",
+            "/onboarding?step=listing",
+            false,
+          ),
+          onboardingState(
+            "onboarding-listing-upload",
+            "Listing upload",
+            "The visible listing-image upload dropzone.",
+            "/onboarding?step=listing",
+            false,
+          ),
+          onboardingState(
+            "onboarding-listing-crop",
+            "Listing crop",
+            "The real crop dialog after selecting a listing image.",
+            "/onboarding?step=listing",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Review the catalog",
+        states: [
+          onboardingState(
+            "onboarding-catalog-preview",
+            "Catalog preview",
+            "The completed seller and example-listing preview before membership.",
+            "/onboarding?step=preview",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Start the trial",
+        states: [
+          onboardingState(
+            "onboarding-checkout-review",
+            "Checkout review",
+            "The account email and membership terms immediately before Stripe.",
+            "/onboarding?step=checkout",
+            false,
           ),
         ],
       },
@@ -131,8 +278,10 @@ export function getAtlasFlow(flowId, flows = ATLAS_FLOWS) {
   if (!flow) throw new Error(`Unknown Atlas flow: ${flowId}`);
   return flow;
 }
-export function getAtlasState(stateId, flow = ATLAS_FLOWS[0]) {
-  const found = statesForFlow(flow).find(({ id }) => id === stateId);
+export function getAtlasState(stateId, flow) {
+  const found = (flow ? [flow] : ATLAS_FLOWS)
+    .flatMap(statesForFlow)
+    .find(({ id }) => id === stateId);
   if (!found) throw new Error(`Unknown Atlas state: ${stateId}`);
   return found;
 }

--- a/apps/main/tests/atlas-flows.test.ts
+++ b/apps/main/tests/atlas-flows.test.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import {
   ATLAS_FLOWS,
+  getAtlasFlow,
+  getAtlasState,
   missingFreshStateIds,
   resolveLiveStateUrl,
   statesForFlow,
@@ -20,6 +22,22 @@ describe("Atlas flow contract", () => {
   it("validates the public flow and every referenced file", () => {
     expect(validateAtlasFlows({ appRoot })).toBe(true);
     expect(statesForFlow(ATLAS_FLOWS[0]!)).toHaveLength(9);
+  });
+
+  it("resolves states from independently captured flows", () => {
+    const onboarding = getAtlasFlow("onboarding-membership");
+
+    expect(onboarding.steps.map(({ title }) => title)).toEqual([
+      "Understand the offer",
+      "Start setup",
+      "Build a profile",
+      "Build an example listing",
+      "Review the catalog",
+      "Start the trial",
+    ]);
+    expect(getAtlasState("onboarding-email-empty").captureSpec).toBe(
+      "tests/atlas/onboarding-membership.atlas.ts",
+    );
   });
 
   it.each([

--- a/apps/main/tests/atlas/onboarding-membership.atlas.ts
+++ b/apps/main/tests/atlas/onboarding-membership.atlas.ts
@@ -1,0 +1,210 @@
+import path from "node:path";
+import type { Page } from "@playwright/test";
+import {
+  ANONYMOUS_ONBOARDING_DRAFT_KEY,
+  createAnonymousOnboardingDraft,
+  type AnonymousOnboardingDraft,
+  type AnonymousOnboardingStepId,
+} from "../../src/app/onboarding/anonymous-onboarding-draft";
+import { captureAtlasState, expect, test } from "./atlas-test";
+
+const email = "atlas-grower@example.test";
+const uploadPath = path.resolve(
+  import.meta.dirname,
+  "../../public/assets/catalog-blooms.webp",
+);
+
+function draftAt(step: AnonymousOnboardingStepId): AnonymousOnboardingDraft {
+  const draft = createAnonymousOnboardingDraft({
+    email,
+    step,
+    furthestStep: step,
+  });
+
+  return {
+    ...draft,
+    profile: {
+      ...draft.profile,
+      gardenName: "Atlas Daylilies",
+      location: "Olympia, WA",
+      description:
+        "Small grower catalog focused on clear photos and seasonal availability.",
+    },
+    listingPreview: {
+      ...draft.listingPreview,
+      title: "Coffee Frenzy Spring Double Fan",
+      price: 32,
+      description: "Healthy double fan ready for local pickup or shipping.",
+    },
+  };
+}
+
+async function openDraft(
+  page: Page,
+  step: AnonymousOnboardingStepId,
+  draft = draftAt(step),
+) {
+  await page.addInitScript(
+    ({ key, value }) => window.localStorage.setItem(key, value),
+    { key: ANONYMOUS_ONBOARDING_DRAFT_KEY, value: JSON.stringify(draft) },
+  );
+  await page.goto(`/onboarding?step=${step}`);
+  await expect(page.getByTestId("anonymous-onboarding-page")).toBeVisible();
+  await expect(
+    page.getByTestId("anonymous-onboarding-step-content"),
+  ).toBeVisible();
+}
+
+test("Membership offer", async ({ page }) => {
+  await page.goto("/start-membership");
+  await expect(
+    page.getByRole("heading", {
+      name: "Your whole daylily catalog. One link buyers can browse.",
+    }),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-membership-offer");
+});
+
+test("Email empty", async ({ page }) => {
+  await page.goto("/onboarding?step=email");
+  await expect(page.getByTestId("anonymous-onboarding-page")).toBeVisible();
+  await expect(
+    page.getByTestId("anonymous-onboarding-email-submit"),
+  ).toBeDisabled();
+  await captureAtlasState(page, "onboarding-email-empty");
+});
+
+test("Email invalid", async ({ page }) => {
+  await page.goto("/onboarding?step=email");
+  await page.getByTestId("anonymous-onboarding-email").fill("not-an-email");
+  await expect(
+    page.getByTestId("anonymous-onboarding-email-submit"),
+  ).toBeDisabled();
+  await captureAtlasState(page, "onboarding-email-invalid");
+});
+
+test("Email valid", async ({ page }) => {
+  await page.goto("/onboarding?step=email");
+  await page.getByTestId("anonymous-onboarding-email").fill(email);
+  await expect(
+    page.getByTestId("anonymous-onboarding-email-submit"),
+  ).toBeEnabled();
+  await captureAtlasState(page, "onboarding-email-valid");
+});
+
+test("Profile defaults", async ({ page }) => {
+  const draft = createAnonymousOnboardingDraft({
+    email,
+    step: "profile",
+    furthestStep: "profile",
+  });
+  await openDraft(page, "profile", draft);
+  await expect(
+    page.getByRole("heading", { name: "Edit your profile" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Dew-Kissed Leaf" }),
+  ).toHaveAttribute("aria-pressed", "true");
+  await captureAtlasState(page, "onboarding-profile-default");
+});
+
+test("Profile customized", async ({ page }) => {
+  await openDraft(page, "profile");
+  const gardenPath = page.getByRole("button", { name: "Garden Path" });
+  await expect(gardenPath).toBeEnabled();
+  await gardenPath.click();
+  await expect(gardenPath).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByTestId("anonymous-profile-name")).toHaveValue(
+    "Atlas Daylilies",
+  );
+  await captureAtlasState(page, "onboarding-profile-custom");
+});
+
+test("Profile upload", async ({ page }) => {
+  await openDraft(page, "profile");
+  await page.getByTestId("anonymous-profile-image-mode-upload").click();
+  await expect(
+    page.getByTestId("anonymous-profile-image-dropzone"),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-profile-upload");
+});
+
+test("Profile crop", async ({ page }) => {
+  await openDraft(page, "profile");
+  await page.getByTestId("anonymous-profile-image-mode-upload").click();
+  await page.getByTestId("anonymous-profile-image").setInputFiles(uploadPath);
+  await expect(page.getByRole("img", { name: "Crop preview" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Use cropped image" }),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-profile-crop");
+});
+
+test("Listing defaults", async ({ page }) => {
+  const draft = createAnonymousOnboardingDraft({
+    email,
+    step: "listing",
+    furthestStep: "listing",
+  });
+  await openDraft(page, "listing", draft);
+  await expect(
+    page.getByRole("heading", { name: "Edit your first listing" }),
+  ).toBeVisible();
+  await expect(page.getByText("Example only", { exact: true })).toBeVisible();
+  await captureAtlasState(page, "onboarding-listing-default");
+});
+
+test("Listing customized", async ({ page }) => {
+  await openDraft(page, "listing");
+  await page.getByRole("button", { name: "Lemon Chiffon Cupcake" }).click();
+  await page
+    .getByTestId("anonymous-listing-title")
+    .fill("Lemon Chiffon Cupcake Double Fan");
+  await expect(page.getByTestId("anonymous-listing-title")).toHaveValue(
+    "Lemon Chiffon Cupcake Double Fan",
+  );
+  await captureAtlasState(page, "onboarding-listing-custom");
+});
+
+test("Listing upload", async ({ page }) => {
+  await openDraft(page, "listing");
+  await expect(
+    page.getByTestId("anonymous-listing-image-dropzone"),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-listing-upload");
+});
+
+test("Listing crop", async ({ page }) => {
+  await openDraft(page, "listing");
+  await page.getByTestId("anonymous-listing-image").setInputFiles(uploadPath);
+  await expect(page.getByRole("img", { name: "Crop preview" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Use cropped image" }),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-listing-crop");
+});
+
+test("Catalog preview", async ({ page }) => {
+  await openDraft(page, "preview");
+  await expect(
+    page.getByText(
+      "Path 1: Buyer opens your catalog and sends an email immediately.",
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Atlas Daylilies", { exact: true }),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-catalog-preview");
+});
+
+test("Checkout review", async ({ page }) => {
+  await openDraft(page, "checkout");
+  await expect(
+    page.getByRole("heading", { name: "Confirm your account email" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("anonymous-checkout-email-value")).toHaveText(
+    email,
+  );
+  await expect(page.getByTestId("anonymous-onboarding-checkout")).toBeEnabled();
+  await captureAtlasState(page, "onboarding-checkout-review");
+});


### PR DESCRIPTION
## Description

Adds an onboarding and membership UI Atlas flow on top of the public-catalog cockpit. Agents can regenerate and inspect 14 realistic states from the membership offer through checkout review without changing production UI or invoking checkout.

This PR intentionally stops before Clerk and Stripe completion, failure, and cancellation states. Those require a separate network-boundary test seam and should remain independently reviewable.

## Files

- `apps/main/scripts/atlas-flows.mjs`: makes Atlas states resolve across multiple capture specs and registers the onboarding flow, steps, test references, URLs, and non-URL-reproducible interaction states.
- `apps/main/tests/atlas/onboarding-membership.atlas.ts`: captures the real membership, email, profile, image upload/crop, example listing, catalog preview, and checkout-review UI using realistic local draft data and visible interactions.
- `apps/main/tests/atlas-flows.test.ts`: verifies independent flow/state resolution and the onboarding flow contract.

## Verification

- 14 Atlas states captured successfully in 35.2 seconds using Next 16.2.6 with Turbopack; no retries.
- 28 referenced onboarding and Atlas contract tests passed.
- TypeScript typecheck passed.
- `git diff --check` passed.
