### PR TITLE
Deepen hermetic listing save coverage

### DIFF
--- a/apps/main/scripts/seed-integration-data.mjs
+++ b/apps/main/scripts/seed-integration-data.mjs
@@ -90,6 +90,14 @@ export async function seedIntegrationData(databaseUrl) {
           status: "PUBLISHED",
         },
       }),
+      db.list.create({
+        data: {
+          id: "integration-favorites-list",
+          userId: INTEGRATION_SELLER.userId,
+          title: "Integration Favorites",
+          description: "List membership integration fixture",
+        },
+      }),
       db.keyValue.create({
         data: {
           key: `clerk:user:${INTEGRATION_SELLER.clerkUserId}`,

--- a/apps/main/tests/integration/create-edit-listing.integration.ts
+++ b/apps/main/tests/integration/create-edit-listing.integration.ts
@@ -7,6 +7,9 @@ test("seller creates, edits, and reloads a listing through the app", async ({
   editListingDialog,
 }) => {
   const editedTitle = "Integration Tracer Listing Edited";
+  const description = "A hermetic listing saved through the real application.";
+  const privateNote = "Integration-only private note";
+  const listName = "Integration Favorites";
   const toast = (message: string) =>
     page.locator("[data-sonner-toast]").filter({ hasText: message }).first();
 
@@ -25,13 +28,71 @@ test("seller creates, edits, and reloads a listing through the app", async ({
   await expect(toast("Listing created")).toBeVisible();
   await editListingDialog.isReady();
   await editListingDialog.fillTitle(editedTitle);
-  await editListingDialog.saveAndClose();
+  await editListingDialog.fillDescription(description);
+  await editListingDialog.fillPrice(37);
+  await editListingDialog.fillPrivateNote(privateNote);
+  await editListingDialog.setStatusToHidden();
+  await editListingDialog.openListsPicker();
+  await editListingDialog.toggleListByName(listName);
+  await editListingDialog.closeListsPicker();
+  await editListingDialog.clickSaveChanges();
   await expect(toast("Changes saved")).toBeVisible();
-  await page.getByTestId("dashboard-nav-listings").click();
-  await expect(page).toHaveURL(/\/dashboard\/listings$/);
+  await expect(editListingDialog.dialog).toBeHidden();
 
-  await page.reload();
+  await page.goto(
+    `/dashboard/listings?query=${encodeURIComponent(editedTitle)}`,
+  );
   await dashboardListings.isReady();
-  await dashboardListings.setGlobalSearch(editedTitle);
+  await expect(dashboardListings.globalSearchInput).toHaveValue(editedTitle);
   await expect(dashboardListings.listingRow(editedTitle)).toBeVisible();
+
+  await page
+    .locator('[data-testid="listing-row-actions-trigger"]:visible')
+    .first()
+    .click();
+  await page.locator('[data-testid="listing-row-action-edit"]:visible').click();
+  await editListingDialog.isReady();
+  await expect(editListingDialog.titleInput).toHaveValue(editedTitle);
+  await expect(editListingDialog.descriptionInput).toHaveValue(description);
+  await expect(editListingDialog.priceInput).toHaveValue("37");
+  await expect(editListingDialog.privateNoteInput).toHaveValue(privateNote);
+  await expect(editListingDialog.statusSelect).toContainText("Hidden");
+  await expect(editListingDialog.listSelectButton).toContainText(
+    "Integration Fa",
+  );
+});
+
+test("seller cannot persist a listing without a name", async ({
+  page,
+  dashboardListings,
+  editListingDialog,
+}) => {
+  const existingTitle = "Existing Bloom";
+
+  await page.goto(
+    `/dashboard/listings?query=${encodeURIComponent(existingTitle)}`,
+  );
+  await dashboardListings.isReady();
+  await expect(dashboardListings.listingRow(existingTitle)).toBeVisible();
+  await page
+    .locator('[data-testid="listing-row-actions-trigger"]:visible')
+    .first()
+    .click();
+  await page.locator('[data-testid="listing-row-action-edit"]:visible').click();
+  await editListingDialog.isReady();
+
+  await editListingDialog.titleInput.fill("");
+  await editListingDialog.titleInput.blur();
+  await editListingDialog.clickSaveChanges();
+
+  await expect(
+    editListingDialog.dialog.getByText("Name is required"),
+  ).toBeVisible();
+  await expect(editListingDialog.dialog).toBeVisible();
+
+  await page.goto(
+    `/dashboard/listings?query=${encodeURIComponent(existingTitle)}`,
+  );
+  await dashboardListings.isReady();
+  await expect(dashboardListings.listingRow(existingTitle)).toBeVisible();
 });


### PR DESCRIPTION
## Overall

Deepens the existing offline full-app listing tracer without adding another test harness or mocking application internals. The real browser flow now proves that a member can persist all important listing fields and list membership, reopen the listing through URL state, and see the saved values. A second focused case proves required-name validation prevents an invalid edit from persisting.

This remains offline from third parties and real through Next, tRPC, the dashboard collections, and SQLite. No production application code changes.

## Files

- `apps/main/scripts/seed-integration-data.mjs`: adds one owned list fixture so membership is exercised through the real list picker and server mutation.
- `apps/main/tests/integration/create-edit-listing.integration.ts`: expands the create/edit/reopen tracer to cover description, price, private notes, hidden status, list membership, save completion, URL-state reopening, and persisted values; adds one invalid-name integration case.

## Verification

- Targeted listing integration: 2 passed in 15.6s
- Complete hermetic browser integration suite: 4 passed in 28.8s / 30.36s wall time
- `pnpm main exec vitest run tests/integration-runtime.test.ts`: 3 passed
- `pnpm main exec tsc --noEmit`
- `pnpm lint` (passes with one pre-existing dashboard hook warning)