### PR TITLE
Describe the buyer contact dialog

### DIFF
--- a/apps/main/src/components/floating-cart-button.tsx
+++ b/apps/main/src/components/floating-cart-button.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
@@ -77,6 +78,10 @@ export function FloatingCartButton({
           {itemCount > 0 &&
             ` (${itemCount} ${itemCount === 1 ? "item" : "items"} in cart)`}
         </DialogTitle>
+        <DialogDescription className="sr-only">
+          Ask the seller about availability, shipping, pickup, or anything else
+          you need to know.
+        </DialogDescription>
         <ContactForm
           userId={userId}
           onSubmitSuccess={() => setIsDialogOpen(false)}

--- a/apps/main/tests/floating-cart-button.test.tsx
+++ b/apps/main/tests/floating-cart-button.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FloatingCartButton } from "@/components/floating-cart-button";
+
+vi.mock("@/components/contact-form", () => ({
+  ContactForm: () => <div>Contact form</div>,
+}));
+
+describe("FloatingCartButton", () => {
+  it("describes the seller contact dialog", () => {
+    render(
+      <FloatingCartButton
+        showTopButton
+        userId="seller-1"
+        userName="Starcrossed Seeds"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Contact Seller$/ }));
+
+    expect(screen.getByRole("dialog")).toHaveAccessibleDescription(
+      "Ask the seller about availability, shipping, pickup, or anything else you need to know.",
+    );
+  });
+});


### PR DESCRIPTION
## Description

Adds the missing accessible description to the public buyer contact dialog without changing its visible layout. The fix removes the Radix accessibility warning observed by the buyer-inquiry Atlas and gives assistive technology useful dialog context.

## Files

- `apps/main/src/components/floating-cart-button.tsx`: adds a screen-reader-only `DialogDescription` to the Contact Seller dialog.
- `apps/main/tests/floating-cart-button.test.tsx`: opens the dialog through its visible button and verifies its accessible description.

## Verification

- Focused accessibility test: 1/1 passed.
- Buyer-inquiry Atlas: 8/8 states before and after.
- Radix warning lines: 12 before, 0 after.
- Before/after contact-dialog screenshot hashes are identical.
- Visible Chrome flow: opened a seeded listing, added it to the cart, opened Contact Seller, verified `aria-describedby`, changed quantity, and observed the subtotal update.
- Relevant flow suite: 32/32 passed.
- Typecheck passed.
- Lint passed with one unrelated pre-existing warning.
- Prettier and `git diff --check` passed.