### PR TITLE
Keep Atlas server output concise

### DIFF
--- a/apps/main/scripts/run-atlas-flow.mjs
+++ b/apps/main/scripts/run-atlas-flow.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, rmSync } from "node:fs";
 import path from "node:path";
 import * as dotenv from "dotenv";
 import {
@@ -33,10 +33,12 @@ const flows =
   requestedFlowId === "all" ? ATLAS_FLOWS : [getAtlasFlow(requestedFlowId)];
 validateAtlasFlows({ appRoot });
 const outputDirectory = path.resolve(process.cwd(), outputArgument.slice(9));
+const serverLogPath = path.join(outputDirectory, "server.log");
 const baseURL = process.env.BASE_URL ?? "http://localhost:3210";
 const explicitDatabaseUrl = process.env.DATABASE_URL;
 let disposableDatabase;
 let server;
+let serverLogFd;
 const stopServer = async () => {
   if (!server?.pid || server.exitCode !== null || server.signalCode !== null)
     return;
@@ -118,10 +120,11 @@ async function startServer() {
     });
     databaseUrl = `file:${disposableDatabase.databasePath}`;
   }
+  serverLogFd = openSync(serverLogPath, "w");
   server = spawn("pnpm", ["dev", "--", "--port", new URL(baseURL).port], {
     cwd: repoRoot,
     detached: process.platform !== "win32",
-    stdio: "inherit",
+    stdio: ["ignore", serverLogFd, serverLogFd],
     env: {
       ...process.env,
       DATABASE_URL: databaseUrl,
@@ -137,15 +140,18 @@ async function startServer() {
   const deadline = Date.now() + 120_000;
   while (Date.now() < deadline) {
     if (server.exitCode !== null)
-      throw new Error("Atlas dev server exited early.");
+      throw new Error(`Atlas dev server exited early. See ${serverLogPath}.`);
     if (await isHealthy()) return;
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
-  throw new Error(`Atlas dev server was not ready at ${baseURL}`);
+  throw new Error(
+    `Atlas dev server was not ready at ${baseURL}. See ${serverLogPath}.`,
+  );
 }
 try {
-  await startServer();
   rmSync(outputDirectory, { recursive: true, force: true });
+  mkdirSync(outputDirectory, { recursive: true });
+  await startServer();
   for (const flow of flows) {
     const flowOutputDirectory =
       flows.length === 1
@@ -203,7 +209,10 @@ try {
     console.log(
       `Atlas home: ${path.resolve(generateAtlasHome({ outputDirectory, flows }))}`,
     );
+  if (serverLogFd !== undefined)
+    console.log(`Atlas server log: ${serverLogPath}`);
 } finally {
   await stopServer();
+  if (serverLogFd !== undefined) closeSync(serverLogFd);
   disposableDatabase?.cleanup();
 }

--- a/apps/main/scripts/run-atlas-flow.mjs
+++ b/apps/main/scripts/run-atlas-flow.mjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from "node:child_process";
-import { closeSync, existsSync, mkdirSync, openSync, rmSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
 import path from "node:path";
 import * as dotenv from "dotenv";
 import {
@@ -33,7 +40,11 @@ const flows =
   requestedFlowId === "all" ? ATLAS_FLOWS : [getAtlasFlow(requestedFlowId)];
 validateAtlasFlows({ appRoot });
 const outputDirectory = path.resolve(process.cwd(), outputArgument.slice(9));
-const serverLogPath = path.join(outputDirectory, "server.log");
+const finalServerLogPath = path.join(outputDirectory, "server.log");
+let serverLogPath = path.join(
+  path.dirname(outputDirectory),
+  `.${path.basename(outputDirectory)}-server-${process.pid}.log`,
+);
 const baseURL = process.env.BASE_URL ?? "http://localhost:3210";
 const explicitDatabaseUrl = process.env.DATABASE_URL;
 let disposableDatabase;
@@ -149,9 +160,14 @@ async function startServer() {
   );
 }
 try {
+  mkdirSync(path.dirname(outputDirectory), { recursive: true });
+  await startServer();
   rmSync(outputDirectory, { recursive: true, force: true });
   mkdirSync(outputDirectory, { recursive: true });
-  await startServer();
+  if (serverLogFd !== undefined) {
+    renameSync(serverLogPath, finalServerLogPath);
+    serverLogPath = finalServerLogPath;
+  }
   for (const flow of flows) {
     const flowOutputDirectory =
       flows.length === 1


### PR DESCRIPTION
## Description

Keep Atlas runs readable for agents while preserving complete local server diagnostics. Playwright state progress remains visible; Next, Prisma, browser warnings, and shutdown output are written to the generated Atlas artifact as `server.log`. Production app behavior is unchanged.

## Files

- `apps/main/scripts/run-atlas-flow.mjs`: creates the output directory before startup, captures the spawned dev server stdout/stderr in `server.log`, points startup errors to that log, closes the log descriptor during cleanup, and prints the final log path.

## Verification

- `pnpm main test -- atlas-flows.test.ts realistic-data-snapshot.test.ts`
- `node apps/main/scripts/run-atlas-flow.mjs buyer-inquiry --output=local/atlas/concise-proof` (8 states passed; concise terminal output; 157 diagnostic lines preserved in `server.log`)
- `git diff --check`