### PR TITLE
Make buyer cart controls reliable

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -150,6 +150,7 @@
     "@tailwindcss/postcss": "^4.1.13",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/eslint": "^9.6.1",
     "@types/lodash.deburr": "^4.1.9",
     "@types/node": "^24.3.1",

--- a/apps/main/src/components/add-to-cart-button.tsx
+++ b/apps/main/src/components/add-to-cart-button.tsx
@@ -76,6 +76,11 @@ export function AddToCartButton({
             )}
             onClick={handleAddToCart}
             disabled={isAdding}
+            aria-label={
+              isInCart
+                ? `${listing.title} is already in cart`
+                : `Add ${listing.title} to cart`
+            }
           >
             <ShoppingCart className="size-1" />
             <div className="h-3 w-px bg-current opacity-30" />

--- a/apps/main/src/components/contact-form.tsx
+++ b/apps/main/src/components/contact-form.tsx
@@ -314,13 +314,20 @@ function CartItemRow({ item, onQuantityChange, onRemove }: CartItemRowProps) {
         )}
       </div>
 
-      <div className="flex items-center gap-2">
+      <div
+        className="flex items-center gap-2"
+        onPointerDown={(event) => {
+          // Keep blur validation from replacing this row before the click fires.
+          event.preventDefault();
+        }}
+      >
         <Button
           type="button"
           variant="outline"
           size="icon"
           className="size-7"
           onClick={() => onQuantityChange(item.id, item.quantity - 1)}
+          aria-label={`Decrease quantity for ${item.title}`}
         >
           <MinusCircle className="size-4" />
         </Button>
