### PR TITLE
Preserve Clerk auth across tRPC requests

### DIFF
--- a/apps/main/docs/agent-development-flywheel.md
+++ b/apps/main/docs/agent-development-flywheel.md
@@ -1,0 +1,36 @@
+# Agent development flywheel
+
+The flywheel is organized by user flow. For each flow, establish a visual and
+test baseline, change the app, then rerun the same evidence.
+## Confidence layers
+
+- **Atlas screenshots** document declared meaningful UI states. A capture may
+  navigate directly to a state; it does not prove the user journey.
+- **Integration tests** exercise the real app in detail, replacing only
+  external network boundaries.
+- **Connected E2E tests** prove the most important complete happy paths through
+  visible UI and real stage-service contracts.
+- **Unit tests** cover isolated logic. A flow may legitimately have none.
+The gallery lists every test currently associated with its flow. Missing layers
+remain visible instead of being converted into a misleading coverage score.
+## Public catalog loop
+
+From the repository root:
+
+```sh
+node apps/main/scripts/run-atlas-flow.mjs public-catalog --output=local/atlas/before
+```
+Open the absolute `index.html` path printed by the command and run the tests
+listed there. After making a change:
+
+```sh
+node apps/main/scripts/run-atlas-flow.mjs public-catalog --output=local/atlas/after
+pnpm test
+pnpm typecheck
+pnpm lint
+```
+Compare the retained `before` and `after` galleries. “Open live” appears only
+for states fully represented by their URL; interaction-only states provide an
+exact Playwright reproduction command instead.
+Atlas uses the standard realistic seeded development database and does not
+write to it. If it is missing, run `pnpm db:seed:prepare`.

--- a/apps/main/playwright.atlas.config.ts
+++ b/apps/main/playwright.atlas.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+const baseURL = process.env.BASE_URL ?? "http://localhost:3210";
+const outputRoot = process.env.ATLAS_OUTPUT_DIR ?? "local/atlas/current";
+export default defineConfig({
+  testDir: "./tests/atlas",
+  testMatch: "**/*.atlas.ts",
+  timeout: 120_000,
+  retries: 0,
+  workers: 1,
+  outputDir:
+    process.env.ATLAS_PLAYWRIGHT_RESULTS_DIR ??
+    path.join(outputRoot, "playwright-results"),
+  reporter: [
+    ["list"],
+    [
+      "html",
+      {
+        open: "never",
+        outputFolder:
+          process.env.ATLAS_PLAYWRIGHT_REPORT_DIR ??
+          path.join(outputRoot, "playwright-report"),
+      },
+    ],
+  ],
+  use: {
+    ...devices["Desktop Chrome"],
+    baseURL,
+    viewport: { width: 1440, height: 1000 },
+    screenshot: "off",
+    trace: "retain-on-failure",
+  },
+});

