### PR TITLE
Stabilize Atlas member authentication

### DIFF
--- a/apps/main/tests/atlas/member-auth.setup.ts
+++ b/apps/main/tests/atlas/member-auth.setup.ts
@@ -21,10 +21,12 @@ setup("authenticate realistic catalog member", async ({ page }) => {
     "You need to send a verification code before attempting to verify.",
   );
   if (await sendCodeWarning.isVisible()) {
-    await page.getByRole("button", { name: /continue/i }).last().click();
+    await page
+      .getByRole("button", { name: /didn't receive a code\? resend/i })
+      .click();
     await expect(sendCodeWarning).toBeHidden();
   }
-  await codeInput.fill("424242");
+  await codeInput.pressSequentially("424242", { delay: 100 });
 
   await expect(page).toHaveURL(/\/dashboard/, { timeout: 30_000 });
   mkdirSync(path.dirname(authState), { recursive: true });


### PR DESCRIPTION
## Description

The Atlas member setup now uses Clerk’s visible resend action when Clerk reports that no verification code was sent, then enters the fixed test code as a user would. This removes the ambiguous fallback to the last generic Continue button.

## Files

- `apps/main/tests/atlas/member-auth.setup.ts`: targets the visible resend control and types the six-digit code sequentially.

## Verification

- `BASE_URL=http://localhost:3211 ATLAS_AUTH_STATE=/private/tmp/atlas-auth-proof/member.json pnpm main exec playwright test -c playwright.atlas.config.ts --project=member-auth`
- Result: 1/1 passed in 6.5s against the realistic member and a disposable database