@@ -333,6 +340,7 @@ function CartItemRow({ item, onQuantityChange, onRemove }: CartItemRowProps) {
           size="icon"
           className="size-7"
           onClick={() => onQuantityChange(item.id, item.quantity + 1)}
+          aria-label={`Increase quantity for ${item.title}`}
         >
           <PlusCircle className="size-4" />
         </Button>
@@ -343,6 +351,7 @@ function CartItemRow({ item, onQuantityChange, onRemove }: CartItemRowProps) {
           size="icon"
           className="ml-2 size-7"
           onClick={() => onRemove(item.id)}
+          aria-label={`Remove ${item.title} from cart`}
         >
           <Trash2 className="size-4" />
         </Button>

--- a/apps/main/tests/contact-form.test.tsx
+++ b/apps/main/tests/contact-form.test.tsx
@@ -6,20 +6,34 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
+import { AddToCartButton } from "@/components/add-to-cart-button";
 import { ContactForm } from "@/components/contact-form";
+import type { CartItem } from "@/types";
 
 // Mock hooks
-let cartItems: Array<{ id: string }> = [];
+const cartItem: CartItem = {
+  id: "item-1",
+  listingId: "item-1",
+  price: 40,
+  quantity: 1,
+  title: "Example Daylily",
+  userId: "test-user-id",
+};
+let cartItems: CartItem[] = [];
 type MutationOnError = (error: unknown, errorInfo: unknown) => void;
 const mutationOnError = vi.hoisted(() => ({
   current: undefined as MutationOnError | undefined,
 }));
 const reportErrorMock = vi.hoisted(() => vi.fn());
+const mockAddItem = vi.fn();
+const mockUpdateQuantity = vi.fn();
+const mockRemoveItem = vi.fn();
 
 const mockUseCart = vi.fn(() => ({
   items: cartItems,
-  updateQuantity: vi.fn(),
-  removeItem: vi.fn(),
+  addItem: mockAddItem,
+  updateQuantity: mockUpdateQuantity,
+  removeItem: mockRemoveItem,
   clearCart: vi.fn(),
   total: 0,
 }));
@@ -152,7 +166,7 @@ describe("ContactForm", () => {
   it("cart change revalidates message without unhandled rejection", async () => {
     const t = trackUnhandledRejections();
     try {
-      cartItems = [{ id: "item-1" }];
+      cartItems = [cartItem];
       const { rerender, container } = render(
         <ContactForm userId="test-user-id" />,
       );
@@ -180,7 +194,7 @@ describe("ContactForm", () => {
   });
 
   it("enables submission for a cart when valid remembered customer info is restored", async () => {
-    cartItems = [{ id: "item-1" }];
+    cartItems = [cartItem];
     customerInfo = { email: "remembered@example.com", name: "Buyer" };
 
     render(<ContactForm userId="test-user-id" />);
@@ -190,6 +204,53 @@ describe("ContactForm", () => {
         screen.getByRole("button", { name: "Send Message" }),
       ).toBeEnabled(),
     );
+  });
+
+  it("keeps named cart controls clickable while the email field is focused", async () => {
+    cartItems = [cartItem];
+
+    render(<ContactForm userId="test-user-id" />);
+    await act(async () => {
+      screen.getByRole("textbox", { name: "Email" }).focus();
+    });
+
+    const increase = screen.getByRole("button", {
+      name: "Increase quantity for Example Daylily",
+    });
+    await act(async () => {
+      expect(fireEvent.pointerDown(increase)).toBe(false);
+      fireEvent.click(increase);
+    });
+
+    expect(mockUpdateQuantity).toHaveBeenCalledWith("item-1", 2);
+    expect(
+      screen.getByRole("button", {
+        name: "Decrease quantity for Example Daylily",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove Example Daylily from cart" }),
+    ).toBeInTheDocument();
+  });
+
+  it("names the listing cart action and adds the selected listing", () => {
+    const listing = {
+      id: "item-1",
+      price: 40,
+      title: "Example Daylily",
+      userId: "test-user-id",
+    };
+
+    render(<AddToCartButton listing={listing} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add Example Daylily to cart" }),
+    );
+
+    expect(mockAddItem).toHaveBeenCalledWith({
+      ...listing,
+      listingId: listing.id,
+      quantity: 1,
+    });
   });
 
   it("does not report expected BAD_REQUEST validation errors", async () => {

--- a/apps/main/tests/contact-form.test.tsx
+++ b/apps/main/tests/contact-form.test.tsx
@@ -5,38 +5,27 @@ import {
   act,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { AddToCartButton } from "@/components/add-to-cart-button";
 import { ContactForm } from "@/components/contact-form";
+import { writeCartItems } from "@/hooks/cart-store";
 import type { CartItem } from "@/types";
 
-// Mock hooks
+const userId = "test-user-id";
 const cartItem: CartItem = {
   id: "item-1",
   listingId: "item-1",
   price: 40,
   quantity: 1,
   title: "Example Daylily",
-  userId: "test-user-id",
+  userId,
 };
-let cartItems: CartItem[] = [];
 type MutationOnError = (error: unknown, errorInfo: unknown) => void;
 const mutationOnError = vi.hoisted(() => ({
   current: undefined as MutationOnError | undefined,
 }));
 const reportErrorMock = vi.hoisted(() => vi.fn());
-const mockAddItem = vi.fn();
-const mockUpdateQuantity = vi.fn();
-const mockRemoveItem = vi.fn();
-
-const mockUseCart = vi.fn(() => ({
-  items: cartItems,
-  addItem: mockAddItem,
-  updateQuantity: mockUpdateQuantity,
-  removeItem: mockRemoveItem,
-  clearCart: vi.fn(),
-  total: 0,
-}));
 
 let customerInfo = { email: "", name: "" };
 const mockUseCustomerInfo = vi.fn(() => ({
@@ -45,10 +34,6 @@ const mockUseCustomerInfo = vi.fn(() => ({
 }));
 
 const mockSendMessage = vi.fn();
-
-vi.mock("@/hooks/use-cart", () => ({
-  useCart: () => mockUseCart(),
-}));
 
 vi.mock("@/hooks/use-customer-info", () => ({
   useCustomerInfo: () => mockUseCustomerInfo(),
@@ -131,7 +116,7 @@ describe("ContactForm", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    cartItems = [];
+    writeCartItems(userId, []);
     customerInfo = { email: "", name: "" };
   });
 
@@ -166,13 +151,10 @@ describe("ContactForm", () => {
   it("cart change revalidates message without unhandled rejection", async () => {
     const t = trackUnhandledRejections();
     try {
-      cartItems = [cartItem];
-      const { rerender, container } = render(
-        <ContactForm userId="test-user-id" />,
-      );
+      writeCartItems(userId, [cartItem]);
+      const { container } = render(<ContactForm userId={userId} />);
 
-      cartItems = [];
-      rerender(<ContactForm userId="test-user-id" />);
+      act(() => writeCartItems(userId, []));
 
       const emailInput = screen.getByLabelText(/email/i) as HTMLInputElement;
       fireEvent.change(emailInput, { target: { value: "test@example.com" } });
@@ -194,10 +176,10 @@ describe("ContactForm", () => {
   });
 
   it("enables submission for a cart when valid remembered customer info is restored", async () => {
-    cartItems = [cartItem];
+    writeCartItems(userId, [cartItem]);
     customerInfo = { email: "remembered@example.com", name: "Buyer" };
 
-    render(<ContactForm userId="test-user-id" />);
+    render(<ContactForm userId={userId} />);
 
     await waitFor(() =>
       expect(
@@ -206,51 +188,44 @@ describe("ContactForm", () => {
     );
   });
 
-  it("keeps named cart controls clickable while the email field is focused", async () => {
-    cartItems = [cartItem];
+  it("increments the quantity on the first user click while email is focused", async () => {
+    const user = userEvent.setup();
+    writeCartItems(userId, [cartItem]);
 
-    render(<ContactForm userId="test-user-id" />);
-    await act(async () => {
-      screen.getByRole("textbox", { name: "Email" }).focus();
-    });
+    render(<ContactForm userId={userId} />);
+    const email = screen.getByRole("textbox", { name: "Email" });
+    await user.click(email);
+    expect(email).toHaveFocus();
 
-    const increase = screen.getByRole("button", {
-      name: "Increase quantity for Example Daylily",
-    });
-    await act(async () => {
-      expect(fireEvent.pointerDown(increase)).toBe(false);
-      fireEvent.click(increase);
-    });
-
-    expect(mockUpdateQuantity).toHaveBeenCalledWith("item-1", 2);
-    expect(
+    await user.click(
       screen.getByRole("button", {
-        name: "Decrease quantity for Example Daylily",
+        name: "Increase quantity for Example Daylily",
       }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Remove Example Daylily from cart" }),
-    ).toBeInTheDocument();
+    );
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(email).toHaveFocus();
   });
 
-  it("names the listing cart action and adds the selected listing", () => {
+  it("names the listing cart action and adds the selected listing", async () => {
+    const user = userEvent.setup();
     const listing = {
       id: "item-1",
       price: 40,
       title: "Example Daylily",
-      userId: "test-user-id",
+      userId,
     };
 
     render(<AddToCartButton listing={listing} />);
-    fireEvent.click(
+    await user.click(
       screen.getByRole("button", { name: "Add Example Daylily to cart" }),
     );
 
-    expect(mockAddItem).toHaveBeenCalledWith({
-      ...listing,
-      listingId: listing.id,
-      quantity: 1,
-    });
+    expect(
+      screen.getByRole("button", {
+        name: "Example Daylily is already in cart",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("does not report expected BAD_REQUEST validation errors", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/eslint':
         specifier: ^9.6.1
         version: 9.6.1
@@ -3318,6 +3321,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@trpc/client@11.16.0':
     resolution: {integrity: sha512-TxIzm7OoK3baKZ0XCbuMUbI3GhgjcbKHIc4nWVKaRpCRnbSh0T31BT6fTPYwtnA/Nur8pBCGqC2B4J5hEPiPFQ==}
@@ -10143,6 +10152,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@trpc/client@11.16.0(@trpc/server@11.16.0(typescript@5.9.2))(typescript@5.9.2)':
     dependencies:


### PR DESCRIPTION
## Overall

Make public buyer cart controls reliable on the first click and identifiable to assistive technology and browser agents. The visual design is unchanged.

The observed failure was email-field blur validation rerendering a cart row between pointer-down and click, while icon-only buttons lacked purpose-specific accessible names. The production fix preserves pointer focus during cart actions; keyboard activation remains unchanged.

## Files

- `apps/main/src/components/add-to-cart-button.tsx`: add listing-specific accessible labels for add/already-added states.
- `apps/main/src/components/contact-form.tsx`: prevent the email blur race during pointer cart actions and add explicit quantity/remove labels.
- `apps/main/tests/contact-form.test.tsx`: use the real cart store and a complete user-event click to prove the first click increments quantity while Email is focused; retain coverage for accessible cart actions.
- `apps/main/package.json`: add Testing Library `user-event` for browser-like component interactions.
- `pnpm-lock.yaml`: lock the new test dependency.

## Verification

- `pnpm main exec vitest run tests/contact-form.test.tsx tests/use-cart.test.tsx` — 7 passed
- Regression sensitivity: the focused-email interaction test fails when the pointer guard is removed and passes when restored.
- `pnpm typecheck`
- `pnpm lint` — one unrelated existing hook-dependency warning
- Real local Chrome with realistic seeded data: one visible Increase action worked by mouse, touch tap, and keyboard Enter. Mouse and touch preserved Email focus; the dialog stayed open and the subtotal changed on the first action.