--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -1,0 +1,181 @@
+// @ts-nocheck -- Directly executable Node registry, contract-tested by Vitest.
+import { existsSync, statSync } from "node:fs";
+import path from "node:path";
+const CAPTURE_SPEC = "tests/atlas/public-catalog.atlas.ts";
+const reproduce = (title) =>
+  `pnpm main exec playwright test -c playwright.atlas.config.ts tests/atlas/public-catalog.atlas.ts --grep "${title}"`;
+const state = (id, title, description, url, urlReproducible = true) => ({
+  id,
+  title,
+  description,
+  capture: `${id}.png`,
+  captureSpec: CAPTURE_SPEC,
+  reproductionCommand: reproduce(title),
+  url,
+  urlReproducible,
+});
+const testRef = (layer, file) => ({
+  path: file,
+  command:
+    layer === "e2e"
+      ? `pnpm main exec playwright test ${file}`
+      : `pnpm main exec vitest run ${file}`,
+});
+export const ATLAS_FLOWS = [
+  {
+    id: "public-catalog",
+    audience: "public",
+    title: "Browse a public catalog",
+    description:
+      "Find a grower, search a production-sized catalog, and inspect a listing.",
+    tests: {
+      unit: [],
+      integration: [
+        testRef("integration", "tests/get-public-listings.test.ts"),
+        testRef(
+          "integration",
+          "tests/public-catalog-search-persistence.test.ts",
+        ),
+        testRef("integration", "tests/public-catalog-url-state.test.ts"),
+      ],
+      e2e: [
+        testRef("e2e", "tests/e2e/public-catalog-advanced-search.e2e.ts"),
+        testRef("e2e", "tests/e2e/cultivar-page-flow.e2e.ts"),
+        testRef("e2e", "tests/e2e/smoke.e2e.ts"),
+      ],
+    },
+    steps: [
+      {
+        title: "Find a grower",
+        states: [
+          state(
+            "catalog-directory",
+            "Catalog directory",
+            "Public directory with realistic grower profiles and listing counts.",
+            "/catalogs",
+          ),
+          state(
+            "populated-catalog",
+            "Populated catalog",
+            "A real grower profile with navigation, lists, images, and listings.",
+            "/plantfancygardens",
+          ),
+        ],
+      },
+      {
+        title: "Search and filter",
+        states: [
+          state(
+            "search-results",
+            "Search results",
+            "A buyer query narrowed to a matching listing.",
+            "/rollingoaksdaylilies/search?query=Absolute%20Ripper",
+          ),
+          state(
+            "advanced-filters",
+            "Advanced filters",
+            "The complete advanced filter surface with active sale/photo filters.",
+            "/rollingoaksdaylilies/search?mode=advanced&price=true&hasPhoto=true",
+          ),
+          state(
+            "no-results",
+            "No results",
+            "Search feedback when no listing matches the buyer query.",
+            "/rollingoaksdaylilies/search?query=no-such-daylily",
+          ),
+        ],
+      },
+      {
+        title: "Browse results",
+        states: [
+          state(
+            "search-page-two",
+            "Search page two",
+            "The second page at the search table's smallest default size of 12.",
+            "/rollingoaksdaylilies/search",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Inspect a listing",
+        states: [
+          state(
+            "listing-detail",
+            "Listing detail",
+            "A public listing with seller actions, cultivar data, and gallery.",
+            "/plantfancygardens/woodside-debutante",
+          ),
+          state(
+            "listing-alternate-image",
+            "Alternate listing image",
+            "Listing detail after the buyer chooses another gallery thumbnail.",
+            "/plantfancygardens/woodside-debutante",
+            false,
+          ),
+          state(
+            "listing-unavailable",
+            "Unavailable listing",
+            "The public not-found state for a missing or unavailable listing.",
+            "/plantfancygardens/not-a-real-listing",
+          ),
+        ],
+      },
+    ],
+  },
+];
+export const statesForFlow = (flow) =>
+  flow.steps.flatMap((step) => step.states);
+export function getAtlasFlow(flowId, flows = ATLAS_FLOWS) {
+  const flow = flows.find(({ id }) => id === flowId);
+  if (!flow) throw new Error(`Unknown Atlas flow: ${flowId}`);
+  return flow;
+}
+export function getAtlasState(stateId, flow = ATLAS_FLOWS[0]) {
+  const found = statesForFlow(flow).find(({ id }) => id === stateId);
+  if (!found) throw new Error(`Unknown Atlas state: ${stateId}`);
+  return found;
+}
+export function resolveLiveStateUrl(stateItem, baseURL) {
+  return stateItem.urlReproducible && stateItem.url
+    ? new URL(stateItem.url, baseURL).toString()
+    : null;
+}
+export function validateAtlasFlows({ flows = ATLAS_FLOWS, appRoot }) {
+  const stateIds = new Set();
+  const captures = new Set();
+  const allowedLayers = new Set(["unit", "integration", "e2e"]);
+  for (const flow of flows) {
+    for (const layer of Object.keys(flow.tests)) {
+      if (!allowedLayers.has(layer))
+        throw new Error(`Invalid test layer: ${layer}`);
+    }
+    for (const references of Object.values(flow.tests)) {
+      for (const reference of references) {
+        if (!existsSync(path.resolve(appRoot, reference.path)))
+          throw new Error(`Missing referenced test: ${reference.path}`);
+      }
+    }
+    for (const stateItem of statesForFlow(flow)) {
+      if (stateIds.has(stateItem.id))
+        throw new Error(`Duplicate Atlas state id: ${stateItem.id}`);
+      if (captures.has(stateItem.capture))
+        throw new Error(`Duplicate Atlas capture: ${stateItem.capture}`);
+      if (!stateItem.reproductionCommand)
+        throw new Error(`Missing reproduction command: ${stateItem.id}`);
+      if (!existsSync(path.resolve(appRoot, stateItem.captureSpec)))
+        throw new Error(`Missing capture spec: ${stateItem.captureSpec}`);
+      stateIds.add(stateItem.id);
+      captures.add(stateItem.capture);
+    }
+  }
+  return true;
+}
+export function missingFreshStateIds(flow, captureDirectory, startedAt) {
+  return statesForFlow(flow)
+    .filter(({ capture }) => {
+      const file = path.join(captureDirectory, capture);
+      return !existsSync(file) || statSync(file).mtimeMs < startedAt;
+    })
+    .map(({ id }) => id);
+}

--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -1,19 +1,20 @@
 // @ts-nocheck -- Directly executable Node registry, contract-tested by Vitest.
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
-const CAPTURE_SPEC = "tests/atlas/public-catalog.atlas.ts";
-const reproduce = (title) =>
-  `pnpm main exec playwright test -c playwright.atlas.config.ts tests/atlas/public-catalog.atlas.ts --grep "${title}"`;
-const state = (id, title, description, url, urlReproducible = true) => ({
-  id,
-  title,
-  description,
-  capture: `${id}.png`,
-  captureSpec: CAPTURE_SPEC,
-  reproductionCommand: reproduce(title),
-  url,
-  urlReproducible,
-});
+const stateFor =
+  (captureSpec) =>
+  (id, title, description, url, urlReproducible = true) => ({
+    id,
+    title,
+    description,
+    capture: `${id}.png`,
+    captureSpec,
+    reproductionCommand: `pnpm main exec playwright test -c playwright.atlas.config.ts ${captureSpec} --grep "${title}"`,
+    url,
+    urlReproducible,
+  });
+const publicState = stateFor("tests/atlas/public-catalog.atlas.ts");
+const onboardingState = stateFor("tests/atlas/onboarding-membership.atlas.ts");
 const testRef = (layer, file) => ({
   path: file,
   command:
@@ -48,13 +49,13 @@ export const ATLAS_FLOWS = [
       {
         title: "Find a grower",
         states: [
-          state(
+          publicState(
             "catalog-directory",
             "Catalog directory",
             "Public directory with realistic grower profiles and listing counts.",
             "/catalogs",
           ),
-          state(
+          publicState(
             "populated-catalog",
             "Populated catalog",
             "A real grower profile with navigation, lists, images, and listings.",
@@ -65,19 +66,19 @@ export const ATLAS_FLOWS = [
       {
         title: "Search and filter",
         states: [
-          state(
+          publicState(
             "search-results",
             "Search results",
             "A buyer query narrowed to a matching listing.",
             "/rollingoaksdaylilies/search?query=Absolute%20Ripper",
           ),
-          state(
+          publicState(
             "advanced-filters",
             "Advanced filters",
             "The complete advanced filter surface with active sale/photo filters.",
             "/rollingoaksdaylilies/search?mode=advanced&price=true&hasPhoto=true",
           ),
-          state(
+          publicState(
             "no-results",
             "No results",
             "Search feedback when no listing matches the buyer query.",
@@ -88,7 +89,7 @@ export const ATLAS_FLOWS = [
       {
         title: "Browse results",
         states: [
-          state(
+          publicState(
             "search-page-two",
             "Search page two",
             "The second page at the search table's smallest default size of 12.",
@@ -100,24 +101,170 @@ export const ATLAS_FLOWS = [
       {
         title: "Inspect a listing",
         states: [
-          state(
+          publicState(
             "listing-detail",
             "Listing detail",
             "A public listing with seller actions, cultivar data, and gallery.",
             "/plantfancygardens/woodside-debutante",
           ),
-          state(
+          publicState(
             "listing-alternate-image",
             "Alternate listing image",
             "Listing detail after the buyer chooses another gallery thumbnail.",
             "/plantfancygardens/woodside-debutante",
             false,
           ),
-          state(
+          publicState(
             "listing-unavailable",
             "Unavailable listing",
             "The public not-found state for a missing or unavailable listing.",
             "/plantfancygardens/not-a-real-listing",
+          ),
+        ],
+      },
+    ],
+  },
+  {
+    id: "onboarding-membership",
+    audience: "member",
+    title: "Create a catalog and start membership",
+    description:
+      "Understand the grower offer, build a catalog preview, and reach the trial handoff.",
+    tests: {
+      unit: [
+        testRef("unit", "tests/anonymous-onboarding-draft.test.ts"),
+        testRef("unit", "tests/anonymous-onboarding-config.test.ts"),
+      ],
+      integration: [
+        testRef("integration", "tests/anonymous-onboarding-layout.test.tsx"),
+        testRef("integration", "tests/onboarding-router.test.ts"),
+      ],
+      e2e: [testRef("e2e", "tests/e2e/onboarding-full-flow.e2e.ts")],
+    },
+    steps: [
+      {
+        title: "Understand the offer",
+        states: [
+          onboardingState(
+            "onboarding-membership-offer",
+            "Membership offer",
+            "The public grower offer before setup begins.",
+            "/start-membership",
+          ),
+        ],
+      },
+      {
+        title: "Start setup",
+        states: [
+          onboardingState(
+            "onboarding-email-empty",
+            "Email empty",
+            "The initial setup state before an account email is entered.",
+            "/onboarding?step=email",
+          ),
+          onboardingState(
+            "onboarding-email-invalid",
+            "Email invalid",
+            "An incomplete email keeps progression unavailable.",
+            "/onboarding?step=email",
+            false,
+          ),
+          onboardingState(
+            "onboarding-email-valid",
+            "Email valid",
+            "A valid account email makes setup ready to continue.",
+            "/onboarding?step=email",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Build a profile",
+        states: [
+          onboardingState(
+            "onboarding-profile-default",
+            "Profile defaults",
+            "The starter profile and live catalog-card preview.",
+            "/onboarding?step=profile",
+            false,
+          ),
+          onboardingState(
+            "onboarding-profile-custom",
+            "Profile customized",
+            "Realistic seller details with an alternate starter image.",
+            "/onboarding?step=profile",
+            false,
+          ),
+          onboardingState(
+            "onboarding-profile-upload",
+            "Profile upload",
+            "The visible image upload dropzone before a file is selected.",
+            "/onboarding?step=profile",
+            false,
+          ),
+          onboardingState(
+            "onboarding-profile-crop",
+            "Profile crop",
+            "The real crop dialog after selecting a profile image.",
+            "/onboarding?step=profile",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Build an example listing",
+        states: [
+          onboardingState(
+            "onboarding-listing-default",
+            "Listing defaults",
+            "The initial example listing with generated placeholder content.",
+            "/onboarding?step=listing",
+            false,
+          ),
+          onboardingState(
+            "onboarding-listing-custom",
+            "Listing customized",
+            "A selected cultivar with realistic title, price, and description.",
+            "/onboarding?step=listing",
+            false,
+          ),
+          onboardingState(
+            "onboarding-listing-upload",
+            "Listing upload",
+            "The visible listing-image upload dropzone.",
+            "/onboarding?step=listing",
+            false,
+          ),
+          onboardingState(
+            "onboarding-listing-crop",
+            "Listing crop",
+            "The real crop dialog after selecting a listing image.",
+            "/onboarding?step=listing",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Review the catalog",
+        states: [
+          onboardingState(
+            "onboarding-catalog-preview",
+            "Catalog preview",
+            "The completed seller and example-listing preview before membership.",
+            "/onboarding?step=preview",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Start the trial",
+        states: [
+          onboardingState(
+            "onboarding-checkout-review",
+            "Checkout review",
+            "The account email and membership terms immediately before Stripe.",
+            "/onboarding?step=checkout",
+            false,
           ),
         ],
       },
@@ -131,8 +278,10 @@ export function getAtlasFlow(flowId, flows = ATLAS_FLOWS) {
   if (!flow) throw new Error(`Unknown Atlas flow: ${flowId}`);
   return flow;
 }
-export function getAtlasState(stateId, flow = ATLAS_FLOWS[0]) {
-  const found = statesForFlow(flow).find(({ id }) => id === stateId);
+export function getAtlasState(stateId, flow) {
+  const found = (flow ? [flow] : ATLAS_FLOWS)
+    .flatMap(statesForFlow)
+    .find(({ id }) => id === stateId);
   if (!found) throw new Error(`Unknown Atlas state: ${stateId}`);
   return found;
 }

--- a/apps/main/scripts/atlas-server-process.mjs
+++ b/apps/main/scripts/atlas-server-process.mjs
@@ -1,0 +1,19 @@
+export const ATLAS_HEALTH_PATH = "/api/runtime-config";
+
+/**
+ * @param {{ exitCode?: number | null; pid?: number } | undefined} server
+ * @param {{ platform?: NodeJS.Platform; signal?: typeof process.kill }} options
+ */
+export function terminateAtlasServer(
+  server,
+  { platform = process.platform, signal = process.kill } = {},
+) {
+  if (!server?.pid) return false;
+
+  try {
+    signal(platform === "win32" ? server.pid : -server.pid, "SIGTERM");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/main/scripts/generate-atlas-gallery.mjs
+++ b/apps/main/scripts/generate-atlas-gallery.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  getAtlasFlow,
+  resolveLiveStateUrl,
+  statesForFlow,
+} from "./atlas-flows.mjs";
+const escapeHtml = (value) =>
+  String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+export function generateAtlasGallery({
+  flowId,
+  outputDirectory,
+  baseURL = "http://localhost:3210",
+}) {
+  const flow = getAtlasFlow(flowId);
+  const captureDirectory = path.join(outputDirectory, "screenshots");
+  const missing = statesForFlow(flow)
+    .filter(({ capture }) => !existsSync(path.join(captureDirectory, capture)))
+    .map(({ id }) => id);
+  if (missing.length)
+    throw new Error(`Missing Atlas states: ${missing.join(", ")}`);
+
+  const tests = Object.entries(flow.tests)
+    .map(
+      ([layer, references]) =>
+        `<section><h2>${escapeHtml(layer)}</h2>${
+          references.length
+            ? references
+                .map(
+                  (reference) =>
+                    `<p><code>${escapeHtml(reference.path)}</code><br><code>${escapeHtml(reference.command)}</code></p>`,
+                )
+                .join("")
+            : "<p>None declared.</p>"
+        }</section>`,
+    )
+    .join("");
+  const steps = flow.steps
+    .map(
+      (step, index) =>
+        `<section class="step"><h2>${index + 1}. ${escapeHtml(step.title)}</h2><div class="grid">${step.states
+          .map((stateItem) => {
+            const liveUrl = resolveLiveStateUrl(stateItem, baseURL);
+            return `<article><a href="screenshots/${escapeHtml(stateItem.capture)}"><img src="screenshots/${escapeHtml(stateItem.capture)}" alt="${escapeHtml(stateItem.title)} screenshot" loading="lazy"></a><div class="copy"><h3>${escapeHtml(stateItem.title)}</h3><p>${escapeHtml(stateItem.description)}</p><p class="meta"><code>${escapeHtml(stateItem.url)}</code>${liveUrl ? `<a href="${escapeHtml(liveUrl)}" target="_blank" rel="noreferrer">Open live</a>` : "<span>Requires interaction</span>"}</p><details><summary>Reproduce</summary><code>${escapeHtml(stateItem.reproductionCommand)}</code></details></div></article>`;
+          })
+          .join("")}</div></section>`,
+    )
+    .join("");
+  const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(flow.title)} · UI Atlas</title><style>
+  :root{font-family:Inter,ui-sans-serif,system-ui;color:#20251f;background:#f4f5f1}*{box-sizing:border-box}body{margin:0;padding:36px}main{max-width:1600px;margin:auto}header{max-width:850px;margin-bottom:38px}h1{font-size:clamp(2.3rem,5vw,4.5rem);letter-spacing:-.05em;margin:0 0 12px}h2{text-transform:capitalize}header p,.copy p,section>p{color:#62685f;line-height:1.5}.tests{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:28px 0 50px}.tests section,article{border:1px solid #d9ddd4;border-radius:16px;background:white;overflow:hidden}.tests section{padding:18px}.tests h2{margin-top:0}.step{margin-bottom:50px}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:22px;align-items:start}article>a{display:block;max-height:520px;overflow:auto;background:#e7e9e3;border-bottom:1px solid #d9ddd4}img{display:block;width:100%;height:auto}.copy{padding:18px}.copy h3{margin:0 0 8px}.meta{display:flex;flex-wrap:wrap;gap:9px;align-items:center}.meta a,.meta span{padding:6px 9px;border-radius:7px;background:#e7efe3;color:#3f6037;font-weight:700;text-decoration:none}code{display:inline-block;max-width:100%;overflow:auto;padding:6px 8px;border-radius:6px;background:#eef0eb;font-size:.78rem}details code{margin-top:10px}@media(max-width:800px){body{padding:22px 12px}.tests{grid-template-columns:1fr}.grid{grid-template-columns:1fr}}
+  </style></head><body><main><header><p>Daylily Catalog UI Atlas</p><h1>${escapeHtml(flow.title)}</h1><p>${escapeHtml(flow.description)}</p></header><div class="tests">${tests}</div>${steps}</main></body></html>`;
+  mkdirSync(outputDirectory, { recursive: true });
+  const galleryPath = path.join(outputDirectory, "index.html");
+  writeFileSync(galleryPath, html);
+  return galleryPath;
+}
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const value = (name) =>
+    process.argv
+      .find((argument) => argument.startsWith(`${name}=`))
+      ?.slice(name.length + 1);
+  const flowId = value("--flow");
+  const output = value("--output");
+  if (!flowId || !output)
+    throw new Error(
+      "Usage: generate-atlas-gallery.mjs --flow=<id> --output=<directory>",
+    );
+  console.log(
+    path.resolve(
+      generateAtlasGallery({
+        flowId,
+        outputDirectory: path.resolve(output),
+        baseURL: value("--base-url"),
+      }),
+    ),
+  );
+}

--- a/apps/main/scripts/run-atlas-flow.mjs
+++ b/apps/main/scripts/run-atlas-flow.mjs
@@ -5,6 +5,10 @@ import path from "node:path";
 import * as dotenv from "dotenv";
 import { generateAtlasGallery } from "./generate-atlas-gallery.mjs";
 import {
+  ATLAS_HEALTH_PATH,
+  terminateAtlasServer,
+} from "./atlas-server-process.mjs";
+import {
   getAtlasFlow,
   missingFreshStateIds,
   validateAtlasFlows,
@@ -22,15 +26,7 @@ const captureDirectory = path.join(outputDirectory, "screenshots");
 const baseURL = process.env.BASE_URL ?? "http://localhost:3210";
 const explicitDatabaseUrl = process.env.DATABASE_URL;
 let server;
-const stopServer = () => {
-  if (!server?.pid || server.exitCode !== null) return;
-  try {
-    process.kill(
-      process.platform === "win32" ? server.pid : -server.pid,
-      "SIGTERM",
-    );
-  } catch {}
-};
+const stopServer = () => terminateAtlasServer(server);
 for (const signal of ["SIGINT", "SIGTERM"]) {
   process.on(signal, () => {
     stopServer();
@@ -39,7 +35,7 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
 }
 async function isHealthy() {
   try {
-    const response = await fetch(new URL("/catalogs", baseURL), {
+    const response = await fetch(new URL(ATLAS_HEALTH_PATH, baseURL), {
       signal: AbortSignal.timeout(5_000),
     });
     return response.status < 500;
@@ -65,23 +61,19 @@ async function startServer() {
     throw new Error(
       "Seeded database missing. Run `pnpm db:seed:prepare` first.",
     );
-  server = spawn(
-    "pnpm",
-    ["dev", "--", "--port", new URL(baseURL).port],
-    {
-      cwd: repoRoot,
-      detached: process.platform !== "win32",
-      stdio: "inherit",
-      env: {
-        ...process.env,
-        DATABASE_URL: explicitDatabaseUrl ?? `file:${seededDatabase}`,
-        PUBLIC_SEARCH_INDEX_REFRESH_INTERVAL_SECONDS: "0",
-        TURSO_DATABASE_AUTH_TOKEN: "",
-        TURSO_EMBEDDED_REPLICA_URL: "",
-        TURSO_EMBEDDED_REPLICA_SYNC_URL: "",
-      },
+  server = spawn("pnpm", ["dev", "--", "--port", new URL(baseURL).port], {
+    cwd: repoRoot,
+    detached: process.platform !== "win32",
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      DATABASE_URL: explicitDatabaseUrl ?? `file:${seededDatabase}`,
+      PUBLIC_SEARCH_INDEX_REFRESH_INTERVAL_SECONDS: "0",
+      TURSO_DATABASE_AUTH_TOKEN: "",
+      TURSO_EMBEDDED_REPLICA_URL: "",
+      TURSO_EMBEDDED_REPLICA_SYNC_URL: "",
     },
-  );
+  });
   const deadline = Date.now() + 120_000;
   while (Date.now() < deadline) {
     if (server.exitCode !== null)

--- a/apps/main/scripts/run-atlas-flow.mjs
+++ b/apps/main/scripts/run-atlas-flow.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import * as dotenv from "dotenv";
+import { generateAtlasGallery } from "./generate-atlas-gallery.mjs";
+import {
+  getAtlasFlow,
+  missingFreshStateIds,
+  validateAtlasFlows,
+} from "./atlas-flows.mjs";
+const appRoot = path.resolve(import.meta.dirname, "..");
+const repoRoot = path.resolve(appRoot, "../..");
+const [flowId, outputArgument, ...unexpected] = process.argv.slice(2);
+if (!flowId || !outputArgument?.startsWith("--output=") || unexpected.length)
+  throw new Error("Usage: run-atlas-flow.mjs <flow-id> --output=<directory>");
+
+const flow = getAtlasFlow(flowId);
+validateAtlasFlows({ appRoot });
+const outputDirectory = path.resolve(process.cwd(), outputArgument.slice(9));
+const captureDirectory = path.join(outputDirectory, "screenshots");
+const baseURL = process.env.BASE_URL ?? "http://localhost:3210";
+const explicitDatabaseUrl = process.env.DATABASE_URL;
+let server;
+const stopServer = () => {
+  if (!server?.pid || server.exitCode !== null) return;
+  try {
+    process.kill(
+      process.platform === "win32" ? server.pid : -server.pid,
+      "SIGTERM",
+    );
+  } catch {}
+};
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    stopServer();
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  });
+}
+async function isHealthy() {
+  try {
+    const response = await fetch(new URL("/catalogs", baseURL), {
+      signal: AbortSignal.timeout(5_000),
+    });
+    return response.status < 500;
+  } catch {
+    return false;
+  }
+}
+async function startServer() {
+  if (await isHealthy()) return;
+  if (process.env.BASE_URL)
+    throw new Error(`BASE_URL is not healthy: ${process.env.BASE_URL}`);
+  for (const envPath of [
+    path.join(repoRoot, ".env.development"),
+    path.join(appRoot, ".env.development"),
+  ]) {
+    if (existsSync(envPath)) dotenv.config({ path: envPath, quiet: true });
+  }
+  const seededDatabase = path.join(
+    appRoot,
+    "local/realistic-data/realistic-data.sqlite",
+  );
+  if (!explicitDatabaseUrl && !existsSync(seededDatabase))
+    throw new Error(
+      "Seeded database missing. Run `pnpm db:seed:prepare` first.",
+    );
+  server = spawn(
+    "pnpm",
+    ["dev", "--", "--port", new URL(baseURL).port],
+    {
+      cwd: repoRoot,
+      detached: process.platform !== "win32",
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        DATABASE_URL: explicitDatabaseUrl ?? `file:${seededDatabase}`,
+        PUBLIC_SEARCH_INDEX_REFRESH_INTERVAL_SECONDS: "0",
+        TURSO_DATABASE_AUTH_TOKEN: "",
+        TURSO_EMBEDDED_REPLICA_URL: "",
+        TURSO_EMBEDDED_REPLICA_SYNC_URL: "",
+      },
+    },
+  );
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null)
+      throw new Error("Atlas dev server exited early.");
+    if (await isHealthy()) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Atlas dev server was not ready at ${baseURL}`);
+}
+try {
+  await startServer();
+  rmSync(outputDirectory, { recursive: true, force: true });
+  mkdirSync(captureDirectory, { recursive: true });
+  const startedAt = Date.now();
+  const result = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "playwright",
+      "test",
+      "-c",
+      "playwright.atlas.config.ts",
+      flow.steps[0].states[0].captureSpec,
+    ],
+    {
+      cwd: appRoot,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        BASE_URL: baseURL,
+        ATLAS_OUTPUT_DIR: outputDirectory,
+        ATLAS_CAPTURE_DIR: captureDirectory,
+        ATLAS_PLAYWRIGHT_RESULTS_DIR: path.join(
+          outputDirectory,
+          "playwright-results",
+        ),
+        ATLAS_PLAYWRIGHT_REPORT_DIR: path.join(
+          outputDirectory,
+          "playwright-report",
+        ),
+      },
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exitCode = result.status ?? 1;
+  else {
+    const missing = missingFreshStateIds(flow, captureDirectory, startedAt);
+    if (missing.length)
+      throw new Error(`Missing or stale Atlas states: ${missing.join(", ")}`);
+    const galleryPath = generateAtlasGallery({
+      flowId,
+      outputDirectory,
+      baseURL,
+    });
+    console.log(`Atlas gallery: ${path.resolve(galleryPath)}`);
+  }
+} finally {
+  stopServer();
+}

--- a/apps/main/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/main/src/app/api/trpc/[trpc]/route.ts
@@ -1,5 +1,6 @@
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { type NextRequest } from "next/server";
+import { getAuth } from "@clerk/nextjs/server";
 
 import { env } from "@/env";
 import { appRouter } from "@/server/api/root";
@@ -9,19 +10,25 @@ import { createTRPCContext } from "@/server/api/trpc";
  * This wraps the `createTRPCContext` helper and provides the required context for the tRPC API when
  * handling a HTTP request (e.g. when you make requests from Client Components).
  */
-const createContext = async (req: NextRequest) => {
+const createContext = async (
+  req: NextRequest,
+  clerkUserId: string | null,
+) => {
   return createTRPCContext({
     headers: req.headers,
     requestUrl: req.url,
+    clerkUserId,
   });
 };
 
-const handler = (req: NextRequest) =>
-  fetchRequestHandler({
+const handler = async (req: NextRequest) => {
+  const { userId: clerkUserId } = getAuth(req);
+
+  return fetchRequestHandler({
     endpoint: "/api/trpc",
     req,
     router: appRouter,
-    createContext: () => createContext(req),
+    createContext: () => createContext(req, clerkUserId),
     onError:
       env.NODE_ENV === "development"
         ? ({ path, error }) => {
@@ -31,5 +38,6 @@ const handler = (req: NextRequest) =>
           }
         : undefined,
   });
+};
 
 export { handler as GET, handler as POST };

--- a/apps/main/src/server/api/routers/dashboard-db/user.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/user.ts
@@ -15,7 +15,10 @@ export const dashboardDbUserRouter = createTRPCRouter({
       return { id: contextUser.id };
     }
 
-    const clerkUserId = await resolveAuthenticatedClerkUserId();
+    const clerkUserId =
+      typeof ctx.clerkUserId === "undefined"
+        ? await resolveAuthenticatedClerkUserId()
+        : ctx.clerkUserId;
 
     if (!clerkUserId) {
       throw new TRPCError({

--- a/apps/main/src/server/api/trpc.ts
+++ b/apps/main/src/server/api/trpc.ts
@@ -44,6 +44,7 @@ const SESSION_AUTH_TOKENS = ["session_token"] as const;
 export interface TRPCContext {
   headers: Headers;
   db: typeof db;
+  clerkUserId?: string | null;
   hasReplicaDb?: boolean;
   replicaDb?: typeof db;
   requestUrl?: string;
@@ -75,6 +76,7 @@ export interface TRPCInternalContext extends TRPCContext {
 export const createTRPCContext = async (opts: {
   headers: Headers;
   requestUrl?: string;
+  clerkUserId?: string | null;
 }): Promise<TRPCContext> => {
   return {
     ...opts,
@@ -172,8 +174,11 @@ export async function resolveAuthenticatedClerkUserId() {
   return null;
 }
 
-async function resolveAuthenticatedUser() {
-  const clerkUserId = await resolveAuthenticatedClerkUserId();
+async function resolveAuthenticatedUser(requestClerkUserId?: string | null) {
+  const clerkUserId =
+    typeof requestClerkUserId === "undefined"
+      ? await resolveAuthenticatedClerkUserId()
+      : requestClerkUserId;
 
   if (!clerkUserId) {
     return null;
@@ -191,7 +196,9 @@ const READ_ONLY_MUTATION_PATHS = new Set([
 
 const isAuthenticated = t.middleware(async (opts) => {
   if (typeof opts.ctx._authUser === "undefined") {
-    opts.ctx._authUserPromise ??= resolveAuthenticatedUser();
+    opts.ctx._authUserPromise ??= resolveAuthenticatedUser(
+      opts.ctx.clerkUserId,
+    );
     opts.ctx._authUser = await opts.ctx._authUserPromise;
   }
 

--- a/apps/main/tests/atlas-flows.test.ts
+++ b/apps/main/tests/atlas-flows.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  ATLAS_FLOWS,
+  missingFreshStateIds,
+  resolveLiveStateUrl,
+  statesForFlow,
+  validateAtlasFlows,
+} from "../scripts/atlas-flows.mjs";
+const appRoot = path.resolve(import.meta.dirname, "..");
+const tempDirectories: string[] = [];
+const cloneFlows = () => structuredClone(ATLAS_FLOWS);
+afterEach(() =>
+  tempDirectories.splice(0).forEach((dir) => rmSync(dir, { recursive: true })),
+);
+describe("Atlas flow contract", () => {
+  it("validates the public flow and every referenced file", () => {
+    expect(validateAtlasFlows({ appRoot })).toBe(true);
+    expect(statesForFlow(ATLAS_FLOWS[0]!)).toHaveLength(9);
+  });
+
+  it.each([
+    ["state id", "id", "Duplicate Atlas state id"],
+    ["capture", "capture", "Duplicate Atlas capture"],
+  ])("rejects a duplicate %s", (_label, property, message) => {
+    const flows = cloneFlows();
+    const states = statesForFlow(flows[0]!);
+    Object.assign(states[1]!, { [property]: states[0]![property] });
+    expect(() => validateAtlasFlows({ flows, appRoot })).toThrow(message);
+  });
+
+  it("rejects missing files and invalid test layers", () => {
+    const missing = cloneFlows();
+    missing[0]!.tests.integration[0]!.path = "tests/missing.test.ts";
+    expect(() => validateAtlasFlows({ flows: missing, appRoot })).toThrow(
+      "Missing referenced test: tests/missing.test.ts",
+    );
+    const invalid = cloneFlows();
+    (invalid[0]!.tests as Record<string, unknown>).browser = [];
+    expect(() => validateAtlasFlows({ flows: invalid, appRoot })).toThrow(
+      "Invalid test layer: browser",
+    );
+  });
+
+  it("rejects a state without a reproduction command", () => {
+    const flows = cloneFlows();
+    statesForFlow(flows[0]!)[0]!.reproductionCommand = "";
+    expect(() => validateAtlasFlows({ flows, appRoot })).toThrow(
+      "Missing reproduction command: catalog-directory",
+    );
+  });
+
+  it("never publishes a live link for interaction-only state", () => {
+    const pageTwo = statesForFlow(ATLAS_FLOWS[0]!).find(
+      ({ id }: { id: string }) => id === "search-page-two",
+    )!;
+    expect(resolveLiveStateUrl(pageTwo, "http://localhost:3210")).toBeNull();
+  });
+
+  it("reports the exact missing or stale states", () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "atlas-flow-"));
+    tempDirectories.push(directory);
+    const [fresh, stale] = statesForFlow(ATLAS_FLOWS[0]!);
+    writeFileSync(path.join(directory, fresh!.capture), "fresh");
+    writeFileSync(path.join(directory, stale!.capture), "stale");
+    utimesSync(path.join(directory, stale!.capture), new Date(0), new Date(0));
+    const missing = missingFreshStateIds(
+      {
+        ...ATLAS_FLOWS[0]!,
+        steps: [{ title: "test", states: [fresh!, stale!] }],
+      },
+      directory,
+      Date.now() - 1_000,
+    );
+    expect(missing).toEqual([stale!.id]);
+  });
+});

--- a/apps/main/tests/atlas-flows.test.ts
+++ b/apps/main/tests/atlas-flows.test.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import {
   ATLAS_FLOWS,
+  getAtlasFlow,
+  getAtlasState,
   missingFreshStateIds,
   resolveLiveStateUrl,
   statesForFlow,
@@ -20,6 +22,22 @@ describe("Atlas flow contract", () => {
   it("validates the public flow and every referenced file", () => {
     expect(validateAtlasFlows({ appRoot })).toBe(true);
     expect(statesForFlow(ATLAS_FLOWS[0]!)).toHaveLength(9);
+  });
+
+  it("resolves states from independently captured flows", () => {
+    const onboarding = getAtlasFlow("onboarding-membership");
+
+    expect(onboarding.steps.map(({ title }) => title)).toEqual([
+      "Understand the offer",
+      "Start setup",
+      "Build a profile",
+      "Build an example listing",
+      "Review the catalog",
+      "Start the trial",
+    ]);
+    expect(getAtlasState("onboarding-email-empty").captureSpec).toBe(
+      "tests/atlas/onboarding-membership.atlas.ts",
+    );
   });
 
   it.each([

--- a/apps/main/tests/atlas-server-process.test.ts
+++ b/apps/main/tests/atlas-server-process.test.ts
@@ -1,0 +1,14 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { terminateAtlasServer } from "../scripts/atlas-server-process.mjs";
+
+it("terminates the server process group after its leader exits", () => {
+  const signal = vi.fn();
+
+  terminateAtlasServer(
+    { exitCode: 1, pid: 4242 },
+    { platform: "darwin", signal },
+  );
+
+  expect(signal).toHaveBeenCalledWith(-4242, "SIGTERM");
+});

--- a/apps/main/tests/atlas/atlas-test.ts
+++ b/apps/main/tests/atlas/atlas-test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { getAtlasState } from "../../scripts/atlas-flows.mjs";
+export { expect, test };
+export async function captureAtlasState(
+  page: Page,
+  stateId: string,
+  { fullPage = true }: { fullPage?: boolean } = {},
+) {
+  const captureDirectory = process.env.ATLAS_CAPTURE_DIR;
+  if (!captureDirectory) throw new Error("ATLAS_CAPTURE_DIR is required.");
+  const stateItem = getAtlasState(stateId);
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    const visibleImages = [...document.images].filter((image) => {
+      const rect = image.getBoundingClientRect();
+      return rect.bottom > 0 && rect.top < innerHeight;
+    });
+    await Promise.all(
+      visibleImages.map(
+        (image) =>
+          image.complete ||
+          new Promise<void>((resolve) => {
+            image.addEventListener("load", () => resolve(), { once: true });
+            image.addEventListener("error", () => resolve(), { once: true });
+          }),
+      ),
+    );
+  });
+  await expect(page.locator("body")).not.toBeEmpty();
+  await expect(
+    page.locator("[data-nextjs-dialog], #webpack-dev-server-client-overlay"),
+  ).toHaveCount(0);
+  mkdirSync(captureDirectory, { recursive: true });
+  await page.screenshot({
+    path: path.join(captureDirectory, stateItem.capture),
+    fullPage,
+    animations: "disabled",
+  });
+}

--- a/apps/main/tests/atlas/onboarding-membership.atlas.ts
+++ b/apps/main/tests/atlas/onboarding-membership.atlas.ts
@@ -1,0 +1,210 @@
+import path from "node:path";
+import type { Page } from "@playwright/test";
+import {
+  ANONYMOUS_ONBOARDING_DRAFT_KEY,
+  createAnonymousOnboardingDraft,
+  type AnonymousOnboardingDraft,
+  type AnonymousOnboardingStepId,
+} from "../../src/app/onboarding/anonymous-onboarding-draft";
+import { captureAtlasState, expect, test } from "./atlas-test";
+
+const email = "atlas-grower@example.test";
+const uploadPath = path.resolve(
+  import.meta.dirname,
+  "../../public/assets/catalog-blooms.webp",
+);
+
+function draftAt(step: AnonymousOnboardingStepId): AnonymousOnboardingDraft {
+  const draft = createAnonymousOnboardingDraft({
+    email,
+    step,
+    furthestStep: step,
+  });
+
+  return {
+    ...draft,
+    profile: {
+      ...draft.profile,
+      gardenName: "Atlas Daylilies",
+      location: "Olympia, WA",
+      description:
+        "Small grower catalog focused on clear photos and seasonal availability.",
+    },
+    listingPreview: {
+      ...draft.listingPreview,
+      title: "Coffee Frenzy Spring Double Fan",
+      price: 32,
+      description: "Healthy double fan ready for local pickup or shipping.",
+    },
+  };
+}
+
+async function openDraft(
+  page: Page,
+  step: AnonymousOnboardingStepId,
+  draft = draftAt(step),
+) {
+  await page.addInitScript(
+    ({ key, value }) => window.localStorage.setItem(key, value),
+    { key: ANONYMOUS_ONBOARDING_DRAFT_KEY, value: JSON.stringify(draft) },
+  );
+  await page.goto(`/onboarding?step=${step}`);
+  await expect(page.getByTestId("anonymous-onboarding-page")).toBeVisible();
+  await expect(
+    page.getByTestId("anonymous-onboarding-step-content"),
+  ).toBeVisible();
+}
+
+test("Membership offer", async ({ page }) => {
+  await page.goto("/start-membership");
+  await expect(
+    page.getByRole("heading", {
+      name: "Your whole daylily catalog. One link buyers can browse.",
+    }),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-membership-offer");
+});
+
+test("Email empty", async ({ page }) => {
+  await page.goto("/onboarding?step=email");
+  await expect(page.getByTestId("anonymous-onboarding-page")).toBeVisible();
+  await expect(
+    page.getByTestId("anonymous-onboarding-email-submit"),
+  ).toBeDisabled();
+  await captureAtlasState(page, "onboarding-email-empty");
+});
+
+test("Email invalid", async ({ page }) => {
+  await page.goto("/onboarding?step=email");
+  await page.getByTestId("anonymous-onboarding-email").fill("not-an-email");
+  await expect(
+    page.getByTestId("anonymous-onboarding-email-submit"),
+  ).toBeDisabled();
+  await captureAtlasState(page, "onboarding-email-invalid");
+});
+
+test("Email valid", async ({ page }) => {
+  await page.goto("/onboarding?step=email");
+  await page.getByTestId("anonymous-onboarding-email").fill(email);
+  await expect(
+    page.getByTestId("anonymous-onboarding-email-submit"),
+  ).toBeEnabled();
+  await captureAtlasState(page, "onboarding-email-valid");
+});
+
+test("Profile defaults", async ({ page }) => {
+  const draft = createAnonymousOnboardingDraft({
+    email,
+    step: "profile",
+    furthestStep: "profile",
+  });
+  await openDraft(page, "profile", draft);
+  await expect(
+    page.getByRole("heading", { name: "Edit your profile" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Dew-Kissed Leaf" }),
+  ).toHaveAttribute("aria-pressed", "true");
+  await captureAtlasState(page, "onboarding-profile-default");
+});
+
+test("Profile customized", async ({ page }) => {
+  await openDraft(page, "profile");
+  const gardenPath = page.getByRole("button", { name: "Garden Path" });
+  await expect(gardenPath).toBeEnabled();
+  await gardenPath.click();
+  await expect(gardenPath).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByTestId("anonymous-profile-name")).toHaveValue(
+    "Atlas Daylilies",
+  );
+  await captureAtlasState(page, "onboarding-profile-custom");
+});
+
+test("Profile upload", async ({ page }) => {
+  await openDraft(page, "profile");
+  await page.getByTestId("anonymous-profile-image-mode-upload").click();
+  await expect(
+    page.getByTestId("anonymous-profile-image-dropzone"),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-profile-upload");
+});
+
+test("Profile crop", async ({ page }) => {
+  await openDraft(page, "profile");
+  await page.getByTestId("anonymous-profile-image-mode-upload").click();
+  await page.getByTestId("anonymous-profile-image").setInputFiles(uploadPath);
+  await expect(page.getByRole("img", { name: "Crop preview" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Use cropped image" }),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-profile-crop");
+});
+
+test("Listing defaults", async ({ page }) => {
+  const draft = createAnonymousOnboardingDraft({
+    email,
+    step: "listing",
+    furthestStep: "listing",
+  });
+  await openDraft(page, "listing", draft);
+  await expect(
+    page.getByRole("heading", { name: "Edit your first listing" }),
+  ).toBeVisible();
+  await expect(page.getByText("Example only", { exact: true })).toBeVisible();
+  await captureAtlasState(page, "onboarding-listing-default");
+});
+
+test("Listing customized", async ({ page }) => {
+  await openDraft(page, "listing");
+  await page.getByRole("button", { name: "Lemon Chiffon Cupcake" }).click();
+  await page
+    .getByTestId("anonymous-listing-title")
+    .fill("Lemon Chiffon Cupcake Double Fan");
+  await expect(page.getByTestId("anonymous-listing-title")).toHaveValue(
+    "Lemon Chiffon Cupcake Double Fan",
+  );
+  await captureAtlasState(page, "onboarding-listing-custom");
+});
+
+test("Listing upload", async ({ page }) => {
+  await openDraft(page, "listing");
+  await expect(
+    page.getByTestId("anonymous-listing-image-dropzone"),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-listing-upload");
+});
+
+test("Listing crop", async ({ page }) => {
+  await openDraft(page, "listing");
+  await page.getByTestId("anonymous-listing-image").setInputFiles(uploadPath);
+  await expect(page.getByRole("img", { name: "Crop preview" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Use cropped image" }),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-listing-crop");
+});
+
+test("Catalog preview", async ({ page }) => {
+  await openDraft(page, "preview");
+  await expect(
+    page.getByText(
+      "Path 1: Buyer opens your catalog and sends an email immediately.",
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Atlas Daylilies", { exact: true }),
+  ).toBeVisible();
+  await captureAtlasState(page, "onboarding-catalog-preview");
+});
+
+test("Checkout review", async ({ page }) => {
+  await openDraft(page, "checkout");
+  await expect(
+    page.getByRole("heading", { name: "Confirm your account email" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("anonymous-checkout-email-value")).toHaveText(
+    email,
+  );
+  await expect(page.getByTestId("anonymous-onboarding-checkout")).toBeEnabled();
+  await captureAtlasState(page, "onboarding-checkout-review");
+});

--- a/apps/main/tests/atlas/public-catalog.atlas.ts
+++ b/apps/main/tests/atlas/public-catalog.atlas.ts
@@ -1,0 +1,85 @@
+import { captureAtlasState, expect, test } from "./atlas-test";
+test("Catalog directory", async ({ page }) => {
+  await page.goto("/catalogs");
+  await expect(
+    page.getByRole("heading", { name: "Daylily Catalogs" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "PlantFancyGardens, LLC" }),
+  ).toBeVisible();
+  await captureAtlasState(page, "catalog-directory");
+});
+test("Populated catalog", async ({ page }) => {
+  await page.goto("/plantfancygardens");
+  await expect(page.getByRole("heading", { level: 1 })).toContainText(
+    "PlantFancyGardens",
+  );
+  await expect(
+    page.getByRole("heading", { name: "Listings", exact: true }),
+  ).toBeVisible();
+  await captureAtlasState(page, "populated-catalog", { fullPage: false });
+});
+test("Search results", async ({ page }) => {
+  await page.goto("/rollingoaksdaylilies/search?query=Absolute%20Ripper");
+  await expect(page.getByPlaceholder("Search listings...")).toHaveValue(
+    "Absolute Ripper",
+  );
+  await expect(
+    page.getByRole("heading", { name: "Absolute Ripper" }),
+  ).toBeVisible();
+  await captureAtlasState(page, "search-results");
+});
+test("Advanced filters", async ({ page }) => {
+  await page.goto(
+    "/rollingoaksdaylilies/search?mode=advanced&price=true&hasPhoto=true",
+  );
+  await expect(page.getByRole("switch", { name: "Advanced" })).toBeChecked();
+  await expect(
+    page.getByRole("heading", { name: "Bloom Traits" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Classification & Details" }),
+  ).toBeVisible();
+  await captureAtlasState(page, "advanced-filters", { fullPage: false });
+});
+test("No results", async ({ page }) => {
+  await page.goto("/rollingoaksdaylilies/search?query=no-such-daylily");
+  await expect(page.getByText("No listings found")).toBeVisible();
+  await captureAtlasState(page, "no-results");
+});
+test("Search page two", async ({ page }) => {
+  await page.goto("/rollingoaksdaylilies/search");
+  await expect(page.getByTestId("pager-per-page")).toContainText("12");
+  await page.getByTestId("pager-next").click();
+  await expect(page.getByTestId("pager-page-indicator")).toContainText(
+    "Page 2 of",
+  );
+  await captureAtlasState(page, "search-page-two", { fullPage: false });
+});
+test("Listing detail", async ({ page }) => {
+  await page.goto("/plantfancygardens/woodside-debutante");
+  await expect(page.getByRole("heading", { level: 1 })).toContainText(
+    "Woodside Debutante",
+  );
+  await expect(
+    page.getByRole("button", { name: "Contact Seller", exact: true }),
+  ).toBeVisible();
+  await captureAtlasState(page, "listing-detail");
+});
+test("Alternate listing image", async ({ page }) => {
+  await page.goto("/plantfancygardens/woodside-debutante");
+  const thumbnails = page.getByRole("button", {
+    name: "Woodside Debutante thumbnail",
+  });
+  await expect(thumbnails).toHaveCount(4);
+  await thumbnails.nth(1).click();
+  await expect(thumbnails.nth(1)).toHaveClass(/ring-primary/);
+  await captureAtlasState(page, "listing-alternate-image");
+});
+test("Unavailable listing", async ({ page }) => {
+  await page.goto("/plantfancygardens/not-a-real-listing");
+  await expect(
+    page.getByRole("heading", { name: "Page Not Found" }),
+  ).toBeVisible();
+  await captureAtlasState(page, "listing-unavailable");
+});

--- a/apps/main/tests/user-router-context-auth.test.ts
+++ b/apps/main/tests/user-router-context-auth.test.ts
@@ -72,4 +72,17 @@ describe("user router context auth resolution", () => {
     });
     expect(authMock).not.toHaveBeenCalled();
   });
+
+  it("uses request-boundary Clerk identity without resolving auth again", async () => {
+    const caller = userRouter.createCaller(
+      createCallerContext({
+        clerkUserId: null,
+      }),
+    );
+
+    await expect(caller.getCurrentUser()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(authMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Overall
Fixes signed-in local dashboard requests under Next 16 by reading Clerk identity from the explicit NextRequest at the App Router boundary and carrying it through tRPC context. This removes the later ambient auth lookup that loses request scope after development latency. No user flow or authorization rule changes.

## Files
- app/api/trpc/[trpc]/route.ts: read Clerk auth from the request and pass the user ID into context.
- server/api/trpc.ts: accept the request-boundary identity and reuse it in protected procedures.
- dashboard-db/user.ts: reuse the same identity for dashboard bootstrap.
- user-router-context-auth.test.ts: prove pre-resolved unauthenticated identity does not call Clerk again.

## Verification
- Red/green focused context-auth test.
- pnpm main exec tsc --noEmit.
- pnpm lint (one pre-existing dashboard hook warning).
- Real stage-Clerk 424242 login in Chrome-compatible agent browser.
- Rolling Oaks /dashboard/listings loaded 3,078 realistic listings after the fix; the prior request-scope error disappeared.