### PR TITLE
Add realistic listing-management Atlas flow

### DIFF
--- a/apps/main/playwright.atlas.config.ts
+++ b/apps/main/playwright.atlas.config.ts
@@ -2,9 +2,10 @@ import { defineConfig, devices } from "@playwright/test";
 import path from "node:path";
 const baseURL = process.env.BASE_URL ?? "http://localhost:3210";
 const outputRoot = process.env.ATLAS_OUTPUT_DIR ?? "local/atlas/current";
+const authState =
+  process.env.ATLAS_AUTH_STATE ?? path.join(outputRoot, ".auth/member.json");
 export default defineConfig({
   testDir: "./tests/atlas",
-  testMatch: "**/*.atlas.ts",
   timeout: 120_000,
   retries: 0,
   workers: 1,
@@ -30,4 +31,20 @@ export default defineConfig({
     screenshot: "off",
     trace: "retain-on-failure",
   },
+  projects: [
+    {
+      name: "anonymous",
+      testMatch: ["public-catalog.atlas.ts", "onboarding-membership.atlas.ts"],
+    },
+    {
+      name: "member-auth",
+      testMatch: "member-auth.setup.ts",
+    },
+    {
+      name: "member",
+      testMatch: "listing-management.atlas.ts",
+      dependencies: ["member-auth"],
+      use: { storageState: authState },
+    },
+  ],
 });

--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -15,6 +15,7 @@ const stateFor =
   });
 const publicState = stateFor("tests/atlas/public-catalog.atlas.ts");
 const onboardingState = stateFor("tests/atlas/onboarding-membership.atlas.ts");
