### PR TITLE
Wait for tier data before creating records

### DIFF
--- a/apps/main/src/app/dashboard/_components/tier-limited-create-action.tsx
+++ b/apps/main/src/app/dashboard/_components/tier-limited-create-action.tsx
@@ -25,6 +25,7 @@ type TierLimitedCreateActionProps = {
   buttonLabel: string;
   buttonTestId?: string;
   currentCount?: number;
+  disabled?: boolean;
   freeTierLimit: number;
   isPro: boolean;
   upgradeDialogBody: ReactNode;
@@ -37,6 +38,7 @@ export function TierLimitedCreateAction({
   buttonLabel,
   buttonTestId,
   currentCount,
+  disabled = false,
   freeTierLimit,
   isPro,
   onCreate,
@@ -67,7 +69,11 @@ export function TierLimitedCreateAction({
 
   return (
     <>
-      <Button onClick={handleCreateClick} data-testid={buttonTestId}>
+      <Button
+        onClick={handleCreateClick}
+        data-testid={buttonTestId}
+        disabled={disabled}
+      >
         <Plus className="mr-2 size-4" />
         {buttonLabel}
       </Button>

--- a/apps/main/src/app/dashboard/listings/_components/create-listing-button.tsx
+++ b/apps/main/src/app/dashboard/listings/_components/create-listing-button.tsx
@@ -20,7 +20,7 @@ type Listing = RouterOutputs["dashboardDb"]["listing"]["list"][number];
  * Handles subscription tier checks and upgrade prompts for free tier users.
  */
 export function CreateListingButton() {
-  const { isPro } = usePro();
+  const { isPro, isLoading: isSubscriptionLoading } = usePro();
   const { openCreateListing } = useCreateListing();
   const listingsQuery = useSeededDashboardDbQuery<Listing>({
     query: (q) => q.from({ listing: listingsCollection }),
@@ -41,6 +41,7 @@ export function CreateListingButton() {
       buttonLabel="Create Listing"
       buttonTestId="create-listing-button"
       currentCount={listingCount}
+      disabled={isSubscriptionLoading || !listingsQuery.isReady}
       freeTierLimit={APP_CONFIG.LISTING.FREE_TIER_MAX_LISTINGS}
       isPro={isPro}
       onCreate={openCreateListing}

--- a/apps/main/src/app/dashboard/lists/_components/create-list-button.tsx
+++ b/apps/main/src/app/dashboard/lists/_components/create-list-button.tsx
@@ -9,14 +9,16 @@ import { TierLimitedCreateAction } from "@/app/dashboard/_components/tier-limite
 import { CreateListDialog } from "./create-list-dialog";
 
 export function CreateListButton() {
-  const { isPro } = usePro();
+  const { isPro, isLoading: isSubscriptionLoading } = usePro();
 
-  const { data: listCount } = api.dashboardDb.list.count.useQuery();
+  const { data: listCount, isLoading: isListCountLoading } =
+    api.dashboardDb.list.count.useQuery();
 
   return (
     <TierLimitedCreateAction
       buttonLabel="Create List"
       currentCount={listCount}
+      disabled={isSubscriptionLoading || isListCountLoading}
       freeTierLimit={APP_CONFIG.LIST.FREE_TIER_MAX_LISTS}
       isPro={isPro}
       upgradeDialogClassName="sm:max-w-[500px]"

--- a/apps/main/tests/tier-limited-create-action.test.tsx
+++ b/apps/main/tests/tier-limited-create-action.test.tsx
@@ -47,4 +47,27 @@ describe("TierLimitedCreateAction", () => {
     expect(screen.getByText("Create dialog")).toBeInTheDocument();
     expect(screen.queryByText("Upgrade Required")).not.toBeInTheDocument();
   });
+
+  it("does not choose a tier path while account data is loading", () => {
+    render(
+      <TierLimitedCreateAction
+        buttonLabel="Create Thing"
+        currentCount={2}
+        disabled
+        freeTierLimit={2}
+        isPro={false}
+        upgradeDialogTitle="Upgrade Required"
+        upgradeDialogDescription="Limit reached"
+        upgradeDialogBody={<div>Upgrade body</div>}
+        renderCreateDialog={() => <div>Create dialog</div>}
+      />,
+    );
+
+    const createButton = screen.getByRole("button", { name: "Create Thing" });
+    expect(createButton).toBeDisabled();
+    fireEvent.click(createButton);
+
+    expect(screen.queryByText("Upgrade Required")).not.toBeInTheDocument();
+    expect(screen.queryByText("Create dialog")).not.toBeInTheDocument();
+  });
 });

--- a/apps/main/tests/tier-limited-create-action.test.tsx
+++ b/apps/main/tests/tier-limited-create-action.test.tsx
@@ -1,73 +1,120 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import { TierLimitedCreateAction } from "@/app/dashboard/_components/tier-limited-create-action";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CreateListingButton } from "@/app/dashboard/listings/_components/create-listing-button";
+import { CreateListButton } from "@/app/dashboard/lists/_components/create-list-button";
+import { APP_CONFIG } from "@/config/constants";
+
+const mocks = vi.hoisted(() => ({
+  listCount: vi.fn(),
+  listings: vi.fn(),
+  openCreateListing: vi.fn(),
+  usePro: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-pro", () => ({
+  usePro: mocks.usePro,
+}));
+
+vi.mock(
+  "@/app/dashboard/_lib/dashboard-db/use-seeded-dashboard-db-query",
+  () => ({
+    useSeededDashboardDbQuery: mocks.listings,
+  }),
+);
+
+vi.mock("@/app/dashboard/_lib/dashboard-db/listings-collection", () => ({
+  listingsCollection: {},
+}));
+
+vi.mock("@/app/dashboard/_lib/dashboard-timing", () => ({
+  logDashboardTiming: vi.fn(),
+}));
+
+vi.mock(
+  "@/app/dashboard/listings/_components/create-listing-dialog",
+  () => ({
+    useCreateListing: () => ({
+      openCreateListing: mocks.openCreateListing,
+    }),
+  }),
+);
+
+vi.mock("@/trpc/react", () => ({
+  api: {
+    dashboardDb: {
+      list: {
+        count: {
+          useQuery: mocks.listCount,
+        },
+      },
+    },
+  },
+}));
 
 vi.mock("@/components/checkout-button", () => ({
   CheckoutButton: () => <button type="button">Checkout</button>,
 }));
 
-describe("TierLimitedCreateAction", () => {
-  it("opens the upgrade dialog when a free user hits the limit", () => {
-    render(
-      <TierLimitedCreateAction
-        buttonLabel="Create Thing"
-        currentCount={2}
-        freeTierLimit={2}
-        isPro={false}
-        upgradeDialogTitle="Upgrade Required"
-        upgradeDialogDescription="Limit reached"
-        upgradeDialogBody={<div>Upgrade body</div>}
-        renderCreateDialog={() => <div>Create dialog</div>}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Create Thing" }));
-
-    expect(screen.getByText("Upgrade Required")).toBeInTheDocument();
-    expect(screen.getByText("Upgrade body")).toBeInTheDocument();
-    expect(screen.queryByText("Create dialog")).not.toBeInTheDocument();
+describe("dashboard create buttons", () => {
+  beforeEach(() => {
+    mocks.openCreateListing.mockReset();
   });
 
-  it("opens the create dialog when under the limit", () => {
-    render(
-      <TierLimitedCreateAction
-        buttonLabel="Create Thing"
-        currentCount={1}
-        freeTierLimit={2}
-        isPro={false}
-        upgradeDialogTitle="Upgrade Required"
-        upgradeDialogDescription="Limit reached"
-        upgradeDialogBody={<div>Upgrade body</div>}
-        renderCreateDialog={() => <div>Create dialog</div>}
-      />,
-    );
+  it("disables listing and list creation until account data is loaded", () => {
+    mocks.usePro.mockReturnValue({ isLoading: true, isPro: false });
+    mocks.listings.mockReturnValue({ data: [], isReady: false });
+    mocks.listCount.mockReturnValue({ data: undefined, isLoading: true });
 
-    fireEvent.click(screen.getByRole("button", { name: "Create Thing" }));
+    const listing = render(<CreateListingButton />);
+    expect(
+      screen.getByRole("button", { name: "Create Listing" }),
+    ).toBeDisabled();
+    listing.unmount();
 
-    expect(screen.getByText("Create dialog")).toBeInTheDocument();
-    expect(screen.queryByText("Upgrade Required")).not.toBeInTheDocument();
+    render(<CreateListButton />);
+    expect(screen.getByRole("button", { name: "Create List" })).toBeDisabled();
   });
 
-  it("does not choose a tier path while account data is loading", () => {
-    render(
-      <TierLimitedCreateAction
-        buttonLabel="Create Thing"
-        currentCount={2}
-        disabled
-        freeTierLimit={2}
-        isPro={false}
-        upgradeDialogTitle="Upgrade Required"
-        upgradeDialogDescription="Limit reached"
-        upgradeDialogBody={<div>Upgrade body</div>}
-        renderCreateDialog={() => <div>Create dialog</div>}
-      />,
-    );
+  it("opens each create path for a loaded Pro account", () => {
+    mocks.usePro.mockReturnValue({ isLoading: false, isPro: true });
+    mocks.listings.mockReturnValue({
+      data: Array(APP_CONFIG.LISTING.FREE_TIER_MAX_LISTINGS).fill({}),
+      isReady: true,
+    });
+    mocks.listCount.mockReturnValue({
+      data: APP_CONFIG.LIST.FREE_TIER_MAX_LISTS,
+      isLoading: false,
+    });
 
-    const createButton = screen.getByRole("button", { name: "Create Thing" });
-    expect(createButton).toBeDisabled();
-    fireEvent.click(createButton);
+    const listing = render(<CreateListingButton />);
+    fireEvent.click(screen.getByRole("button", { name: "Create Listing" }));
+    expect(mocks.openCreateListing).toHaveBeenCalledOnce();
+    listing.unmount();
 
-    expect(screen.queryByText("Upgrade Required")).not.toBeInTheDocument();
-    expect(screen.queryByText("Create dialog")).not.toBeInTheDocument();
+    render(<CreateListButton />);
+    fireEvent.click(screen.getByRole("button", { name: "Create List" }));
+    expect(screen.getByRole("dialog")).toHaveTextContent("Create New List");
+  });
+
+  it("opens each upgrade path for a loaded free account at its limit", () => {
+    mocks.usePro.mockReturnValue({ isLoading: false, isPro: false });
+    mocks.listings.mockReturnValue({
+      data: Array(APP_CONFIG.LISTING.FREE_TIER_MAX_LISTINGS).fill({}),
+      isReady: true,
+    });
+    mocks.listCount.mockReturnValue({
+      data: APP_CONFIG.LIST.FREE_TIER_MAX_LISTS,
+      isLoading: false,
+    });
+
+    const listing = render(<CreateListingButton />);
+    fireEvent.click(screen.getByRole("button", { name: "Create Listing" }));
+    expect(screen.getByRole("dialog")).toHaveTextContent("Upgrade Required");
+    expect(mocks.openCreateListing).not.toHaveBeenCalled();
+    listing.unmount();
+
+    render(<CreateListButton />);
+    fireEvent.click(screen.getByRole("button", { name: "Create List" }));
+    expect(screen.getByRole("dialog")).toHaveTextContent("Upgrade to Pro");
   });
 });


### PR DESCRIPTION
## Overall

Wait for subscription and record-count data before choosing a free-tier or Pro creation path. This prevents a Pro member from temporarily seeing an upgrade prompt and prevents decisions based on incomplete listing/list counts.

This remains a client-side readiness fix only. Server-side list-limit enforcement is intentionally out of scope and should be handled in a separate small PR.

## Files

- `apps/main/src/app/dashboard/_components/tier-limited-create-action.tsx`: allow the shared create action button to remain disabled while prerequisites load.
- `apps/main/src/app/dashboard/listings/_components/create-listing-button.tsx`: wait for subscription and listing-collection readiness before enabling Create Listing.
- `apps/main/src/app/dashboard/lists/_components/create-list-button.tsx`: wait for subscription and list-count readiness before enabling Create List.
- `apps/main/tests/tier-limited-create-action.test.tsx`: exercise the actual listing and list create buttons through loading, loaded Pro, and loaded limited-free states; the Pro list path renders the real create dialog.

## Verification

- `pnpm main exec vitest run tests/tier-limited-create-action.test.tsx` — 3 passed
- Mutation check: removing the listing readiness guard makes the loading integration case fail
- `pnpm typecheck`
- `pnpm lint` — passes with one unrelated existing hook-dependency warning
- Chrome against the realistic local database: paused only the real `dashboardDb.list.count` request, observed Create List disabled, resumed the request, and observed the same button become enabled

The browser smoke required the separate request-bound Clerk auth change locally because the current `main` code reproduced the authenticated tRPC request-scope failure; that auth change is not included in this PR.
