### PR TITLE
Use full-page list create and edit surfaces

### DIFF
--- a/apps/main/src/app/dashboard/lists/_components/create-list-button.tsx
+++ b/apps/main/src/app/dashboard/lists/_components/create-list-button.tsx
@@ -6,10 +6,11 @@ import { APP_CONFIG, PRO_FEATURES } from "@/config/constants";
 import { usePro } from "@/hooks/use-pro";
 import { CheckoutButton } from "@/components/checkout-button";
 import { TierLimitedCreateAction } from "@/app/dashboard/_components/tier-limited-create-action";
-import { CreateListDialog } from "./create-list-dialog";
+import { useCreateList } from "./create-list-dialog";
 
 export function CreateListButton() {
   const { isPro, isLoading: isSubscriptionLoading } = usePro();
+  const { openCreateList } = useCreateList();
 
   const { data: listCount, isLoading: isListCountLoading } =
     api.dashboardDb.list.count.useQuery();
@@ -21,6 +22,7 @@ export function CreateListButton() {
       disabled={isSubscriptionLoading || isListCountLoading}
       freeTierLimit={APP_CONFIG.LIST.FREE_TIER_MAX_LISTS}
       isPro={isPro}
+      onCreate={openCreateList}
       upgradeDialogClassName="sm:max-w-[500px]"
       upgradeDialogTitle="Upgrade to Pro"
       upgradeDialogDescription={
@@ -50,9 +52,6 @@ export function CreateListButton() {
           <CheckoutButton size="lg" />
         </div>
       }
-      renderCreateDialog={(onOpenChange) => (
-        <CreateListDialog onOpenChange={onOpenChange} />
-      )}
     />
   );
 }

--- a/apps/main/src/app/dashboard/lists/_components/create-list-button.tsx
+++ b/apps/main/src/app/dashboard/lists/_components/create-list-button.tsx
@@ -1,25 +1,24 @@
 "use client";
 
 import { H3 } from "@/components/typography";
-import { api } from "@/trpc/react";
 import { APP_CONFIG, PRO_FEATURES } from "@/config/constants";
-import { usePro } from "@/hooks/use-pro";
 import { CheckoutButton } from "@/components/checkout-button";
 import { TierLimitedCreateAction } from "@/app/dashboard/_components/tier-limited-create-action";
 import { useCreateList } from "./create-list-dialog";
 
 export function CreateListButton() {
-  const { isPro, isLoading: isSubscriptionLoading } = usePro();
-  const { openCreateList } = useCreateList();
-
-  const { data: listCount, isLoading: isListCountLoading } =
-    api.dashboardDb.list.count.useQuery();
+  const {
+    isEligibilityLoading,
+    isPro,
+    listCount,
+    openCreateList,
+  } = useCreateList();
 
   return (
     <TierLimitedCreateAction
       buttonLabel="Create List"
       currentCount={listCount}
-      disabled={isSubscriptionLoading || isListCountLoading}
+      disabled={isEligibilityLoading}
       freeTierLimit={APP_CONFIG.LIST.FREE_TIER_MAX_LISTS}
       isPro={isPro}
       onCreate={openCreateList}

--- a/apps/main/src/app/dashboard/lists/_components/create-list-dialog.tsx
+++ b/apps/main/src/app/dashboard/lists/_components/create-list-dialog.tsx
@@ -1,27 +1,59 @@
 "use client";
 
-import { useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ArrowLeft } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import { useSetAtom } from "jotai";
-import { editingListIdAtom } from "./edit-list-dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { PageHeader } from "@/components/page-header";
 import { normalizeError, reportError } from "@/lib/error-utils";
 import { insertList } from "@/app/dashboard/_lib/dashboard-db/lists-collection";
-import { useManagedDialogOpen } from "@/hooks/use-managed-dialog-open";
-import { ManagedCreateDialog } from "@/app/dashboard/_components/managed-create-dialog";
+import { useQueryParamDialogState } from "@/hooks/use-dialog-search-param";
+import { useUnsavedChangesGuard } from "@/hooks/use-unsaved-changes-guard";
+import { ListingSurfaceSaveBar } from "../../listings/_components/listing-surface-save-bar";
 
-export function CreateListDialog({
-  onOpenChange,
+export function useCreateList() {
+  const { setValue, value } = useQueryParamDialogState({
+    history: "push",
+    paramName: "creating",
+    scroll: false,
+  });
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  return {
+    closeCreateList: () => setValue(null, "replace"),
+    finishCreateList: (listId: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("creating");
+      params.set("editing", listId);
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    isCreating: value === "true",
+    openCreateList: () => setValue("true"),
+  };
+}
+
+export function CreateListSurface({
+  onClose,
+  onCreated,
 }: {
-  onOpenChange: (open: boolean) => void;
+  onClose: () => void;
+  onCreated: (listId: string) => void;
 }) {
   const [title, setTitle] = useState("");
   const [isSaving, setIsSaving] = useState(false);
-  const { closeDialog, handleOpenChange, open } =
-    useManagedDialogOpen(onOpenChange);
+  const backButtonRef = useRef<HTMLButtonElement | null>(null);
+  const hasPendingChanges = () => Boolean(title.trim());
+  const { confirmDiscard } = useUnsavedChangesGuard(hasPendingChanges);
 
-  const setEditingId = useSetAtom(editingListIdAtom);
+  useLayoutEffect(() => {
+    backButtonRef.current?.focus({ preventScroll: true });
+  }, []);
 
   const handleCreate = async () => {
     if (!title.trim()) {
@@ -42,8 +74,7 @@ export function CreateListDialog({
         description: `${newList.title} has been created.`,
       });
 
-      closeDialog();
-      setEditingId(newList.id);
+      onCreated(newList.id);
     } catch (error) {
       toast.error("Failed to create list");
       reportError({
@@ -55,32 +86,76 @@ export function CreateListDialog({
     }
   };
 
+  const handleBack = () => {
+    if (confirmDiscard()) {
+      onClose();
+    }
+  };
+
   return (
-    <ManagedCreateDialog
-      cancelDisabled={isSaving}
-      confirmDisabled={isSaving || !title.trim()}
-      confirmLabel="Create List"
-      contentClassName="top-[20%] sm:top-[30%]"
-      description="Create a new list to organize your daylilies."
-      onCancel={closeDialog}
-      onConfirm={handleCreate}
-      onOpenChange={handleOpenChange}
-      open={open}
-      title="Create New List"
+    <section
+      aria-label="Create list"
+      className="mx-auto w-full max-w-3xl pb-8"
     >
-      <div className="space-y-2">
-        <Label htmlFor="title">
-          List Title <span className="text-destructive">*</span>
-        </Label>
-        <Input
-          id="title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="Enter a title"
-          disabled={isSaving}
-          required
+      {hasPendingChanges() ? (
+        <ListingSurfaceSaveBar
+          title="Unsaved list"
+          saveLabel="Save"
+          isSaving={isSaving}
+          saveDisabled={false}
+          onDiscard={onClose}
+          onSave={() => void handleCreate()}
         />
+      ) : null}
+
+      <PageHeader
+        heading="Create New List"
+        text="Create a new list to organize your daylilies."
+      >
+        <Button
+          ref={backButtonRef}
+          type="button"
+          variant="outline"
+          onClick={handleBack}
+          disabled={isSaving}
+        >
+          <ArrowLeft aria-hidden="true" />
+          Back to lists
+        </Button>
+      </PageHeader>
+
+      <div className="space-y-6 pb-16">
+        <div className="space-y-2">
+          <Label htmlFor="title">
+            List Title <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Enter a title"
+            disabled={isSaving}
+            required
+          />
+        </div>
+
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            onClick={() => void handleCreate()}
+            disabled={isSaving || !title.trim()}
+          >
+            {isSaving ? (
+              <>
+                <Spinner aria-hidden="true" />
+                Creating…
+              </>
+            ) : (
+              "Create List"
+            )}
+          </Button>
+        </div>
       </div>
-    </ManagedCreateDialog>
+    </section>
   );
 }

--- a/apps/main/src/app/dashboard/lists/_components/create-list-dialog.tsx
+++ b/apps/main/src/app/dashboard/lists/_components/create-list-dialog.tsx
@@ -14,6 +14,9 @@ import { insertList } from "@/app/dashboard/_lib/dashboard-db/lists-collection";
 import { useQueryParamDialogState } from "@/hooks/use-dialog-search-param";
 import { useUnsavedChangesGuard } from "@/hooks/use-unsaved-changes-guard";
 import { ListingSurfaceSaveBar } from "../../listings/_components/listing-surface-save-bar";
+import { api } from "@/trpc/react";
+import { APP_CONFIG } from "@/config/constants";
+import { usePro } from "@/hooks/use-pro";
 
 export function useCreateList() {
   const { setValue, value } = useQueryParamDialogState({
@@ -24,8 +27,17 @@ export function useCreateList() {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { isPro, isLoading: isSubscriptionLoading } = usePro();
+  const { data: listCount, isLoading: isListCountLoading } =
+    api.dashboardDb.list.count.useQuery();
+  const isEligibilityLoading =
+    isSubscriptionLoading || isListCountLoading || listCount === undefined;
+  const canCreateList =
+    !isEligibilityLoading &&
+    (isPro || listCount < APP_CONFIG.LIST.FREE_TIER_MAX_LISTS);
 
   return {
+    canCreateList,
     closeCreateList: () => setValue(null, "replace"),
     finishCreateList: (listId: string) => {
       const params = new URLSearchParams(searchParams.toString());
@@ -33,7 +45,10 @@ export function useCreateList() {
       params.set("editing", listId);
       router.replace(`${pathname}?${params.toString()}`, { scroll: false });
     },
-    isCreating: value === "true",
+    isCreateRequested: value === "true",
+    isEligibilityLoading,
+    isPro,
+    listCount,
     openCreateList: () => setValue("true"),
   };
 }

--- a/apps/main/src/app/dashboard/lists/_components/edit-list-dialog.tsx
+++ b/apps/main/src/app/dashboard/lists/_components/edit-list-dialog.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from "lucide-react";
 import {
   Suspense,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -25,15 +26,33 @@ export const useEditList = () => {
     paramName: "editing",
     scroll: false,
   });
+  const [optimisticEditing, setOptimisticEditing] = useState<{
+    from: string | null;
+    to: string | null;
+  } | null>(null);
+
+  const editingId =
+    optimisticEditing?.from === value ? optimisticEditing.to : value;
+
+  useEffect(() => {
+    if (optimisticEditing?.to !== value) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setOptimisticEditing(null), 0);
+    return () => window.clearTimeout(timeout);
+  }, [optimisticEditing, value]);
 
   return {
     editList: (id: string) => {
+      setOptimisticEditing({ from: value, to: id });
       setValue(id);
     },
     closeEditList: () => {
+      setOptimisticEditing({ from: editingId, to: null });
       setValue(null, "replace");
     },
-    editingId: value,
+    editingId,
   };
 };
 

--- a/apps/main/src/app/dashboard/lists/_components/edit-list-dialog.tsx
+++ b/apps/main/src/app/dashboard/lists/_components/edit-list-dialog.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { ErrorFallback } from "@/components/error-fallback";
 import { PageHeader } from "@/components/page-header";
 import { ListingSurfaceSaveBar } from "../../listings/_components/listing-surface-save-bar";
+import { reportError } from "@/lib/error-utils";
 
 export const useEditList = () => {
   const { setValue, value } = useQueryParamDialogState({
@@ -97,7 +98,15 @@ export function EditListSurface({
         </Button>
       </PageHeader>
 
-      <ErrorBoundary fallback={<ErrorFallback resetErrorBoundary={onClose} />}>
+      <ErrorBoundary
+        fallback={<ErrorFallback resetErrorBoundary={onClose} />}
+        onError={(error, errorInfo) =>
+          reportError({
+            error,
+            context: { source: "EditListSurface", errorInfo },
+          })
+        }
+      >
         <Suspense fallback={<ListFormSkeleton />}>
           <ListForm
             formRef={formRef}

--- a/apps/main/src/app/dashboard/lists/_components/edit-list-dialog.tsx
+++ b/apps/main/src/app/dashboard/lists/_components/edit-list-dialog.tsx
@@ -1,54 +1,113 @@
 "use client";
 
-import { reportError } from "@/lib/error-utils";
 import { ListForm, type ListFormHandle } from "@/components/forms/list-form";
 import { ListFormSkeleton } from "@/components/forms/list-form-skeleton";
-import { atom } from "jotai";
-import { useAtomDialogSearchParam } from "@/hooks/use-dialog-search-param";
-import { ManagedEditDialog } from "@/app/dashboard/_components/managed-edit-dialog";
-
-// Atom for editing state
-export const editingListIdAtom = atom<string | null>(null);
+import { ArrowLeft } from "lucide-react";
+import {
+  Suspense,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { useQueryParamDialogState } from "@/hooks/use-dialog-search-param";
+import { useUnsavedChangesGuard } from "@/hooks/use-unsaved-changes-guard";
+import { Button } from "@/components/ui/button";
+import { ErrorFallback } from "@/components/error-fallback";
+import { PageHeader } from "@/components/page-header";
+import { ListingSurfaceSaveBar } from "../../listings/_components/listing-surface-save-bar";
 
 export const useEditList = () => {
-  const { close, open, value } = useAtomDialogSearchParam({
-    atom: editingListIdAtom,
-    history: "replace",
+  const { setValue, value } = useQueryParamDialogState({
+    history: "push",
     paramName: "editing",
+    scroll: false,
   });
 
   return {
     editList: (id: string) => {
-      open(id);
+      setValue(id);
     },
     closeEditList: () => {
-      close();
+      setValue(null, "replace");
     },
     editingId: value,
   };
 };
 
-export function EditListDialog() {
-  const { editingId, closeEditList } = useEditList();
+export function EditListSurface({
+  listId,
+  onClose,
+}: {
+  listId: string;
+  onClose: () => void;
+}) {
+  const formRef = useRef<ListFormHandle | null>(null);
+  const backButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const hasPendingChanges = useCallback(
+    () => formRef.current?.hasPendingChanges() ?? false,
+    [],
+  );
+  const { confirmDiscard } = useUnsavedChangesGuard(hasPendingChanges);
+
+  const handleBack = () => {
+    if (confirmDiscard()) {
+      onClose();
+    }
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await formRef.current?.saveChanges("manual");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  useLayoutEffect(() => {
+    backButtonRef.current?.focus({ preventScroll: true });
+  }, []);
 
   return (
-    <ManagedEditDialog<ListFormHandle>
-      contentWrapperClassName="h-[calc(100%-4rem)]"
-      description="Make changes to your list here."
-      entityId={editingId}
-      fallback={<ListFormSkeleton />}
-      isOpen={!!editingId}
-      onClose={closeEditList}
-      onError={(error, errorInfo) =>
-        reportError({
-          error,
-          context: { source: "EditListDialog", errorInfo },
-        })
-      }
-      renderForm={(id, formRef, onClose) => (
-        <ListForm formRef={formRef} listId={id} onDelete={onClose} />
-      )}
-      title="Edit List"
-    />
+    <section aria-label="Edit list" className="mx-auto w-full max-w-3xl pb-8">
+      {isDirty ? (
+        <ListingSurfaceSaveBar
+          title="Unsaved list"
+          saveLabel="Save"
+          isSaving={isSaving}
+          saveDisabled={false}
+          onDiscard={onClose}
+          onSave={() => void handleSave()}
+        />
+      ) : null}
+
+      <PageHeader heading="Edit List" text="Make changes to your list.">
+        <Button
+          ref={backButtonRef}
+          type="button"
+          variant="outline"
+          onClick={handleBack}
+        >
+          <ArrowLeft aria-hidden="true" />
+          Back to lists
+        </Button>
+      </PageHeader>
+
+      <ErrorBoundary fallback={<ErrorFallback resetErrorBoundary={onClose} />}>
+        <Suspense fallback={<ListFormSkeleton />}>
+          <ListForm
+            formRef={formRef}
+            listId={listId}
+            onDelete={onClose}
+            onSave={onClose}
+            onPendingChangesChange={setIsDirty}
+          />
+        </Suspense>
+      </ErrorBoundary>
+    </section>
   );
 }

--- a/apps/main/src/app/dashboard/lists/page.tsx
+++ b/apps/main/src/app/dashboard/lists/page.tsx
@@ -2,6 +2,7 @@
 
 import {
   Activity,
+  useEffect,
   useLayoutEffect,
   useRef,
   type MouseEvent as ReactMouseEvent,
@@ -20,12 +21,34 @@ import {
 
 export default function ListsPage() {
   const { closeEditList, editingId } = useEditList();
-  const { closeCreateList, finishCreateList, isCreating } = useCreateList();
+  const {
+    canCreateList,
+    closeCreateList,
+    finishCreateList,
+    isCreateRequested,
+    isEligibilityLoading,
+  } = useCreateList();
+  const isCreating = isCreateRequested && canCreateList;
   const isShowingSurface = isCreating || Boolean(editingId);
   const dashboardScrollYRef = useRef(0);
   const dashboardRef = useRef<HTMLDivElement | null>(null);
   const returnFocusRef = useRef<HTMLElement | null>(null);
   const wasEditingRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      isCreateRequested &&
+      !isEligibilityLoading &&
+      !canCreateList
+    ) {
+      closeCreateList();
+    }
+  }, [
+    canCreateList,
+    closeCreateList,
+    isCreateRequested,
+    isEligibilityLoading,
+  ]);
 
   useLayoutEffect(() => {
     if (isShowingSurface) {

--- a/apps/main/src/app/dashboard/lists/page.tsx
+++ b/apps/main/src/app/dashboard/lists/page.tsx
@@ -1,23 +1,95 @@
 "use client";
 
+import {
+  Activity,
+  useLayoutEffect,
+  useRef,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 import { CreateListButton } from "./_components/create-list-button";
+import {
+  CreateListSurface,
+  useCreateList,
+} from "./_components/create-list-dialog";
 import { ListsTable } from "./_components/lists-table";
 import { PageHeader } from "@/components/page-header";
-import { EditListDialog } from "./_components/edit-list-dialog";
+import {
+  EditListSurface,
+  useEditList,
+} from "./_components/edit-list-dialog";
 
 export default function ListsPage() {
+  const { closeEditList, editingId } = useEditList();
+  const { closeCreateList, finishCreateList, isCreating } = useCreateList();
+  const isShowingSurface = isCreating || Boolean(editingId);
+  const dashboardScrollYRef = useRef(0);
+  const dashboardRef = useRef<HTMLDivElement | null>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const wasEditingRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (isShowingSurface) {
+      wasEditingRef.current = true;
+      window.scrollTo({ top: 0 });
+      return;
+    }
+
+    if (!wasEditingRef.current) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      wasEditingRef.current = false;
+      window.scrollTo({ top: dashboardScrollYRef.current });
+      const focusTarget = returnFocusRef.current?.isConnected
+        ? returnFocusRef.current
+        : dashboardRef.current;
+      focusTarget?.focus({ preventScroll: true });
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [isShowingSurface]);
+
+  const rememberDashboardState = (event: ReactMouseEvent) => {
+    dashboardScrollYRef.current = window.scrollY;
+    const openedFromRow =
+      event.target instanceof Element &&
+      event.target.closest('[data-testid="list-row-action-edit"]');
+    returnFocusRef.current = openedFromRow
+      ? document.querySelector<HTMLElement>(
+          '[data-testid="list-row-actions-trigger"][data-state="open"]',
+        )
+      : null;
+  };
+
   return (
     <>
-      <PageHeader
-        heading="Lists"
-        text="Organize your daylilies into collections."
-      >
-        <CreateListButton />
-      </PageHeader>
+      <Activity mode={isShowingSurface ? "hidden" : "visible"}>
+        <div
+          ref={dashboardRef}
+          className="space-y-4"
+          onClickCapture={rememberDashboardState}
+          tabIndex={-1}
+        >
+          <PageHeader
+            heading="Lists"
+            text="Organize your daylilies into collections."
+          >
+            <CreateListButton />
+          </PageHeader>
 
-      <ListsTable />
+          <ListsTable />
+        </div>
+      </Activity>
 
-      <EditListDialog />
+      {isCreating ? (
+        <CreateListSurface
+          onClose={closeCreateList}
+          onCreated={finishCreateList}
+        />
+      ) : editingId ? (
+        <EditListSurface listId={editingId} onClose={closeEditList} />
+      ) : null}
     </>
   );
 }

--- a/apps/main/src/components/forms/list-form.tsx
+++ b/apps/main/src/components/forms/list-form.tsx
@@ -31,6 +31,8 @@ import { useConfirmableAsyncAction } from "@/hooks/use-confirmable-async-action"
 interface ListFormProps {
   listId: string;
   onDelete?: () => void;
+  onSave?: () => void;
+  onPendingChangesChange?: (hasPendingChanges: boolean) => void;
   formRef?: React.RefObject<ListFormHandle | null>;
 }
 
@@ -57,17 +59,22 @@ function ListFormInner({
   list,
   listId,
   onDelete,
+  onSave,
+  onPendingChangesChange,
   formRef,
 }: {
   list: ListCollectionItem;
   listId: string;
   onDelete?: () => void;
+  onSave?: () => void;
+  onPendingChangesChange?: (hasPendingChanges: boolean) => void;
   formRef?: React.RefObject<ListFormHandle | null>;
 }) {
   const [isSaving, setIsSaving] = useState(false);
   const committedValuesRef = useRef<ListFormData>(toFormValues(list));
   const {
     markNeedsParentCommit,
+    needsParentCommit,
     needsParentCommitRef,
     resetNeedsParentCommit,
   } = useParentCommitFlag();
@@ -157,6 +164,9 @@ function ListFormInner({
         toast.success("List updated", {
           description: "Your list has been updated successfully",
         });
+        if (reason === "manual") {
+          onSave?.();
+        }
         return true;
       } catch {
         if (shouldUpdateUi) {
@@ -176,6 +186,16 @@ function ListFormInner({
       markNeedsCommit: markNeedsParentCommit,
     }),
   });
+
+  useEffect(() => {
+    const notifyPendingChanges = () => {
+      onPendingChangesChange?.(hasPendingChanges());
+    };
+
+    notifyPendingChanges();
+    const subscription = form.watch(notifyPendingChanges);
+    return () => subscription.unsubscribe();
+  }, [form, hasPendingChanges, needsParentCommit, onPendingChangesChange]);
 
   useEffect(() => {
     const nextCommittedValues = toFormValues(list);
@@ -275,7 +295,13 @@ function ListFormInner({
   );
 }
 
-function ListFormLive({ listId, onDelete, formRef }: ListFormProps) {
+function ListFormLive({
+  listId,
+  onDelete,
+  onSave,
+  onPendingChangesChange,
+  formRef,
+}: ListFormProps) {
   const { isReady, list } = useListResource(listId);
 
   if (!isReady || !list) {
@@ -288,6 +314,8 @@ function ListFormLive({ listId, onDelete, formRef }: ListFormProps) {
       list={list}
       listId={listId}
       onDelete={onDelete}
+      onSave={onSave}
+      onPendingChangesChange={onPendingChangesChange}
       formRef={formRef}
     />
   );

--- a/apps/main/src/components/forms/list-form.tsx
+++ b/apps/main/src/components/forms/list-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useManagedFormSave } from "@/hooks/use-managed-form-save";
 import { useParentCommitFlag } from "@/hooks/use-parent-commit-flag";
 import { useZodForm } from "@/hooks/use-zod-form";
@@ -91,13 +92,13 @@ function ListFormInner({
     setIsDialogOpen: setIsDeleteDialogOpen,
   } = useConfirmableAsyncAction({
     action: async () => {
+      flushSync(() => onDelete?.());
       await deleteList({ id: listId });
     },
     onSuccess: () => {
       toast.success("List deleted", {
         description: "Your list has been deleted successfully",
       });
-      onDelete?.();
     },
     onError: () => {
       toast.error("Failed to delete list", {

--- a/apps/main/src/server/api/routers/dashboard-db/list.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/list.ts
@@ -9,6 +9,9 @@ import {
   dashboardSyncInputSchema,
   parseDashboardSyncSince,
 } from "./dashboard-db-router-helpers";
+import { APP_CONFIG } from "@/config/constants";
+import { getStripeSubscriptionResult } from "@/server/stripe/sync-subscription";
+import { hasActiveSubscription } from "@/server/stripe/subscription-utils";
 
 const listSelect = {
   id: true,
@@ -75,16 +78,35 @@ export const dashboardDbListRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const list = await ctx.db.list.create({
-        data: {
-          userId: ctx.user.id,
-          title: input.title,
-          description: input.description,
-        },
-        select: listSelect,
-      });
+      const subscriptionResult = await getStripeSubscriptionResult(
+        ctx.user.stripeCustomerId,
+      );
 
-      return list;
+      return ctx.db.$transaction(async (tx) => {
+        if (
+          subscriptionResult.confirmed &&
+          !hasActiveSubscription(subscriptionResult.subscription.status)
+        ) {
+          const listCount = await tx.list.count({
+            where: { userId: ctx.user.id },
+          });
+          if (listCount >= APP_CONFIG.LIST.FREE_TIER_MAX_LISTS) {
+            throw new TRPCError({
+              code: "FORBIDDEN",
+              message: "Upgrade to Pro to create more lists.",
+            });
+          }
+        }
+
+        return tx.list.create({
+          data: {
+            userId: ctx.user.id,
+            title: input.title,
+            description: input.description,
+          },
+          select: listSelect,
+        });
+      });
     }),
 
   get: protectedProcedure

--- a/apps/main/tests/dashboard-db-list-entitlements.integration.test.ts
+++ b/apps/main/tests/dashboard-db-list-entitlements.integration.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TRPCInternalContext } from "@/server/api/trpc";
+import { APP_CONFIG } from "@/config/constants";
+import { withTempAppDb } from "@/lib/test-utils/app-test-db";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL ??=
+  "file:./tests/.tmp/dashboard-db-list-entitlements.sqlite";
+
+const getStripeSubscriptionResult = vi.hoisted(() => vi.fn());
+const getStripeSubscription = vi.hoisted(() => vi.fn());
+
+vi.mock("@/server/stripe/sync-subscription", () => ({
+  getStripeSubscription,
+  getStripeSubscriptionResult,
+}));
+
+async function createAuthedCaller(userId: string) {
+  const { db } = await import("@/server/db");
+  const { createCaller } = await import("@/server/api/root");
+  const caller = createCaller(async () => {
+    const user = await db.user.findUniqueOrThrow({ where: { id: userId } });
+    return {
+      db,
+      headers: new Headers(),
+      _authUser: user as unknown as TRPCInternalContext["_authUser"],
+    } satisfies TRPCInternalContext;
+  });
+
+  return { caller, db } satisfies {
+    caller: ReturnType<typeof createCaller>;
+    db: TRPCInternalContext["db"];
+  };
+}
+
+async function seedFreeTierLimit(
+  db: TRPCInternalContext["db"],
+  userId: string,
+) {
+  await db.list.createMany({
+    data: Array.from(
+      { length: APP_CONFIG.LIST.FREE_TIER_MAX_LISTS },
+      (_, index) => ({
+        userId,
+        title: `List ${index + 1}`,
+      }),
+    ),
+  });
+}
+
+describe("dashboard list creation entitlements", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("blocks a confirmed free account at the server-side list limit", async () => {
+    getStripeSubscriptionResult.mockResolvedValue({
+      subscription: { status: "none" },
+      confirmed: true,
+    });
+
+    await withTempAppDb(async ({ user }) => {
+      const { caller, db } = await createAuthedCaller(user.id);
+      await seedFreeTierLimit(db, user.id);
+
+      await expect(
+        caller.dashboardDb.list.create({ title: "One Too Many" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      await expect(db.list.count({ where: { userId: user.id } })).resolves.toBe(
+        APP_CONFIG.LIST.FREE_TIER_MAX_LISTS,
+      );
+    });
+  });
+
+  it.each([
+    {
+      name: "active Pro account",
+      result: {
+        subscription: { status: "active" },
+        confirmed: true,
+      },
+    },
+    {
+      name: "temporarily unconfirmed Stripe lookup",
+      result: {
+        subscription: { status: "none" },
+        confirmed: false,
+      },
+    },
+  ])("allows creation for an $name", async ({ result }) => {
+    getStripeSubscriptionResult.mockResolvedValue(result);
+
+    await withTempAppDb(async ({ user }) => {
+      const { caller, db } = await createAuthedCaller(user.id);
+      await seedFreeTierLimit(db, user.id);
+
+      await expect(
+        caller.dashboardDb.list.create({ title: "Allowed List" }),
+      ).resolves.toMatchObject({ title: "Allowed List" });
+      await expect(db.list.count({ where: { userId: user.id } })).resolves.toBe(
+        APP_CONFIG.LIST.FREE_TIER_MAX_LISTS + 1,
+      );
+    });
+  });
+});

--- a/apps/main/tests/dashboard-db-list-membership-sync.test.tsx
+++ b/apps/main/tests/dashboard-db-list-membership-sync.test.tsx
@@ -1,8 +1,16 @@
 import React from "react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { useLiveQuery } from "@tanstack/react-db";
 import { withTempAppDb } from "@/lib/test-utils/app-test-db";
+
+vi.mock("@/server/stripe/sync-subscription", () => ({
+  getStripeSubscription: vi.fn().mockResolvedValue({ status: "active" }),
+  getStripeSubscriptionResult: vi.fn().mockResolvedValue({
+    subscription: { status: "active" },
+    confirmed: true,
+  }),
+}));
 
 beforeEach(() => {
   localStorage.clear();

--- a/apps/main/tests/e2e/lists-page-features.e2e.ts
+++ b/apps/main/tests/e2e/lists-page-features.e2e.ts
@@ -81,22 +81,10 @@ test.describe("lists page features @local", () => {
     await expect(page).toHaveURL(/\/dashboard\/lists/);
     await dashboardLists.isReady();
 
-    // Create uses a full-page surface and transitions into the edit surface.
-    const createdListTitle = `Full page list ${Date.now()}`;
+    // Query parameters cannot bypass the free-tier create limit.
     await page.goto("/dashboard/lists?creating=true");
-    await expect(dashboardLists.createSurface()).toBeVisible();
-    await expect(page).toHaveURL(/creating=true/);
-    await dashboardLists.createTitleInput().fill(createdListTitle);
-    await dashboardLists.createSurfaceSubmitButton().click();
-    await expect(dashboardLists.editDialog()).toBeVisible();
-    await expect(page).toHaveURL(/editing=/);
-    await expect(dashboardLists.editTitleInput()).toHaveValue(createdListTitle);
-
-    await dashboardLists.editDialog().getByRole("button", {
-      name: "Delete List",
-    }).click();
-    await dashboardLists.confirmDelete();
-    await expect(dashboardLists.editDialog()).toBeHidden();
+    await expect(dashboardLists.createSurface()).toBeHidden();
+    await expect(page).not.toHaveURL(/creating=true/);
 
     // Phase 2: baseline table and pagination behavior
     await expect(dashboardLists.rows()).toHaveCount(seedMeta.defaultPageSize);

--- a/apps/main/tests/e2e/lists-page-features.e2e.ts
+++ b/apps/main/tests/e2e/lists-page-features.e2e.ts
@@ -203,8 +203,35 @@ test.describe("lists page features @local", () => {
     ).toBeVisible();
 
     await dashboardLists.openFirstVisibleRowActions();
-    await dashboardLists.chooseRowActionDelete();
+    await dashboardLists.chooseRowActionEdit();
+    await expect(dashboardLists.editDialog()).toBeVisible();
+
+    let releaseDeleteRequest = () => {};
+    let markDeleteRequestStarted = () => {};
+    const deleteRequestStarted = new Promise<void>((resolve) => {
+      markDeleteRequestStarted = resolve;
+    });
+    const deleteRequestBlocked = new Promise<void>((resolve) => {
+      releaseDeleteRequest = resolve;
+    });
+    await page.route("**/api/trpc/**", async (route) => {
+      if (route.request().url().includes("dashboardDb.list.delete")) {
+        markDeleteRequestStarted();
+        await deleteRequestBlocked;
+      }
+      await route.continue();
+    });
+
+    await dashboardLists.surfaceDeleteButton().click();
     await dashboardLists.confirmDelete();
+    await deleteRequestStarted;
+    await expect(
+      page.getByRole("heading", { name: "Lists", exact: true }),
+    ).toBeVisible();
+    await expect(dashboardLists.editDialog()).toHaveCount(0);
+    await expect(page.locator(".animate-pulse:visible")).toHaveCount(0);
+    await expect(page).not.toHaveURL(/editing=/);
+    releaseDeleteRequest();
 
     await expect(
       page.getByRole("heading", { name: "No lists found" }),

--- a/apps/main/tests/e2e/lists-page-features.e2e.ts
+++ b/apps/main/tests/e2e/lists-page-features.e2e.ts
@@ -19,6 +19,8 @@ test.describe("lists page features @local", () => {
     page,
     dashboardLists,
   }) => {
+    test.slow();
+
     const expectPageIndicator = async (
       currentPage: number,
       totalPages: number,
@@ -78,6 +80,23 @@ test.describe("lists page features @local", () => {
     await dashboardLists.goto();
     await expect(page).toHaveURL(/\/dashboard\/lists/);
     await dashboardLists.isReady();
+
+    // Create uses a full-page surface and transitions into the edit surface.
+    const createdListTitle = `Full page list ${Date.now()}`;
+    await page.goto("/dashboard/lists?creating=true");
+    await expect(dashboardLists.createSurface()).toBeVisible();
+    await expect(page).toHaveURL(/creating=true/);
+    await dashboardLists.createTitleInput().fill(createdListTitle);
+    await dashboardLists.createSurfaceSubmitButton().click();
+    await expect(dashboardLists.editDialog()).toBeVisible();
+    await expect(page).toHaveURL(/editing=/);
+    await expect(dashboardLists.editTitleInput()).toHaveValue(createdListTitle);
+
+    await dashboardLists.editDialog().getByRole("button", {
+      name: "Delete List",
+    }).click();
+    await dashboardLists.confirmDelete();
+    await expect(dashboardLists.editDialog()).toBeHidden();
 
     // Phase 2: baseline table and pagination behavior
     await expect(dashboardLists.rows()).toHaveCount(seedMeta.defaultPageSize);
@@ -179,9 +198,9 @@ test.describe("lists page features @local", () => {
       .fill(
         `Updated description ${seedMeta.editTargetUpdatedDescriptionToken}`,
       );
-    await dashboardLists.saveChangesButton().click();
-
-    await dashboardLists.closeEditDialog();
+    await expect(page.getByText("Unsaved list", { exact: true })).toBeVisible();
+    await dashboardLists.surfaceSaveButton().click();
+    await expect(dashboardLists.editDialog()).toBeHidden();
 
     await dashboardLists.setGlobalSearch(seedMeta.editTargetUpdatedTitle);
     await expect(dashboardLists.rows()).toHaveCount(1);

--- a/apps/main/tests/e2e/pages/dashboard-lists.ts
+++ b/apps/main/tests/e2e/pages/dashboard-lists.ts
@@ -217,16 +217,6 @@ export class DashboardLists {
     return this.page.getByRole("region", { name: "Create list" });
   }
 
-  createTitleInput(): Locator {
-    return this.createSurface().getByLabel("List Title");
-  }
-
-  createSurfaceSubmitButton(): Locator {
-    return this.createSurface().getByRole("button", {
-      name: "Create List",
-    });
-  }
-
   editTitleInput(): Locator {
     return this.editDialog().getByLabel("Title");
   }

--- a/apps/main/tests/e2e/pages/dashboard-lists.ts
+++ b/apps/main/tests/e2e/pages/dashboard-lists.ts
@@ -232,6 +232,13 @@ export class DashboardLists {
     });
   }
 
+  surfaceDeleteButton(): Locator {
+    return this.editDialog().getByRole("button", {
+      name: "Delete List",
+      exact: true,
+    });
+  }
+
   resetButton(): Locator {
     return this.page.getByRole("button", { name: "Reset" }).first();
   }

--- a/apps/main/tests/e2e/pages/dashboard-lists.ts
+++ b/apps/main/tests/e2e/pages/dashboard-lists.ts
@@ -201,16 +201,30 @@ export class DashboardLists {
   }
 
   async closeEditDialog() {
-    const closeButton = this.page
-      .getByRole("dialog", { name: "Edit List" })
-      .getByRole("button", { name: "Close" });
+    const closeButton = this.editDialog().getByRole("button", {
+      name: "Back to lists",
+    });
     await closeButton.scrollIntoViewIfNeeded();
     await closeButton.click();
     await this.editDialog().waitFor({ state: "hidden" });
   }
 
   editDialog(): Locator {
-    return this.page.getByRole("dialog", { name: "Edit List" });
+    return this.page.getByRole("region", { name: "Edit list" });
+  }
+
+  createSurface(): Locator {
+    return this.page.getByRole("region", { name: "Create list" });
+  }
+
+  createTitleInput(): Locator {
+    return this.createSurface().getByLabel("List Title");
+  }
+
+  createSurfaceSubmitButton(): Locator {
+    return this.createSurface().getByRole("button", {
+      name: "Create List",
+    });
   }
 
   editTitleInput(): Locator {
@@ -221,8 +235,11 @@ export class DashboardLists {
     return this.editDialog().getByLabel("Description");
   }
 
-  saveChangesButton(): Locator {
-    return this.editDialog().getByRole("button", { name: "Save Changes" });
+  surfaceSaveButton(): Locator {
+    return this.editDialog().getByRole("button", {
+      name: "Save",
+      exact: true,
+    });
   }
 
   resetButton(): Locator {

--- a/apps/main/tests/e2e/utils/seed-create-edit-listing.ts
+++ b/apps/main/tests/e2e/utils/seed-create-edit-listing.ts
@@ -1,6 +1,7 @@
 import type { E2EPrismaClient } from "../../../src/lib/test-utils/e2e-db";
 import { createAuthedUser } from "../../../src/lib/test-utils/e2e-users";
 import { seedAhsListing } from "./ahs-listings";
+import { setStripeSubscriptionStatus } from "./stripe";
 
 interface SeedCreateEditListingInput {
   db: E2EPrismaClient;
@@ -28,6 +29,12 @@ export async function seedCreateEditListingData({
   db,
 }: SeedCreateEditListingInput): Promise<CreateEditListingSeedMeta> {
   const user = await createAuthedUser(db);
+  if (user.stripeCustomerId) {
+    await setStripeSubscriptionStatus({
+      db,
+      stripeCustomerId: user.stripeCustomerId,
+    });
+  }
 
   const existingList = await db.list.create({
     data: {

--- a/apps/main/tests/edit-list-dialog-url-sync.test.tsx
+++ b/apps/main/tests/edit-list-dialog-url-sync.test.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditList } from "@/app/dashboard/lists/_components/edit-list-dialog";
 
@@ -61,13 +67,15 @@ describe("useEditList URL sync", () => {
   });
 
   it("clears editing query without pushing a bare '?' URL", async () => {
-    render(<EditListHookHarness />);
+    const { rerender } = render(<EditListHookHarness />);
 
     await waitFor(() => {
       expect(screen.getByRole("button")).toHaveTextContent("list-1");
     });
 
     fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByRole("button")).toHaveTextContent("none");
 
     await waitFor(() => {
       expect(navigationState.replace).toHaveBeenCalledWith(
@@ -79,5 +87,15 @@ describe("useEditList URL sync", () => {
     expect(
       navigationState.replace.mock.calls.some(([url]) => url === "?"),
     ).toBe(false);
+
+    navigationState.setSearch("");
+    rerender(<EditListHookHarness />);
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    navigationState.setSearch("editing=list-1");
+    rerender(<EditListHookHarness />);
+    expect(screen.getByRole("button")).toHaveTextContent("list-1");
   });
 });

--- a/apps/main/tests/edit-list-dialog-url-sync.test.tsx
+++ b/apps/main/tests/edit-list-dialog-url-sync.test.tsx
@@ -70,7 +70,10 @@ describe("useEditList URL sync", () => {
     fireEvent.click(screen.getByRole("button"));
 
     await waitFor(() => {
-      expect(navigationState.replace).toHaveBeenCalledWith("/dashboard/lists");
+      expect(navigationState.replace).toHaveBeenCalledWith(
+        "/dashboard/lists",
+        { scroll: false },
+      );
     });
     expect(navigationState.push).not.toHaveBeenCalled();
     expect(

--- a/apps/main/tests/edit-list-surface-error-reporting.test.tsx
+++ b/apps/main/tests/edit-list-surface-error-reporting.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EditListSurface } from "@/app/dashboard/lists/_components/edit-list-dialog";
+
+const reportError = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/error-utils", () => ({
+  reportError,
+}));
+
+vi.mock("@/components/forms/list-form", () => ({
+  ListForm: () => {
+    throw new Error("list form failed");
+  },
+}));
+
+vi.mock("@/components/forms/list-form-skeleton", () => ({
+  ListFormSkeleton: () => <div>Loading</div>,
+}));
+
+vi.mock("@/components/error-fallback", () => ({
+  ErrorFallback: () => <div>Editor unavailable</div>,
+}));
+
+describe("EditListSurface error reporting", () => {
+  it("reports render failures before showing the fallback", async () => {
+    render(<EditListSurface listId="list-1" onClose={vi.fn()} />);
+
+    expect(screen.getByText("Editor unavailable")).toBeVisible();
+    await waitFor(() => {
+      expect(reportError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ message: "list form failed" }),
+          context: expect.objectContaining({ source: "EditListSurface" }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/main/tests/tier-limited-create-action.test.tsx
+++ b/apps/main/tests/tier-limited-create-action.test.tsx
@@ -41,9 +41,17 @@ vi.mock(
 );
 
 vi.mock("@/app/dashboard/lists/_components/create-list-dialog", () => ({
-  useCreateList: () => ({
-    openCreateList: mocks.openCreateList,
-  }),
+  useCreateList: () => {
+    const pro = mocks.usePro();
+    const count = mocks.listCount();
+
+    return {
+      isEligibilityLoading: pro.isLoading || count.isLoading,
+      isPro: pro.isPro,
+      listCount: count.data,
+      openCreateList: mocks.openCreateList,
+    };
+  },
 }));
 
 vi.mock("@/trpc/react", () => ({

--- a/apps/main/tests/tier-limited-create-action.test.tsx
+++ b/apps/main/tests/tier-limited-create-action.test.tsx
@@ -7,6 +7,7 @@ import { APP_CONFIG } from "@/config/constants";
 const mocks = vi.hoisted(() => ({
   listCount: vi.fn(),
   listings: vi.fn(),
+  openCreateList: vi.fn(),
   openCreateListing: vi.fn(),
   usePro: vi.fn(),
 }));
@@ -39,6 +40,12 @@ vi.mock(
   }),
 );
 
+vi.mock("@/app/dashboard/lists/_components/create-list-dialog", () => ({
+  useCreateList: () => ({
+    openCreateList: mocks.openCreateList,
+  }),
+}));
+
 vi.mock("@/trpc/react", () => ({
   api: {
     dashboardDb: {
@@ -57,6 +64,7 @@ vi.mock("@/components/checkout-button", () => ({
 
 describe("dashboard create buttons", () => {
   beforeEach(() => {
+    mocks.openCreateList.mockReset();
     mocks.openCreateListing.mockReset();
   });
 
@@ -93,7 +101,7 @@ describe("dashboard create buttons", () => {
 
     render(<CreateListButton />);
     fireEvent.click(screen.getByRole("button", { name: "Create List" }));
-    expect(screen.getByRole("dialog")).toHaveTextContent("Create New List");
+    expect(mocks.openCreateList).toHaveBeenCalledOnce();
   });
 
   it("opens each upgrade path for a loaded free account at its limit", () => {
@@ -116,5 +124,6 @@ describe("dashboard create buttons", () => {
     render(<CreateListButton />);
     fireEvent.click(screen.getByRole("button", { name: "Create List" }));
     expect(screen.getByRole("dialog")).toHaveTextContent("Upgrade to Pro");
+    expect(mocks.openCreateList).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changed

- replaced the create-list modal with the same URL-backed full-page surface used by listing creation
- replaced the edit-list modal with a full-page editor, sticky unsaved-state controls, and explicit save/discard behavior
- preserve the lists table state, scroll position, and row-action focus while the editor surface is open
- update list form dirty-state notifications and browser coverage for the full create/edit flow

## Why

The create-list dialog could open outside the visible viewport on the lists page. Lists now follow the established full-page listing editor pattern from #291, avoiding modal viewport geometry while keeping the dashboard state available when the user returns.

## Validation

- `pnpm --filter @daylily-catalog/main lint` (passes with one existing warning in `dashboard-db-provider.tsx`)
- `pnpm --filter @daylily-catalog/main typecheck`
- `pnpm test -- tests/tier-limited-create-action.test.tsx tests/edit-list-dialog-url-sync.test.tsx tests/list-form-boundary-save.test.tsx`
- `pnpm playwright test tests/e2e/lists-page-features.e2e.ts --retries=0`
- `git diff --check`
