### PR TITLE
Mark broad manage-list E2E slow

### DIFF
--- a/apps/main/tests/e2e/manage-list-page-features.e2e.ts
+++ b/apps/main/tests/e2e/manage-list-page-features.e2e.ts
@@ -19,6 +19,8 @@ test.describe("manage list page features @local", () => {
     page,
     manageListPage,
   }) => {
+    test.slow();
+
     const expectPageIndicator = async (
       currentPage: number,
       totalPages: number,


### PR DESCRIPTION
## Description

Classifies the broad manage-list happy-path E2E as slow so its six real-user phases have an appropriate timeout budget without adding waits, retries, or changing coverage.

## Files

- apps/main/tests/e2e/manage-list-page-features.e2e.ts: adds Playwright's test.slow() annotation to the existing test.

## Verification

- pnpm main exec playwright test tests/e2e/manage-list-page-features.e2e.ts --retries=0
- Result: 1 passed; test body 26.9s; zero retries.