### PR TITLE
Capture all Atlas flows in one session

### DIFF
--- a/apps/main/docs/agent-development-flywheel.md
+++ b/apps/main/docs/agent-development-flywheel.md
@@ -20,11 +20,14 @@ test baseline, change the app, then rerun the same evidence.
 From the repository root:
 
 ```sh
+node apps/main/scripts/run-atlas-flow.mjs all --output=local/atlas/current
 node apps/main/scripts/run-atlas-flow.mjs public-catalog --output=local/atlas/before
 ```
 
-Open the absolute `index.html` path printed by the command and run the tests
-listed there. After making a change:
+The `all` command keeps one Turbopack server alive while capturing every flow
+and creates a home page linking the galleries. Open the absolute `index.html`
+path printed by the command and run the tests listed there. After making a
+change:
 
 ```sh
 node apps/main/scripts/run-atlas-flow.mjs public-catalog --output=local/atlas/after

--- a/apps/main/scripts/generate-atlas-gallery.mjs
+++ b/apps/main/scripts/generate-atlas-gallery.mjs
@@ -2,6 +2,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
+  ATLAS_FLOWS,
   getAtlasFlow,
   resolveLiveStateUrl,
   statesForFlow,
@@ -12,6 +13,23 @@ const escapeHtml = (value) =>
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;");
+
+export function generateAtlasHome({ outputDirectory, flows = ATLAS_FLOWS }) {
+  const cards = flows
+    .map(
+      (flow) =>
+        `<a href="${escapeHtml(flow.id)}/index.html"><h2>${escapeHtml(flow.title)}</h2><p>${escapeHtml(flow.description)}</p><strong>${statesForFlow(flow).length} UI states</strong></a>`,
+    )
+    .join("");
+  const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Daylily Catalog UI Atlas</title><style>
+  :root{font-family:Inter,ui-sans-serif,system-ui;color:#20251f;background:#f4f5f1}*{box-sizing:border-box}body{margin:0;padding:36px}main{max-width:1100px;margin:auto}h1{font-size:clamp(2.5rem,7vw,5rem);letter-spacing:-.05em;margin:0 0 12px}header p,a p{color:#62685f;line-height:1.5}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px;margin-top:40px}a{display:block;padding:24px;border:1px solid #d9ddd4;border-radius:18px;background:white;color:inherit;text-decoration:none}a:hover{border-color:#71816b;box-shadow:0 12px 30px #26332212}a h2{margin-top:0}strong{color:#3f6037}@media(max-width:700px){body{padding:24px 14px}}
+  </style></head><body><main><header><p>Daylily Catalog</p><h1>UI Atlas</h1><p>Choose a crucial user flow to review its declared UI states and confidence layers.</p></header><div class="grid">${cards}</div></main></body></html>`;
+  mkdirSync(outputDirectory, { recursive: true });
+  const homePath = path.join(outputDirectory, "index.html");
+  writeFileSync(homePath, html);
+  return homePath;
+}
+
 export function generateAtlasGallery({
   flowId,
   outputDirectory,

--- a/apps/main/scripts/run-atlas-flow.mjs
+++ b/apps/main/scripts/run-atlas-flow.mjs
@@ -3,8 +3,12 @@ import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import * as dotenv from "dotenv";
-import { generateAtlasGallery } from "./generate-atlas-gallery.mjs";
 import {
+  generateAtlasGallery,
+  generateAtlasHome,
+} from "./generate-atlas-gallery.mjs";
+import {
+  ATLAS_FLOWS,
   getAtlasFlow,
   missingFreshStateIds,
   validateAtlasFlows,
@@ -12,14 +16,18 @@ import {
 const ATLAS_HEALTH_PATH = "/api/runtime-config";
 const appRoot = path.resolve(import.meta.dirname, "..");
 const repoRoot = path.resolve(appRoot, "../..");
-const [flowId, outputArgument, ...unexpected] = process.argv.slice(2);
-if (!flowId || !outputArgument?.startsWith("--output=") || unexpected.length)
+const [requestedFlowId, outputArgument, ...unexpected] = process.argv.slice(2);
+if (
+  !requestedFlowId ||
+  !outputArgument?.startsWith("--output=") ||
+  unexpected.length
+)
   throw new Error("Usage: run-atlas-flow.mjs <flow-id> --output=<directory>");
 
-const flow = getAtlasFlow(flowId);
+const flows =
+  requestedFlowId === "all" ? ATLAS_FLOWS : [getAtlasFlow(requestedFlowId)];
 validateAtlasFlows({ appRoot });
 const outputDirectory = path.resolve(process.cwd(), outputArgument.slice(9));
-const captureDirectory = path.join(outputDirectory, "screenshots");
 const baseURL = process.env.BASE_URL ?? "http://localhost:3210";
 const explicitDatabaseUrl = process.env.DATABASE_URL;
 let server;
@@ -93,51 +101,63 @@ async function startServer() {
 try {
   await startServer();
   rmSync(outputDirectory, { recursive: true, force: true });
-  mkdirSync(captureDirectory, { recursive: true });
-  const startedAt = Date.now();
-  const result = spawnSync(
-    "pnpm",
-    [
-      "exec",
-      "playwright",
-      "test",
-      "-c",
-      "playwright.atlas.config.ts",
-      flow.steps[0].states[0].captureSpec,
-    ],
-    {
-      cwd: appRoot,
-      stdio: "inherit",
-      env: {
-        ...process.env,
-        BASE_URL: baseURL,
-        ATLAS_OUTPUT_DIR: outputDirectory,
-        ATLAS_CAPTURE_DIR: captureDirectory,
-        ATLAS_AUTH_STATE: path.join(outputDirectory, ".auth/member.json"),
-        ATLAS_PLAYWRIGHT_RESULTS_DIR: path.join(
-          outputDirectory,
-          "playwright-results",
-        ),
-        ATLAS_PLAYWRIGHT_REPORT_DIR: path.join(
-          outputDirectory,
-          "playwright-report",
-        ),
+  for (const flow of flows) {
+    const flowOutputDirectory =
+      flows.length === 1
+        ? outputDirectory
+        : path.join(outputDirectory, flow.id);
+    const captureDirectory = path.join(flowOutputDirectory, "screenshots");
+    mkdirSync(captureDirectory, { recursive: true });
+    const startedAt = Date.now();
+    const result = spawnSync(
+      "pnpm",
+      [
+        "exec",
+        "playwright",
+        "test",
+        "-c",
+        "playwright.atlas.config.ts",
+        flow.steps[0].states[0].captureSpec,
+      ],
+      {
+        cwd: appRoot,
+        stdio: "inherit",
+        env: {
+          ...process.env,
+          BASE_URL: baseURL,
+          ATLAS_OUTPUT_DIR: flowOutputDirectory,
+          ATLAS_CAPTURE_DIR: captureDirectory,
+          ATLAS_AUTH_STATE: path.join(flowOutputDirectory, ".auth/member.json"),
+          ATLAS_PLAYWRIGHT_RESULTS_DIR: path.join(
+            flowOutputDirectory,
+            "playwright-results",
+          ),
+          ATLAS_PLAYWRIGHT_REPORT_DIR: path.join(
+            flowOutputDirectory,
+            "playwright-report",
+          ),
+        },
       },
-    },
-  );
-  if (result.error) throw result.error;
-  if (result.status !== 0) process.exitCode = result.status ?? 1;
-  else {
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      process.exitCode = result.status ?? 1;
+      break;
+    }
     const missing = missingFreshStateIds(flow, captureDirectory, startedAt);
     if (missing.length)
       throw new Error(`Missing or stale Atlas states: ${missing.join(", ")}`);
     const galleryPath = generateAtlasGallery({
-      flowId,
-      outputDirectory,
+      flowId: flow.id,
+      outputDirectory: flowOutputDirectory,
       baseURL,
     });
     console.log(`Atlas gallery: ${path.resolve(galleryPath)}`);
   }
+  if (flows.length > 1 && !process.exitCode)
+    console.log(
+      `Atlas home: ${path.resolve(generateAtlasHome({ outputDirectory, flows }))}`,
+    );
 } finally {
   stopServer();
 }


### PR DESCRIPTION
## Overall

Adds an all mode to the existing Atlas runner. It starts one real Turbopack dev server, captures every declared flow sequentially, generates each flow gallery, and writes a root home page linking them. This avoids repeated Next teardown and restart cycles and gives agents one command for the complete visual baseline. No production application code changes.

## Files

- apps/main/scripts/run-atlas-flow.mjs: accepts all, reuses one server, isolates each flow's artifacts, stops on the first failed flow, and generates the root home page only after complete success.
- apps/main/scripts/generate-atlas-gallery.mjs: adds the concise flow-index HTML generator.
- apps/main/docs/agent-development-flywheel.md: documents the one-command complete Atlas baseline.

## Verification

- pnpm typecheck passed.
- Atlas registry: 11 passed.
- Pristine worktree full Atlas run: all 47 states passed in one Turbopack session.
- Public catalog: 9; onboarding membership: 14; listing management: 16; buyer inquiry: 8.
- Root gallery generated at /private/tmp/flywheel-atlas-all-proof/index.html.