### PR TITLE
Disable public catalog link prefetching

### DIFF
--- a/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-nav.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-nav.tsx
@@ -29,6 +29,7 @@ export function CatalogNav({
           <li key={section.href}>
             <Link
               href={section.href}
+              prefetch={false}
               className="text-muted-foreground hover:text-primary text-sm font-medium transition-colors"
             >
               {section.name}

--- a/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings.tsx
@@ -46,7 +46,10 @@ export function CatalogSeoListings({
           {profileLists.length > 0 || forSaleCount > 0 ? (
             <div className="grid gap-4 sm:grid-cols-2">
               {forSaleCount > 0 && (
-                <Link href={`/${canonicalUserSlug}/search?price=true`}>
+                <Link
+                  href={`/${canonicalUserSlug}/search?price=true`}
+                  prefetch={false}
+                >
                   <Card className="group h-full transition-all hover:shadow-md">
                     <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-4">
                       <CardTitle className="group-hover:text-primary text-lg font-semibold">
@@ -69,6 +72,7 @@ export function CatalogSeoListings({
                 <Link
                   key={list.id}
                   href={`/${canonicalUserSlug}/search?lists=${encodeURIComponent(list.id)}`}
+                  prefetch={false}
                 >
                   <Card className="group h-full transition-all hover:shadow-md">
                     <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-4">
@@ -108,7 +112,9 @@ export function CatalogSeoListings({
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-3">
               <Button asChild size="sm" variant="outline">
-                <Link href={searchHref}>Search and filter listings</Link>
+                <Link href={searchHref} prefetch={false}>
+                  Search and filter listings
+                </Link>
               </Button>
             </div>
 

--- a/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-pagination.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-pagination.tsx
@@ -92,7 +92,7 @@ export function CatalogSeoPagination({
           disabled={page <= 1}
           data-testid={prevTestId}
         >
-          <Link href={prevHref}>
+          <Link href={prevHref} prefetch={false}>
             <span className="sr-only">Go to previous page</span>
             <ChevronLeftIcon className="size-4" />
           </Link>
@@ -104,7 +104,7 @@ export function CatalogSeoPagination({
           disabled={page >= totalPages}
           data-testid={nextTestId}
         >
-          <Link href={nextHref}>
+          <Link href={nextHref} prefetch={false}>
             <span className="sr-only">Go to next page</span>
             <ChevronRightIcon className="size-4" />
           </Link>

--- a/apps/main/src/components/listing-card.tsx
+++ b/apps/main/src/components/listing-card.tsx
@@ -105,6 +105,7 @@ export function ListingCard({ listing, priority = false }: ListingCardProps) {
                   {cultivarRouteSegment ? (
                     <Link
                       href={`/cultivar/${cultivarRouteSegment}`}
+                      prefetch={false}
                       onClick={(event) => event.stopPropagation()}
                     >
                       <Badge

--- a/apps/main/src/components/user-card.tsx
+++ b/apps/main/src/components/user-card.tsx
@@ -66,7 +66,7 @@ export function UserCard({
   return (
     <Card className="group hover:border-primary flex h-full flex-col overflow-hidden transition-all">
       <div className="relative">
-        <Link href={visiblePath} className="block">
+        <Link href={visiblePath} prefetch={false} className="block">
           {images[0]?.url ? (
             <OptimizedImage
               image={images[0]}
@@ -125,7 +125,11 @@ export function UserCard({
         )}
       </div>
 
-      <Link href={visiblePath} className="flex flex-1 flex-col">
+      <Link
+        href={visiblePath}
+        prefetch={false}
+        className="flex flex-1 flex-col"
+      >
         <CardContent className="flex flex-1 flex-col p-4">
           <div className="flex flex-1 flex-col justify-between gap-4">
             <div className="space-y-2">

--- a/apps/main/tests/catalog-seo-listings.test.tsx
+++ b/apps/main/tests/catalog-seo-listings.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen, within } from "@testing-library/react";
+import { type ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { CatalogSeoListings } from "@/app/(public)/[userSlugOrId]/_components/catalog-seo-listings";
+
+vi.mock("next/link", () => ({
+  default: ({
+    prefetch,
+    ...props
+  }: ComponentProps<"a"> & { prefetch?: boolean }) => (
+    <a {...props} data-prefetch={String(prefetch)} />
+  ),
+}));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -38,6 +48,9 @@ describe("CatalogSeoListings", () => {
     expect(
       screen.getByRole("link", { name: /General Listing/i }),
     ).toHaveAttribute("href", "/rollingoaksdaylilies/search?lists=5");
+    expect(
+      screen.getByRole("link", { name: /General Listing/i }),
+    ).toHaveAttribute("data-prefetch", "false");
     expect(
       screen.getByRole("link", { name: /Kay Cline Seedlings/i }),
     ).toHaveAttribute("href", "/rollingoaksdaylilies/search?lists=4");
@@ -96,6 +109,9 @@ describe("CatalogSeoListings", () => {
     expect(
       screen.getByRole("link", { name: "Search and filter listings" }),
     ).toHaveAttribute("href", "/rollingoaksdaylilies/search?page=3");
+    expect(
+      screen.getByRole("link", { name: "Search and filter listings" }),
+    ).toHaveAttribute("data-prefetch", "false");
   });
 
   it("anchors pagination links to listings section", () => {
@@ -118,6 +134,10 @@ describe("CatalogSeoListings", () => {
     expect(screen.getByTestId("legacy-page-next")).toHaveAttribute(
       "href",
       "/rollingoaksdaylilies/page/4#listings",
+    );
+    expect(screen.getByTestId("legacy-page-next")).toHaveAttribute(
+      "data-prefetch",
+      "false",
     );
     expect(screen.getByTestId("legacy-top-page-prev")).toHaveAttribute(
       "href",


### PR DESCRIPTION
## Summary

- disable automatic Next.js prefetching for high-cardinality public catalog links
- prevent seller cards, catalog search/list links, pagination, and listing cultivar badges from triggering speculative server renders
- keep normal client-side navigation when users click links

## Why

Vercel preview logs showed public pages automatically fanning out into many dynamic RSC renders and Turso reads before users interacted. Cloudflare caches public document requests, but these speculative component requests bypass that benefit and produced avoidable function timeouts.

## User impact

The rendered pages and navigation destinations are unchanged. Requests now begin when users click these high-cardinality links instead of when links enter the viewport.

## Validation

- `pnpm --filter @daylily-catalog/main test -- catalog-nav.test.tsx catalog-seo-listings.test.tsx profile-content.test.tsx` — 9 tests passed
- `pnpm --filter @daylily-catalog/main lint` — passed with one existing dashboard hook warning
- webpack production compilation succeeded

The full production build then stopped on the existing `origin/main` Next.js page-export error for `ManageListPageLive` in `src/app/dashboard/lists/[listId]/page.tsx`; this PR does not modify that route.