### PR TITLE
Resolve Clerk auth in tRPC request context

### DIFF
--- a/apps/main/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/main/src/app/api/trpc/[trpc]/route.ts
@@ -3,25 +3,33 @@ import { type NextRequest } from "next/server";
 
 import { env } from "@/env";
 import { appRouter } from "@/server/api/root";
-import { createTRPCContext } from "@/server/api/trpc";
+import {
+  createTRPCContext,
+  resolveAuthenticatedClerkUserId,
+} from "@/server/api/trpc";
 
 /**
  * This wraps the `createTRPCContext` helper and provides the required context for the tRPC API when
  * handling a HTTP request (e.g. when you make requests from Client Components).
  */
 const createContext = async (req: NextRequest) => {
+  const clerkUserId = await resolveAuthenticatedClerkUserId();
+
   return createTRPCContext({
     headers: req.headers,
     requestUrl: req.url,
+    clerkUserId,
   });
 };
 
-const handler = (req: NextRequest) =>
-  fetchRequestHandler({
+const handler = async (req: NextRequest) => {
+  const context = await createContext(req);
+
+  return fetchRequestHandler({
     endpoint: "/api/trpc",
     req,
     router: appRouter,
-    createContext: () => createContext(req),
+    createContext: () => context,
     onError:
       env.NODE_ENV === "development"
         ? ({ path, error }) => {
@@ -31,5 +39,6 @@ const handler = (req: NextRequest) =>
           }
         : undefined,
   });
+};
 
 export { handler as GET, handler as POST };

--- a/apps/main/src/server/api/routers/dashboard-db/user.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/user.ts
@@ -15,7 +15,10 @@ export const dashboardDbUserRouter = createTRPCRouter({
       return { id: contextUser.id };
     }
 
-    const clerkUserId = await resolveAuthenticatedClerkUserId();
+    const clerkUserId =
+      typeof ctx.clerkUserId === "undefined"
+        ? await resolveAuthenticatedClerkUserId()
+        : ctx.clerkUserId;
 
     if (!clerkUserId) {
       throw new TRPCError({

--- a/apps/main/src/server/api/trpc.ts
+++ b/apps/main/src/server/api/trpc.ts
@@ -44,6 +44,7 @@ const SESSION_AUTH_TOKENS = ["session_token"] as const;
 export interface TRPCContext {
   headers: Headers;
   db: typeof db;
+  clerkUserId?: string | null;
   hasReplicaDb?: boolean;
   replicaDb?: typeof db;
   requestUrl?: string;
@@ -75,6 +76,7 @@ export interface TRPCInternalContext extends TRPCContext {
 export const createTRPCContext = async (opts: {
   headers: Headers;
   requestUrl?: string;
+  clerkUserId?: string | null;
 }): Promise<TRPCContext> => {
   return {
     ...opts,
@@ -172,8 +174,11 @@ export async function resolveAuthenticatedClerkUserId() {
   return null;
 }
 
-async function resolveAuthenticatedUser() {
-  const clerkUserId = await resolveAuthenticatedClerkUserId();
+async function resolveAuthenticatedUser(requestClerkUserId?: string | null) {
+  const clerkUserId =
+    typeof requestClerkUserId === "undefined"
+      ? await resolveAuthenticatedClerkUserId()
+      : requestClerkUserId;
 
   if (!clerkUserId) {
     return null;
@@ -191,7 +196,9 @@ const READ_ONLY_MUTATION_PATHS = new Set([
 
 const isAuthenticated = t.middleware(async (opts) => {
   if (typeof opts.ctx._authUser === "undefined") {
-    opts.ctx._authUserPromise ??= resolveAuthenticatedUser();
+    opts.ctx._authUserPromise ??= resolveAuthenticatedUser(
+      opts.ctx.clerkUserId,
+    );
     opts.ctx._authUser = await opts.ctx._authUserPromise;
   }
 

--- a/apps/main/tests/trpc-route-auth-context.test.ts
+++ b/apps/main/tests/trpc-route-auth-context.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL ??= "file:./tests/.tmp/trpc-route-auth-context.sqlite";
+
+const requestScope = vi.hoisted(() => ({ active: false }));
+const authMock = vi.hoisted(() =>
+  vi.fn(async () => {
+    if (!requestScope.active) {
+      throw new Error(
+        "Clerk: auth() was called outside a request scope: headers was called outside a request scope",
+      );
+    }
+
+    return {
+      isAuthenticated: true,
+      userId: "clerk-user-1",
+    };
+  }),
+);
+const findUniqueMock = vi.hoisted(() =>
+  vi.fn(async () => ({ id: "app-user-1" })),
+);
+
+vi.mock("@clerk/nextjs/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@clerk/nextjs/server")>();
+  return {
+    ...actual,
+    auth: authMock,
+  };
+});
+
+vi.mock("@/server/db", () => ({
+  db: {
+    user: {
+      findUnique: findUniqueMock,
+      upsert: vi.fn(),
+    },
+  },
+  hasEmbeddedReplica: false,
+  replicaDb: undefined,
+}));
+
+describe("authenticated tRPC route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requestScope.active = false;
+  });
+
+  it("resolves Clerk authentication at the HTTP request boundary", async () => {
+    const { GET } = await import("@/app/api/trpc/[trpc]/route");
+    const request = new NextRequest(
+      "http://localhost/api/trpc/dashboardDb.user.getCurrentUserId?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%7D%7D",
+    );
+
+    requestScope.active = true;
+    const responsePromise = GET(request);
+    requestScope.active = false;
+
+    const response = await responsePromise;
+    const body = await response.json();
+
+    expect(body).toMatchObject([
+      {
+        result: {
+          data: {
+            json: { id: "app-user-1" },
+          },
+        },
+      },
+    ]);
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { clerkUserId: "clerk-user-1" },
+      select: { id: true },
+    });
+    expect(authMock).toHaveBeenCalledOnce();
+    expect(authMock).toHaveBeenCalledWith({
+      acceptsToken: ["session_token"],
+    });
+  });
+});

--- a/apps/main/tests/user-router-context-auth.test.ts
+++ b/apps/main/tests/user-router-context-auth.test.ts
@@ -72,4 +72,17 @@ describe("user router context auth resolution", () => {
     });
     expect(authMock).not.toHaveBeenCalled();
   });
+
+  it("does not resolve ambient auth again for a signed-out HTTP context", async () => {
+    const caller = userRouter.createCaller(
+      createCallerContext({
+        clerkUserId: null,
+      }),
+    );
+
+    await expect(caller.getCurrentUser()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(authMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## What changed

Resolve Clerk authentication once while constructing each HTTP tRPC request context, then share the resolved Clerk user ID with every procedure in that request. Internal callers retain the existing ambient-auth fallback, while an HTTP request that is conclusively signed out carries `null` and never attempts a second `auth()` call.

This replaces the closed #304 approach. It continues using Clerk's App Router `auth()` API with `acceptsToken: ["session_token"]`; it does not introduce `getAuth(req)`.

## Why

The HTTP tRPC route previously created context without Clerk auth. Protected middleware and `dashboardDb.user.getCurrentUserId` could therefore call ambient `auth()` later, after tRPC middleware or other asynchronous work. That mismatched Clerk's Next.js+tRPC guidance and tRPC's request-context model, and could produce `headers was called outside a request scope`.

The new route-level regression test was confirmed red against `origin/main` with that exact simulated Clerk request-scope failure. It is green with this change and verifies that Clerk auth is resolved exactly once at the real `/api/trpc/[trpc]` fetch-adapter boundary.

References:

- https://clerk.com/docs/guides/development/trpc
- https://trpc.io/docs/server/context
- https://clerk.com/docs/reference/nextjs/app-router/auth

## Files

- `apps/main/src/app/api/trpc/[trpc]/route.ts`: eagerly resolves Clerk auth inside the Next request scope and passes one shared context to the tRPC fetch adapter.
- `apps/main/src/server/api/trpc.ts`: adds the resolved Clerk user ID to context and makes protected middleware consume it, retaining `undefined` only as the internal-caller fallback.
- `apps/main/src/server/api/routers/dashboard-db/user.ts`: makes `getCurrentUserId` use request context before considering ambient auth.
- `apps/main/tests/trpc-route-auth-context.test.ts`: exercises the real route handler, tRPC fetch adapter, and dashboard user procedure; verifies one session-token auth resolution.
- `apps/main/tests/user-router-context-auth.test.ts`: verifies a conclusively signed-out HTTP context does not call ambient Clerk auth again.

No public page, proxy matcher, or CDN cache behavior is changed.

## Validation

- `pnpm test` — 142 files, 500 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with the existing unrelated `dashboard-db-provider.tsx` hook warning
- Prettier check on all five changed files — passed
- Real Chrome: authenticated `/dashboard/listings` loaded the realistic Rolling Oaks account with 3,078 listings and protected tRPC requests returned 200 without the Clerk scope error
- Browser smoke: `/catalogs` returned 200 and rendered the realistic public catalog list
