### PR TITLE
Enforce complete Atlas captures

### DIFF
--- a/apps/main/tests/atlas/atlas-test.ts
+++ b/apps/main/tests/atlas/atlas-test.ts
@@ -1,13 +1,84 @@
 import { expect, test } from "@playwright/test";
-import type { Page } from "@playwright/test";
-import { mkdirSync } from "node:fs";
+import type { Locator, Page } from "@playwright/test";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { getAtlasState } from "../../scripts/atlas-flows.mjs";
 export { expect, test };
+
+const interactionSurfaceSelectors = [
+  '[role="dialog"]:visible',
+  '[role="alertdialog"]:visible',
+  '[role="menu"]:visible',
+  '[role="listbox"]:visible',
+];
+
+async function visibleInteractionSurface(page: Page) {
+  for (const selector of interactionSurfaceSelectors) {
+    const surfaces = page.locator(selector);
+    if ((await surfaces.count()) > 0) return surfaces.last();
+  }
+  return undefined;
+}
+
+async function expandVerticalScrollContainers(target: Locator) {
+  await target.evaluate((root) => {
+    const elements = [root, ...root.querySelectorAll("*")];
+    for (const element of elements) {
+      if (
+        !(element instanceof HTMLElement) ||
+        element instanceof HTMLTextAreaElement ||
+        element === document.documentElement ||
+        element === document.body
+      ) {
+        continue;
+      }
+      const style = getComputedStyle(element);
+      const verticallyScrollable =
+        element.scrollHeight > element.clientHeight + 1 &&
+        (style.overflowY === "auto" || style.overflowY === "scroll");
+      if (!verticallyScrollable) continue;
+
+      element.dataset.atlasOriginalStyle =
+        element.getAttribute("style") ?? "__no_inline_style__";
+      element.style.setProperty("height", "auto", "important");
+      element.style.setProperty("max-height", "none", "important");
+      element.style.setProperty("overflow-y", "visible", "important");
+    }
+  });
+  await target.evaluate(
+    () =>
+      new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+      ),
+  );
+}
+
+async function restoreVerticalScrollContainers(page: Page) {
+  await page.locator("[data-atlas-original-style]").evaluateAll((elements) => {
+    for (const element of elements) {
+      if (!(element instanceof HTMLElement)) continue;
+      const originalStyle = element.dataset.atlasOriginalStyle;
+      delete element.dataset.atlasOriginalStyle;
+      if (originalStyle === "__no_inline_style__") {
+        element.removeAttribute("style");
+      } else if (originalStyle !== undefined) {
+        element.setAttribute("style", originalStyle);
+      }
+    }
+  });
+}
+
+function pngHeight(image: Buffer) {
+  if (image.toString("ascii", 1, 4) !== "PNG") {
+    throw new Error("Atlas screenshots must be PNG images.");
+  }
+  return image.readUInt32BE(20);
+}
+
 export async function captureAtlasState(page: Page, stateId: string) {
   const captureDirectory = process.env.ATLAS_CAPTURE_DIR;
   if (!captureDirectory) throw new Error("ATLAS_CAPTURE_DIR is required.");
-  const stateItem = getAtlasState(stateId);
+  const stateItem = getAtlasState(stateId) as { capture: string };
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.evaluate(async () => {
     await document.fonts.ready;
@@ -26,12 +97,13 @@ export async function captureAtlasState(page: Page, stateId: string) {
     scrollTo(0, initialScrollY);
     await Promise.all(
       images.map(
-        (image) =>
-          image.complete ||
-          new Promise<void>((resolve) => {
+        (image) => {
+          if (image.complete) return Promise.resolve();
+          return new Promise<void>((resolve) => {
             image.addEventListener("load", () => resolve(), { once: true });
             image.addEventListener("error", () => resolve(), { once: true });
-          }),
+          });
+        },
       ),
     );
   });
@@ -40,9 +112,31 @@ export async function captureAtlasState(page: Page, stateId: string) {
     page.locator("[data-nextjs-dialog], #webpack-dev-server-client-overlay"),
   ).toHaveCount(0);
   mkdirSync(captureDirectory, { recursive: true });
-  await page.screenshot({
-    path: path.join(captureDirectory, stateItem.capture),
-    fullPage: true,
-    animations: "disabled",
-  });
+  const interactionSurface = await visibleInteractionSurface(page);
+  const target = interactionSurface ?? page.locator("html");
+  await expandVerticalScrollContainers(target);
+
+  try {
+    const devicePixelRatio = await page.evaluate(() => window.devicePixelRatio);
+    const expectedHeight = interactionSurface
+      ? ((await interactionSurface.boundingBox())?.height ?? 0) *
+        devicePixelRatio
+      : await page.evaluate(
+          () => document.documentElement.scrollHeight * window.devicePixelRatio,
+        );
+    const screenshot = interactionSurface
+      ? await interactionSurface.screenshot({ animations: "disabled" })
+      : await page.screenshot({
+          fullPage: true,
+          animations: "disabled",
+        });
+    const actualHeight = pngHeight(screenshot);
+    expect(
+      actualHeight,
+      `${stateId} must capture the complete ${interactionSurface ? "component" : "page"}, never only the viewport`,
+    ).toBeGreaterThanOrEqual(Math.floor(expectedHeight) - 2);
+    writeFileSync(path.join(captureDirectory, stateItem.capture), screenshot);
+  } finally {
+    await restoreVerticalScrollContainers(page);
+  }
 }


### PR DESCRIPTION
## Description

Make complete screenshots the only Atlas capture behavior. Page states use Playwright full-page screenshots, while visible dialogs, menus, and listboxes use complete element screenshots after nested vertical scroll regions are expanded. The helper validates the resulting image height so viewport-only captures fail rather than entering the gallery.

## Files

- `apps/main/tests/atlas/atlas-test.ts`: selects page versus interaction-component capture, expands nested scrolling content, validates PNG height, and writes the complete screenshot.

## Verification

- `pnpm exec eslint tests/atlas/atlas-test.ts`
- `pnpm typecheck`
- Buyer inquiry Atlas: 8/8 states passed
- Full listing pages: 1440x1761
- Complete contact dialog components: 500x900

Base branch: `flywheel-v2` (not `main`).