+const listingState = stateFor("tests/atlas/listing-management.atlas.ts");
 const testRef = (layer, file) => ({
   path: file,
   command:
@@ -264,6 +265,153 @@ export const ATLAS_FLOWS = [
             "Checkout review",
             "The account email and membership terms immediately before Stripe.",
             "/onboarding?step=checkout",
+            false,
+          ),
+        ],
+      },
+    ],
+  },
+  {
+    id: "listing-management",
+    audience: "member",
+    title: "Find, create, and edit listings",
+    description:
+      "Manage a production-shaped catalog through the same dashboard controls members use.",
+    tests: {
+      unit: [testRef("unit", "tests/listings-search-normalization.test.tsx")],
+      integration: [
+        testRef(
+          "integration",
+          "tests/dashboard-listing-filter-toolbar.test.ts",
+        ),
+        testRef("integration", "tests/listings-table-filter-columns.test.tsx"),
+        testRef("integration", "tests/create-listing-dialog.test.tsx"),
+        testRef("integration", "tests/listing-dialog-query-state.test.tsx"),
+        testRef("integration", "tests/edit-listing-dialog-url-sync.test.tsx"),
+      ],
+      e2e: [
+        testRef("e2e", "tests/e2e/listings-page-features.e2e.ts"),
+        testRef("e2e", "tests/e2e/create-edit-listing-flow.e2e.ts"),
+      ],
+    },
+    steps: [
+      {
+        title: "Orient in a real catalog",
+        states: [
+          listingState(
+            "listing-management-table",
+            "Listings table",
+            "A compact page of a production-sized member catalog.",
+            "/dashboard/listings?size=10",
+          ),
+          listingState(
+            "listing-management-row-actions",
+            "Listing row actions",
+            "The visible actions available for an existing listing.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Find the right listings",
+        states: [
+          listingState(
+            "listing-management-query",
+            "Listing search",
+            "A member query narrowed to matching catalog rows.",
+            "/dashboard/listings?size=10&query=Richfield%20Muriel",
+          ),
+          listingState(
+            "listing-management-advanced",
+            "Advanced listing search",
+            "The detailed field-by-field search controls.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+          listingState(
+            "listing-management-for-sale",
+            "For sale filter",
+            "The catalog narrowed to listings currently offered for sale.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+          listingState(
+            "listing-management-list-filter",
+            "List filter choices",
+            "The member's real lists available as listing filters.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+          listingState(
+            "listing-management-sort",
+            "Sorted listings",
+            "The table sorted through its visible Title column control.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+          listingState(
+            "listing-management-page-two",
+            "Listings page two",
+            "The next compact page in a production-sized catalog.",
+            "/dashboard/listings?size=10&page=2",
+          ),
+          listingState(
+            "listing-management-no-results",
+            "No matching listings",
+            "Clear feedback when no member listing matches a query.",
+            "/dashboard/listings?size=10&query=no-such-member-listing",
+          ),
+        ],
+      },
+      {
+        title: "Create a listing",
+        states: [
+          listingState(
+            "listing-management-create-empty",
+            "Create listing",
+            "The empty listing dialog before selecting a cultivar.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+          listingState(
+            "listing-management-cultivar-picker",
+            "Cultivar picker results",
+            "Real AHS cultivar matches inside the listing creation flow.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+          listingState(
+            "listing-management-create-selected",
+            "Cultivar selected",
+            "A create form populated from a selected cultivar without saving it.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Edit a listing",
+        states: [
+          listingState(
+            "listing-management-edit-populated",
+            "Edit populated listing",
+            "An existing real listing with images, status, notes, and linked data.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+          listingState(
+            "listing-management-edit-validation",
+            "Empty required listing name",
+            "The current edit state after clearing the required name, before saving.",
+            "/dashboard/listings?size=10",
+            false,
+          ),
+          listingState(
+            "listing-management-list-picker",
+            "Listing membership picker",
+            "The real lists available while editing a listing.",
+            "/dashboard/listings?size=10",
             false,
           ),
         ],

--- a/apps/main/scripts/run-atlas-flow.mjs
+++ b/apps/main/scripts/run-atlas-flow.mjs
@@ -113,6 +113,7 @@ try {
         BASE_URL: baseURL,
         ATLAS_OUTPUT_DIR: outputDirectory,
         ATLAS_CAPTURE_DIR: captureDirectory,
+        ATLAS_AUTH_STATE: path.join(outputDirectory, ".auth/member.json"),
         ATLAS_PLAYWRIGHT_RESULTS_DIR: path.join(
           outputDirectory,
           "playwright-results",

--- a/apps/main/tests/atlas-flows.test.ts
+++ b/apps/main/tests/atlas-flows.test.ts
@@ -40,6 +40,18 @@ describe("Atlas flow contract", () => {
     );
   });
 
+  it("declares the listing-management journey and its compact UI states", () => {
+    const listings = getAtlasFlow("listing-management");
+
+    expect(listings.steps.map(({ title }) => title)).toEqual([
+      "Orient in a real catalog",
+      "Find the right listings",
+      "Create a listing",
+      "Edit a listing",
+    ]);
+    expect(statesForFlow(listings)).toHaveLength(15);
+  });
+
   it.each([
     ["state id", "id", "Duplicate Atlas state id"],
     ["capture", "capture", "Duplicate Atlas capture"],

--- a/apps/main/tests/atlas/listing-management.atlas.ts
+++ b/apps/main/tests/atlas/listing-management.atlas.ts
@@ -1,0 +1,188 @@
+import { CreateListingDialog } from "../e2e/pages/create-listing-dialog";
+import { EditListingDialog } from "../e2e/pages/edit-listing-dialog";
+import { DashboardListings } from "../e2e/pages/dashboard-listings";
+import { captureAtlasState, expect, test } from "./atlas-test";
+
+async function openListings(page: Parameters<typeof captureAtlasState>[0]) {
+  await page.goto("/dashboard/listings?size=10");
+  const listings = new DashboardListings(page);
+  await listings.isReady();
+  await expect(listings.listingTableReady).toBeVisible({ timeout: 30_000 });
+  await expect(listings.pageIndicator()).toContainText("Page 1");
+  return listings;
+}
+
+async function openFirstRowMenu(page: Parameters<typeof captureAtlasState>[0]) {
+  const trigger = page
+    .locator('[data-testid="listing-row-actions-trigger"]:visible')
+    .first();
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+  const menu = page.locator(
+    '[data-slot="dropdown-menu-content"][data-state="open"]',
+  );
+  await expect(menu).toBeVisible();
+  return menu;
+}
+
+async function openFirstListingForEdit(
+  page: Parameters<typeof captureAtlasState>[0],
+) {
+  const menu = await openFirstRowMenu(page);
+  await menu.getByTestId("listing-row-action-edit").click();
+  const dialog = new EditListingDialog(page);
+  await dialog.isReady();
+  return dialog;
+}
+
+test("Listings table", async ({ page }) => {
+  await openListings(page);
+  await captureAtlasState(page, "listing-management-table", {
+    fullPage: false,
+  });
+});
+
+test("Listing row actions", async ({ page }) => {
+  await openListings(page);
+  await openFirstRowMenu(page);
+  await captureAtlasState(page, "listing-management-row-actions", {
+    fullPage: false,
+  });
+});
+
+test("Listing search", async ({ page }) => {
+  const listings = await openListings(page);
+  await listings.setGlobalSearch("Richfield Muriel");
+  await expect(listings.filteredCount()).toContainText("result");
+  await expect(listings.listingsTable).toContainText("Richfield Muriel");
+  await captureAtlasState(page, "listing-management-query", {
+    fullPage: false,
+  });
+});
+
+test("Advanced listing search", async ({ page }) => {
+  await openListings(page);
+  const advanced = page.getByTestId("search-mode-switch");
+  await advanced.click();
+  await expect(advanced).toBeChecked();
+  await captureAtlasState(page, "listing-management-advanced", {
+    fullPage: false,
+  });
+});
+
+test("For sale filter", async ({ page }) => {
+  const listings = await openListings(page);
+  await page.getByRole("button", { name: "For Sale", exact: true }).click();
+  await expect(listings.filteredCount()).toBeVisible();
+  await captureAtlasState(page, "listing-management-for-sale", {
+    fullPage: false,
+  });
+});
+
+test("List filter choices", async ({ page }) => {
+  const listings = await openListings(page);
+  await listings.openListsFilter();
+  await expect(
+    page.locator('[data-slot="command-item"]').first(),
+  ).toBeVisible();
+  await captureAtlasState(page, "listing-management-list-filter", {
+    fullPage: false,
+  });
+});
+
+test("Sorted listings", async ({ page }) => {
+  const listings = await openListings(page);
+  await listings.sortByColumn("Title");
+  await expect(listings.listingTableReady).toBeVisible();
+  await captureAtlasState(page, "listing-management-sort", {
+    fullPage: false,
+  });
+});
+
+test("Listings page two", async ({ page }) => {
+  const listings = await openListings(page);
+  await listings.goToNextPage();
+  await expect(listings.pageIndicator()).toContainText("Page 2");
+  await captureAtlasState(page, "listing-management-page-two", {
+    fullPage: false,
+  });
+});
+
+test("No matching listings", async ({ page }) => {
+  const listings = await openListings(page);
+  await listings.setGlobalSearch("no-such-member-listing");
+  await expect(listings.filteredCount()).toContainText("0");
+  await captureAtlasState(page, "listing-management-no-results", {
+    fullPage: false,
+  });
+});
+
+test("Create listing", async ({ page }) => {
+  const listings = await openListings(page);
+  await listings.createListingButton.click();
+  const dialog = new CreateListingDialog(page);
+  await dialog.isReady();
+  await expect(dialog.createButton).toBeDisabled();
+  await captureAtlasState(page, "listing-management-create-empty", {
+    fullPage: false,
+  });
+});
+
+test("Cultivar picker results", async ({ page }) => {
+  const listings = await openListings(page);
+  await listings.createListingButton.click();
+  const dialog = new CreateListingDialog(page);
+  await dialog.isReady();
+  await dialog.openAhsPicker();
+  await dialog.ahsDialog
+    .getByPlaceholder("Search AHS listings…")
+    .fill("Stella");
+  await expect(dialog.ahsDialog).toContainText("Stella de Oro");
+  await captureAtlasState(page, "listing-management-cultivar-picker", {
+    fullPage: false,
+  });
+});
+
+test("Cultivar selected", async ({ page }) => {
+  const listings = await openListings(page);
+  await listings.createListingButton.click();
+  const dialog = new CreateListingDialog(page);
+  await dialog.isReady();
+  await dialog.searchAndSelectAhsListing("Stella", "Stella de Oro");
+  await expect(dialog.titleInput).toHaveValue(/Stella de Oro/i);
+  await captureAtlasState(page, "listing-management-create-selected", {
+    fullPage: false,
+  });
+});
+
+test("Edit populated listing", async ({ page }) => {
+  await openListings(page);
+  const dialog = await openFirstListingForEdit(page);
+  await expect(dialog.titleInput).not.toHaveValue("");
+  await captureAtlasState(page, "listing-management-edit-populated", {
+    fullPage: false,
+  });
+});
+
+test("Empty required listing name", async ({ page }) => {
+  await openListings(page);
+  const dialog = await openFirstListingForEdit(page);
+  await dialog.titleInput.fill("");
+  await dialog.titleInput.blur();
+  await expect(dialog.saveChangesButton).toBeEnabled();
+  await captureAtlasState(page, "listing-management-edit-validation", {
+    fullPage: false,
+  });
+});
+
+test("Listing membership picker", async ({ page }) => {
+  await openListings(page);
+  const dialog = await openFirstListingForEdit(page);
+  await dialog.openListsPicker();
+  await expect(
+    page.getByRole("heading", { name: "Select Lists" }),
+  ).toBeVisible();
+  await captureAtlasState(page, "listing-management-list-picker", {
+    fullPage: false,
+  });
+});

--- a/apps/main/tests/atlas/member-auth.setup.ts
+++ b/apps/main/tests/atlas/member-auth.setup.ts
@@ -1,0 +1,32 @@
+import { expect, test as setup } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+
+const authState = process.env.ATLAS_AUTH_STATE;
+
+setup("authenticate realistic catalog member", async ({ page }) => {
+  if (!authState) throw new Error("ATLAS_AUTH_STATE is required.");
+
+  await page.goto("/sign-in");
+  const emailInput = page.getByLabel(/email/i).first();
+  await expect(emailInput).toBeVisible();
+  await emailInput.fill("prodlike+clerk_test_rollingoaks@example.com");
+  await page.getByRole("button", { name: /continue/i }).click();
+
+  const codeInput = page
+    .getByRole("textbox", { name: /enter verification code/i })
+    .first();
+  await expect(codeInput).toBeVisible();
+  const sendCodeWarning = page.getByText(
+    "You need to send a verification code before attempting to verify.",
+  );
+  if (await sendCodeWarning.isVisible()) {
+    await page.getByRole("button", { name: /continue/i }).last().click();
+    await expect(sendCodeWarning).toBeHidden();
+  }
+  await codeInput.fill("424242");
+
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 30_000 });
+  mkdirSync(path.dirname(authState), { recursive: true });
+  await page.context().storageState({ path: authState });
+});


### PR DESCRIPTION
## Overall

Adds the authenticated listing-management slice of the development flywheel. The Atlas now signs into the stage Clerk Rolling Oaks persona and captures 15 compact, production-shaped dashboard states across finding, creating, and editing listings. The capture flow uses the real app UI and realistic seeded data but does not save or delete any listing.

Stacked on #296, which preserves Clerk identity across local tRPC requests.

## Files

- `apps/main/scripts/atlas-flows.mjs`: registers the listing-management journey, its 15 UI states, and the existing unit, integration, and E2E tests relevant to the flow.
- `apps/main/tests/atlas/listing-management.atlas.ts`: drives the visible dashboard controls and captures compact viewport screenshots for table, search/filter, create, and edit states.
- `apps/main/tests/atlas/member-auth.setup.ts`: signs in through the visible Clerk UI with the realistic stage test persona and stores browser auth state for member captures.
- `apps/main/playwright.atlas.config.ts`: separates anonymous and authenticated Atlas projects and connects the member project to its auth setup.
- `apps/main/scripts/run-atlas-flow.mjs`: supplies a run-local auth-state path.
- `apps/main/tests/atlas-flows.test.ts`: locks the flow steps and state count into the Atlas registry contract.

## Verification

- `pnpm main exec vitest run tests/atlas-flows.test.ts`
- `pnpm main exec tsc --noEmit`
- `pnpm lint` (passes with one pre-existing dashboard hook warning)
- `BASE_URL=http://localhost:3212 node apps/main/scripts/run-atlas-flow.mjs listing-management --output=local/atlas/listing-management` — 16 passed in 1.9m and generated all 15 screenshots plus the flow gallery.