### PR TITLE
Preserve Clerk auth across tRPC requests

### DIFF
--- a/apps/main/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/main/src/app/api/trpc/[trpc]/route.ts
@@ -1,5 +1,6 @@
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { type NextRequest } from "next/server";
+import { getAuth } from "@clerk/nextjs/server";
 
 import { env } from "@/env";
 import { appRouter } from "@/server/api/root";
@@ -9,19 +10,25 @@ import { createTRPCContext } from "@/server/api/trpc";
  * This wraps the `createTRPCContext` helper and provides the required context for the tRPC API when
  * handling a HTTP request (e.g. when you make requests from Client Components).
  */
-const createContext = async (req: NextRequest) => {
+const createContext = async (
+  req: NextRequest,
+  clerkUserId: string | null,
+) => {
   return createTRPCContext({
     headers: req.headers,
     requestUrl: req.url,
+    clerkUserId,
   });
 };
 
-const handler = (req: NextRequest) =>
-  fetchRequestHandler({
+const handler = async (req: NextRequest) => {
+  const { userId: clerkUserId } = getAuth(req);
+
+  return fetchRequestHandler({
     endpoint: "/api/trpc",
     req,
     router: appRouter,
-    createContext: () => createContext(req),
+    createContext: () => createContext(req, clerkUserId),
     onError:
       env.NODE_ENV === "development"
         ? ({ path, error }) => {
@@ -31,5 +38,6 @@ const handler = (req: NextRequest) =>
           }
         : undefined,
   });
+};
 
 export { handler as GET, handler as POST };

--- a/apps/main/src/server/api/routers/dashboard-db/user.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/user.ts
@@ -15,7 +15,10 @@ export const dashboardDbUserRouter = createTRPCRouter({
       return { id: contextUser.id };
     }
 
-    const clerkUserId = await resolveAuthenticatedClerkUserId();
+    const clerkUserId =
+      typeof ctx.clerkUserId === "undefined"
+        ? await resolveAuthenticatedClerkUserId()
+        : ctx.clerkUserId;
 
     if (!clerkUserId) {
       throw new TRPCError({

--- a/apps/main/src/server/api/trpc.ts
+++ b/apps/main/src/server/api/trpc.ts
@@ -44,6 +44,7 @@ const SESSION_AUTH_TOKENS = ["session_token"] as const;
 export interface TRPCContext {
   headers: Headers;
   db: typeof db;
+  clerkUserId?: string | null;
   hasReplicaDb?: boolean;
   replicaDb?: typeof db;
   requestUrl?: string;
@@ -75,6 +76,7 @@ export interface TRPCInternalContext extends TRPCContext {
 export const createTRPCContext = async (opts: {
   headers: Headers;
   requestUrl?: string;
+  clerkUserId?: string | null;
 }): Promise<TRPCContext> => {
   return {
     ...opts,
@@ -172,8 +174,11 @@ export async function resolveAuthenticatedClerkUserId() {
   return null;
 }
 
-async function resolveAuthenticatedUser() {
-  const clerkUserId = await resolveAuthenticatedClerkUserId();
+async function resolveAuthenticatedUser(requestClerkUserId?: string | null) {
+  const clerkUserId =
+    typeof requestClerkUserId === "undefined"
+      ? await resolveAuthenticatedClerkUserId()
+      : requestClerkUserId;
 
   if (!clerkUserId) {
     return null;
@@ -191,7 +196,9 @@ const READ_ONLY_MUTATION_PATHS = new Set([
 
 const isAuthenticated = t.middleware(async (opts) => {
   if (typeof opts.ctx._authUser === "undefined") {
-    opts.ctx._authUserPromise ??= resolveAuthenticatedUser();
+    opts.ctx._authUserPromise ??= resolveAuthenticatedUser(
+      opts.ctx.clerkUserId,
+    );
     opts.ctx._authUser = await opts.ctx._authUserPromise;
   }
 

--- a/apps/main/tests/user-router-context-auth.test.ts
+++ b/apps/main/tests/user-router-context-auth.test.ts
@@ -72,4 +72,17 @@ describe("user router context auth resolution", () => {
     });
     expect(authMock).not.toHaveBeenCalled();
   });
+
+  it("uses request-boundary Clerk identity without resolving auth again", async () => {
+    const caller = userRouter.createCaller(
+      createCallerContext({
+        clerkUserId: null,
+      }),
+    );
+
+    await expect(caller.getCurrentUser()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(authMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Overall

Preserve Clerk identity at the App Router request boundary and carry it through tRPC context. This fixes signed-in dashboard requests that could lose ambient Clerk request scope under Next 16 development latency, without changing authorization rules.

## Files

- `apps/main/src/app/api/trpc/[trpc]/route.ts`: resolve Clerk auth from the explicit `NextRequest` and pass the user ID into tRPC context.
- `apps/main/src/server/api/trpc.ts`: accept the request-boundary identity and reuse it in protected procedure authentication.
- `apps/main/src/server/api/routers/dashboard-db/user.ts`: reuse the same resolved identity during dashboard user bootstrap.
- `apps/main/tests/user-router-context-auth.test.ts`: prove an explicitly resolved unauthenticated identity does not perform another ambient Clerk lookup.

## Verification

- `pnpm main exec vitest run tests/user-router-context-auth.test.ts` — 4 passed
- `pnpm typecheck`
- `pnpm lint`
