### PR TITLE
Cover create-listing URL state

### DIFF
--- a/apps/main/tests/edit-listing-dialog-url-sync.test.tsx
+++ b/apps/main/tests/edit-listing-dialog-url-sync.test.tsx
@@ -3,6 +3,7 @@ import {
   act,
   fireEvent,
   render,
+  renderHook,
   screen,
   waitFor,
 } from "@testing-library/react";
@@ -123,6 +124,34 @@ describe("useEditListing URL sync", () => {
       );
     });
     expect(navigationState.push).not.toHaveBeenCalled();
+  });
+
+  it("uses the creating query as the source of truth", () => {
+    navigationState.setSearch("");
+    const { result, rerender } = renderHook(useCreateListing);
+
+    expect(result.current.isCreating).toBe(false);
+    act(() => result.current.openCreateListing());
+    expect(navigationState.push).toHaveBeenCalledWith(
+      "/dashboard/listings?creating=true",
+      { scroll: false },
+    );
+
+    rerender();
+    expect(result.current.isCreating).toBe(true);
+
+    navigationState.setSearch("");
+    rerender();
+    expect(result.current.isCreating).toBe(false);
+
+    navigationState.setSearch("creating=true");
+    rerender();
+
+    act(() => result.current.closeCreateListing());
+    expect(navigationState.replace).toHaveBeenCalledWith(
+      "/dashboard/listings",
+      { scroll: false },
+    );
   });
 
   it("follows browser history changes to the editing query", async () => {


### PR DESCRIPTION
## Description

Documents the existing create-listing URL contract with one focused integration test. The test proves that opening adds creating=true, URL/history changes control whether creation is active, and closing removes the parameter.

No production application code changes are included because real Chrome verification showed the desired behavior already works.

## Files

- apps/main/tests/edit-listing-dialog-url-sync.test.tsx: adds the create-listing URL-state characterization test.

## Verification

- pnpm main test -- edit-listing-dialog-url-sync.test.tsx
- pnpm main test -- edit-listing-dialog-url-sync.test.tsx tier-limited-create-action.test.tsx create-listing-dialog.test.tsx
- pnpm main typecheck
- Real Chrome: direct creating=true URL, button open, Back close, and Forward restore all verified.