### PR TITLE
Require visible browser flywheel review

### DIFF
--- a/apps/main/docs/agent-development-flywheel.md
+++ b/apps/main/docs/agent-development-flywheel.md
@@ -3,6 +3,19 @@
 The flywheel is organized by user flow. For each flow, establish a visual and
 test baseline, change the app, then rerun the same evidence.
 
+## Browser-first UI loop
+
+For a UI change, use the app in visible Chrome before editing and again after
+the change. Follow the normal controls a user sees; do not substitute hidden
+controls, direct API calls, or database edits. Atlas captures do not replace
+this walkthrough.
+
+Generate separate before and after galleries, then open and inspect every
+affected screenshot. A passing capture only proves that the state was created;
+it does not prove that the design is correct. Check the complete page or
+component for clipping, overflow, missing content, and unintended layout
+changes.
+
 ## Confidence layers
 
 - **Atlas screenshots** document declared meaningful UI states. A capture may
@@ -24,6 +37,10 @@ node apps/main/scripts/run-atlas-flow.mjs all --output=local/atlas/current
 node apps/main/scripts/run-atlas-flow.mjs public-catalog --output=local/atlas/before
 ```
 
+Available flow IDs are declared in
+`apps/main/scripts/atlas-flows.mjs`. Use an ID with the same runner to capture
+one flow, or use `all` to generate the linked Atlas home page.
+
 The `all` command keeps one Turbopack server alive while capturing every flow
 and creates a home page linking the galleries. Open the absolute `index.html`
 path printed by the command and run the tests listed there. After making a
@@ -43,6 +60,10 @@ Atlas validates the standard realistic seed against the current Prisma schema,
 then runs against a disposable copy. Captures cannot modify the canonical
 development seed. If the seed is missing or stale, the runner stops with the
 single recovery command: `pnpm db:seed:prepare`.
+
+In a restricted agent environment, starting the local Next server may require
+elevated permission to bind its port. Rerun the Atlas command with that
+permission; do not change the app or test flow to work around the restriction.
 
 ## Integration loop
 

--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -671,6 +671,7 @@ export const ATLAS_FLOWS = [
       unit: [testRef("unit", "tests/use-cart.test.tsx")],
       integration: [
         testRef("integration", "tests/contact-form.test.tsx"),
+        testRef("integration", "tests/floating-cart-button.test.tsx"),
         testRef("integration", "tests/public-inquiry.test.ts"),
         testRef("integration", "tests/public-inquiry-rate-limit.test.ts"),
         testRef("integration", "tests/public-router-send-message.test.ts"),

--- a/apps/main/src/components/floating-cart-button.tsx
+++ b/apps/main/src/components/floating-cart-button.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
@@ -77,6 +78,10 @@ export function FloatingCartButton({
           {itemCount > 0 &&
             ` (${itemCount} ${itemCount === 1 ? "item" : "items"} in cart)`}
         </DialogTitle>
+        <DialogDescription className="sr-only">
+          Ask the seller about availability, shipping, pickup, or anything else
+          you need to know.
+        </DialogDescription>
         <ContactForm
           userId={userId}
           onSubmitSuccess={() => setIsDialogOpen(false)}

--- a/apps/main/tests/floating-cart-button.test.tsx
+++ b/apps/main/tests/floating-cart-button.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FloatingCartButton } from "@/components/floating-cart-button";
+
+vi.mock("@/components/contact-form", () => ({
+  ContactForm: () => <div>Contact form</div>,
+}));
+
+describe("FloatingCartButton", () => {
+  it("describes the seller contact dialog", () => {
+    render(
+      <FloatingCartButton
+        showTopButton
+        userId="seller-1"
+        userName="Starcrossed Seeds"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Contact Seller$/ }));
+
+    expect(screen.getByRole("dialog")).toHaveAccessibleDescription(
+      "Ask the seller about availability, shipping, pickup, or anything else you need to know.",
+    );
+  });
+});


### PR DESCRIPTION
## Description

Clarifies the browser-first verification requirements learned from applying the flywheel to the buyer contact-dialog fix. This stacked tooling PR makes visible Chrome use and actual before/after gallery inspection explicit, documents flow discovery and restricted port binding, and associates the new accessibility test with the buyer-inquiry flow.

This PR is stacked on #333 so the referenced test exists. Merge #333 first, then retarget this PR to `main`.

## Files

- `apps/main/docs/agent-development-flywheel.md`: requires visible Chrome walkthroughs before and after UI changes; requires visual inspection rather than treating a successful capture as design approval; documents flow ID discovery and restricted local-server permission.
- `apps/main/scripts/atlas-flows.mjs`: adds the buyer contact-dialog accessibility test to buyer-inquiry integration confidence.

## Verification

- Atlas registry and accessibility tests: 15/15 passed.
- `git diff --check` passed.
- The documentation changes directly address the cold-subagent trial: it initially used only headless Playwright and initially missed a clipped dialog title that was visible in the generated Atlas.