### PR TITLE
Show Atlas flow confidence commands

### DIFF
--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -770,6 +770,20 @@ export function resolveLiveStateUrl(stateItem, baseURL) {
     ? new URL(stateItem.url, baseURL).toString()
     : null;
 }
+export function confidenceCommandsForFlow(flow) {
+  const vitestFiles = [...flow.tests.unit, ...flow.tests.integration].map(
+    ({ path: testPath }) => testPath,
+  );
+  const e2eFiles = flow.tests.e2e.map(({ path: testPath }) => testPath);
+  return [
+    vitestFiles.length
+      ? `pnpm main exec vitest run --maxWorkers=1 ${vitestFiles.join(" ")}`
+      : null,
+    e2eFiles.length
+      ? `pnpm main exec playwright test --retries=0 ${e2eFiles.join(" ")}`
+      : null,
+  ].filter(Boolean);
+}
 export function validateAtlasFlows({ flows = ATLAS_FLOWS, appRoot }) {
   const stateIds = new Set();
   const captures = new Set();

--- a/apps/main/scripts/generate-atlas-gallery.mjs
+++ b/apps/main/scripts/generate-atlas-gallery.mjs
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
   ATLAS_FLOWS,
+  confidenceCommandsForFlow,
   getAtlasFlow,
   resolveLiveStateUrl,
   statesForFlow,
@@ -43,6 +44,9 @@ export function generateAtlasGallery({
   if (missing.length)
     throw new Error(`Missing Atlas states: ${missing.join(", ")}`);
 
+  const confidenceCommands = confidenceCommandsForFlow(flow)
+    .map((command) => `<code>${escapeHtml(command)}</code>`)
+    .join("");
   const tests = Object.entries(flow.tests)
     .map(
       ([layer, references]) =>
@@ -70,8 +74,8 @@ export function generateAtlasGallery({
     )
     .join("");
   const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(flow.title)} · UI Atlas</title><style>
-  :root{font-family:Inter,ui-sans-serif,system-ui;color:#20251f;background:#f4f5f1}*{box-sizing:border-box}body{margin:0;padding:36px}main{max-width:1600px;margin:auto}header{max-width:850px;margin-bottom:38px}h1{font-size:clamp(2.3rem,5vw,4.5rem);letter-spacing:-.05em;margin:0 0 12px}h2{text-transform:capitalize}header p,.copy p,section>p{color:#62685f;line-height:1.5}.tests{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:28px 0 50px}.tests section,article{border:1px solid #d9ddd4;border-radius:16px;background:white;overflow:hidden}.tests section{padding:18px}.tests h2{margin-top:0}.step{margin-bottom:50px}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:22px;align-items:start}article>a{display:block;background:#e7e9e3;border-bottom:1px solid #d9ddd4}img{display:block;width:100%;height:auto}.copy{padding:18px}.copy h3{margin:0 0 8px}.meta{display:flex;flex-wrap:wrap;gap:9px;align-items:center}.meta a,.meta span{padding:6px 9px;border-radius:7px;background:#e7efe3;color:#3f6037;font-weight:700;text-decoration:none}code{display:inline-block;max-width:100%;overflow:auto;padding:6px 8px;border-radius:6px;background:#eef0eb;font-size:.78rem}details code{margin-top:10px}@media(max-width:800px){body{padding:22px 12px}.tests{grid-template-columns:1fr}.grid{grid-template-columns:1fr}}
-  </style></head><body><main><header><p>Daylily Catalog UI Atlas</p><h1>${escapeHtml(flow.title)}</h1><p>${escapeHtml(flow.description)}</p></header><div class="tests">${tests}</div>${steps}</main></body></html>`;
+  :root{font-family:Inter,ui-sans-serif,system-ui;color:#20251f;background:#f4f5f1}*{box-sizing:border-box}body{margin:0;padding:36px}main{max-width:1600px;margin:auto}header{max-width:850px;margin-bottom:38px}h1{font-size:clamp(2.3rem,5vw,4.5rem);letter-spacing:-.05em;margin:0 0 12px}h2{text-transform:capitalize}header p,.copy p,section>p{color:#62685f;line-height:1.5}.confidence{display:grid;gap:10px;margin:28px 0}.confidence code{display:block}.tests{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:28px 0 50px}.tests section,article{border:1px solid #d9ddd4;border-radius:16px;background:white;overflow:hidden}.tests section{padding:18px}.tests h2{margin-top:0}.step{margin-bottom:50px}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:22px;align-items:start}article>a{display:block;background:#e7e9e3;border-bottom:1px solid #d9ddd4}img{display:block;width:100%;height:auto}.copy{padding:18px}.copy h3{margin:0 0 8px}.meta{display:flex;flex-wrap:wrap;gap:9px;align-items:center}.meta a,.meta span{padding:6px 9px;border-radius:7px;background:#e7efe3;color:#3f6037;font-weight:700;text-decoration:none}code{display:inline-block;max-width:100%;overflow:auto;padding:6px 8px;border-radius:6px;background:#eef0eb;font-size:.78rem}details code{margin-top:10px}@media(max-width:800px){body{padding:22px 12px}.tests{grid-template-columns:1fr}.grid{grid-template-columns:1fr}}
+  </style></head><body><main><header><p>Daylily Catalog UI Atlas</p><h1>${escapeHtml(flow.title)}</h1><p>${escapeHtml(flow.description)}</p></header><section class="confidence"><h2>Run this flow's confidence</h2>${confidenceCommands}</section><div class="tests">${tests}</div>${steps}</main></body></html>`;
   mkdirSync(outputDirectory, { recursive: true });
   const galleryPath = path.join(outputDirectory, "index.html");
   writeFileSync(galleryPath, html);

--- a/apps/main/tests/atlas-flows.test.ts
+++ b/apps/main/tests/atlas-flows.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   ATLAS_FLOWS,
+  confidenceCommandsForFlow,
   getAtlasFlow,
   getAtlasState,
   missingFreshStateIds,
@@ -69,6 +70,13 @@ describe("Atlas flow contract", () => {
     expect(getAtlasState("list-management-mobile-remove").urlReproducible).toBe(
       false,
     );
+  });
+
+  it("provides copy-paste confidence commands for a complete flow", () => {
+    expect(confidenceCommandsForFlow(getAtlasFlow("list-management"))).toEqual([
+      "pnpm main exec vitest run --maxWorkers=1 tests/manage-list-columns.test.ts tests/add-listings-combobox.test.tsx tests/dashboard-db-list-membership-sync.test.tsx tests/list-form-boundary-save.test.tsx tests/manage-list-page-membership-commit.test.tsx tests/use-list-resource.test.tsx",
+      "pnpm main exec playwright test --retries=0 tests/e2e/lists-page-features.e2e.ts tests/e2e/manage-list-page-features.e2e.ts",
+    ]);
   });
 
   it("declares the buyer inquiry journey without sending a real message", () => {


### PR DESCRIPTION
## Description

Each Atlas gallery now shows copy-paste commands for that flow’s declared unit/integration and E2E coverage. This turns the visual flow page into the direct entry point for verifying the same flow without adding package scripts or another runner.

## Files

- `apps/main/scripts/atlas-flows.mjs`: derives focused Vitest and Playwright commands from each flow’s existing test declarations.
- `apps/main/scripts/generate-atlas-gallery.mjs`: displays the combined commands above the existing test inventory.
- `apps/main/tests/atlas-flows.test.ts`: locks the list-management flow command contract.

## Verification

- `pnpm main exec vitest run --maxWorkers=1 tests/atlas-flows.test.ts` — 14 tests passed
- Executed the generated list-management Vitest command — 6 files and 9 tests passed in 8.95s