### PR TITLE
Move image moderation to runtime flags

### DIFF
--- a/apps/main/docs/feature-flags.md
+++ b/apps/main/docs/feature-flags.md
@@ -32,6 +32,7 @@ and reports the effective state. Read the current public state at
 
 Before the first deployment, create the file with cultivar search enabled. The
 old app ignores it and the new app reads it on its first request.
+Do not rerun this initialization; use the setter above for every later change.
 
 ```sh
 install -d -o 1001 -g 1001 /srv/stacks/daylilycatalog/data

--- a/apps/main/docs/feature-flags.md
+++ b/apps/main/docs/feature-flags.md
@@ -9,6 +9,7 @@ Values live only in `/data/runtime-feature-flags.json`:
 
 ```json
 {
+  "imageModerationEnforced": false,
   "publicCultivarSearch": true
 }
 ```

--- a/apps/main/scripts/run-integration-local.mjs
+++ b/apps/main/scripts/run-integration-local.mjs
@@ -42,7 +42,6 @@ const integrationEnv = {
   STRIPE_PRICE_ID: "price_integration",
   NEXT_PUBLIC_CLOUDFLARE_URL: appBaseUrl,
   NEXT_PUBLIC_SENTRY_ENABLED: "false",
-  IMAGE_MODERATION_ENFORCED: "false",
   PUBLIC_SEARCH_INDEX_REFRESH_INTERVAL_SECONDS: "0",
   RUST_LOG: "info",
   NODE_OPTIONS: `--import=${guardUrl}`,

--- a/apps/main/src/config/feature-flags.ts
+++ b/apps/main/src/config/feature-flags.ts
@@ -25,10 +25,15 @@ export function isPublicCultivarSearchEnabled() {
   return getRuntimeFeatureFlags().publicCultivarSearch;
 }
 
+export function isImageModerationEnforced() {
+  return getRuntimeFeatureFlags().imageModerationEnforced;
+}
+
 export function getRuntimeFeatureFlags(): RuntimeFeatureFlags {
   const configured = readConfiguredRuntimeFeatureFlags();
 
   return {
+    imageModerationEnforced: configured.imageModerationEnforced,
     publicCultivarSearch: configured.publicCultivarSearch && !isVercel(),
   };
 }

--- a/apps/main/src/config/runtime-feature-flags.ts
+++ b/apps/main/src/config/runtime-feature-flags.ts
@@ -1,4 +1,5 @@
 export const DISABLED_RUNTIME_FEATURE_FLAGS = {
+  imageModerationEnforced: false,
   publicCultivarSearch: false,
 };
 
@@ -12,6 +13,7 @@ export function parseRuntimeFeatureFlags(value: unknown): RuntimeFeatureFlags {
       : {};
 
   return {
+    imageModerationEnforced: flags.imageModerationEnforced === true,
     publicCultivarSearch: flags.publicCultivarSearch === true,
   };
 }

--- a/apps/main/src/env.js
+++ b/apps/main/src/env.js
@@ -4,12 +4,6 @@ import * as dotenv from "dotenv";
 import path from "path";
 import { fileURLToPath } from "url";
 
-const booleanStringSchema = z.stringbool();
-
-/** @param {string | undefined} value */
-export function parseBooleanEnv(value) {
-  return booleanStringSchema.optional().default(false).parse(value);
-}
 const appRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
@@ -46,7 +40,6 @@ export const env = createEnv({
     R2_SECRET_ACCESS_KEY: z.string().optional(),
     R2_BUCKET_NAME: z.string().optional(),
     R2_PUBLIC_BASE_URL: z.string().url().optional(),
-    IMAGE_MODERATION_ENFORCED: booleanStringSchema.optional().default(false),
     OPENAI_IMAGE_MODERATION_API_KEY: z.string().optional(),
     SENTRY_AUTH_TOKEN: z.string().optional(),
     NODE_ENV: z.enum(["development", "test", "production"]),
@@ -84,7 +77,6 @@ export const env = createEnv({
     R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY,
     R2_BUCKET_NAME: process.env.R2_BUCKET_NAME,
     R2_PUBLIC_BASE_URL: process.env.R2_PUBLIC_BASE_URL,
-    IMAGE_MODERATION_ENFORCED: process.env.IMAGE_MODERATION_ENFORCED,
     OPENAI_IMAGE_MODERATION_API_KEY:
       process.env.OPENAI_IMAGE_MODERATION_API_KEY,
     SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,

--- a/apps/main/src/server/api/routers/dashboard-db/image.ts
+++ b/apps/main/src/server/api/routers/dashboard-db/image.ts
@@ -30,7 +30,7 @@ import {
   getUserImageOwnerWhere,
 } from "@/server/services/user-image-records";
 import { captureServerPosthogEvent } from "@/server/analytics/posthog-server";
-import { parseBooleanEnv } from "@/env";
+import { isImageModerationEnforced } from "@/config/feature-flags";
 import { reportError } from "@/lib/error-utils";
 import { after } from "next/server";
 import {
@@ -396,8 +396,7 @@ export const dashboardDbImageRouter = createTRPCRouter({
         process.env.OPENAI_IMAGE_MODERATION_API_KEY?.trim(),
       );
       const moderationEnforced =
-        moderationEnabled &&
-        parseBooleanEnv(process.env.IMAGE_MODERATION_ENFORCED);
+        moderationEnabled && isImageModerationEnforced();
       if (moderationEnforced) {
         if (!input.imageDataUrl) {
           return { moderationRequired: true } as const;

--- a/apps/main/tests/dashboard-db-image-assets.test.ts
+++ b/apps/main/tests/dashboard-db-image-assets.test.ts
@@ -34,6 +34,7 @@ const variantProcessorMock = vi.hoisted(() => vi.fn());
 const captureServerPosthogEventMock = vi.hoisted(() => vi.fn());
 const reportErrorMock = vi.hoisted(() => vi.fn());
 const fetchMock = vi.hoisted(() => vi.fn());
+const featureFlags = vi.hoisted(() => ({ imageModerationEnforced: false }));
 const consoleInfoMock = vi
   .spyOn(console, "info")
   .mockImplementation(() => undefined);
@@ -74,6 +75,10 @@ vi.mock("@/lib/error-utils", async () => {
     );
   return { ...actual, reportError: reportErrorMock };
 });
+
+vi.mock("@/config/feature-flags", () => ({
+  isImageModerationEnforced: () => featureFlags.imageModerationEnforced,
+}));
 
 type RouterModule = typeof import("@/server/api/routers/dashboard-db/image");
 let dashboardDbImageRouter: RouterModule["dashboardDbImageRouter"];
@@ -117,7 +122,7 @@ function createImageRow(overrides: Partial<Record<string, unknown>> = {}) {
 describe("dashboard image asset mutations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.IMAGE_MODERATION_ENFORCED = "false";
+    featureFlags.imageModerationEnforced = false;
     process.env.OPENAI_IMAGE_MODERATION_API_KEY = "test-moderation-key";
     variantProcessorMock.mockResolvedValue({
       processed: 1,
@@ -162,7 +167,7 @@ describe("dashboard image asset mutations", () => {
 
   it("disables moderation when the API key is missing", async () => {
     delete process.env.OPENAI_IMAGE_MODERATION_API_KEY;
-    process.env.IMAGE_MODERATION_ENFORCED = "true";
+    featureFlags.imageModerationEnforced = true;
     const db = {
       listing: {
         findFirst: vi.fn().mockResolvedValue({ id: "listing-1" }),
@@ -212,7 +217,7 @@ describe("dashboard image asset mutations", () => {
   });
 
   it("moderates the submitted image before issuing checksum-bound URLs", async () => {
-    process.env.IMAGE_MODERATION_ENFORCED = "yes";
+    featureFlags.imageModerationEnforced = true;
     const db = {
       listing: {
         findFirst: vi.fn().mockResolvedValue({ id: "listing-1" }),
@@ -265,7 +270,7 @@ describe("dashboard image asset mutations", () => {
   });
 
   it("rejects sexual images before issuing upload URLs", async () => {
-    process.env.IMAGE_MODERATION_ENFORCED = "true";
+    featureFlags.imageModerationEnforced = true;
     const db = {
       listing: {
         findFirst: vi.fn().mockResolvedValue({ id: "listing-1" }),
@@ -302,7 +307,7 @@ describe("dashboard image asset mutations", () => {
   });
 
   it("allows enforced uploads and reports when moderation is unavailable", async () => {
-    process.env.IMAGE_MODERATION_ENFORCED = "true";
+    featureFlags.imageModerationEnforced = true;
     const db = {
       listing: {
         findFirst: vi.fn().mockResolvedValue({ id: "listing-1" }),
@@ -348,7 +353,7 @@ describe("dashboard image asset mutations", () => {
   });
 
   it("rejects sexual content involving minors", async () => {
-    process.env.IMAGE_MODERATION_ENFORCED = "true";
+    featureFlags.imageModerationEnforced = true;
     const db = {
       listing: {
         findFirst: vi.fn().mockResolvedValue({ id: "listing-1" }),
@@ -381,7 +386,7 @@ describe("dashboard image asset mutations", () => {
   });
 
   it("rejects animated images before moderation", async () => {
-    process.env.IMAGE_MODERATION_ENFORCED = "true";
+    featureFlags.imageModerationEnforced = true;
     const sharp = (await import("sharp")).default;
     const animatedImage = await sharp(Buffer.from([255, 0, 0, 0, 255, 0]), {
       raw: { width: 1, height: 2, channels: 3, pageHeight: 1 },

--- a/apps/main/tests/runtime-config-route.test.ts
+++ b/apps/main/tests/runtime-config-route.test.ts
@@ -104,6 +104,7 @@ describe("runtime config route", () => {
         host: "https://eu.i.posthog.com",
       },
       features: {
+        imageModerationEnforced: false,
         publicCultivarSearch: false,
       },
     });

--- a/apps/main/tests/runtime-feature-flags.test.ts
+++ b/apps/main/tests/runtime-feature-flags.test.ts
@@ -4,7 +4,10 @@ import { rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
-import { isPublicCultivarSearchEnabled } from "@/config/feature-flags";
+import {
+  isImageModerationEnforced,
+  isPublicCultivarSearchEnabled,
+} from "@/config/feature-flags";
 import {
   getHomeMarkdown,
   getLlmsTxt,
@@ -19,7 +22,7 @@ const runtimeFlagsPath = join(
   `daylily-public-feature-flags-${process.pid}.json`,
 );
 
-describe("public cultivar search feature flag", () => {
+describe("runtime feature flags", () => {
   beforeEach(() => {
     process.env.RUNTIME_FEATURE_FLAGS_PATH = runtimeFlagsPath;
     writeFileSync(runtimeFlagsPath, '{"publicCultivarSearch":false}');
@@ -63,6 +66,14 @@ describe("public cultivar search feature flag", () => {
 
     writeFileSync(runtimeFlagsPath, '{"publicCultivarSearch":false}');
     expect(isPublicCultivarSearchEnabled()).toBe(false);
+  });
+
+  it("enforces image moderation only from the runtime file", () => {
+    writeFileSync(runtimeFlagsPath, '{"imageModerationEnforced":true}');
+    expect(isImageModerationEnforced()).toBe(true);
+
+    writeFileSync(runtimeFlagsPath, '{"imageModerationEnforced":false}');
+    expect(isImageModerationEnforced()).toBe(false);
   });
 
   it("keeps every public surface disabled on unsupported deployments", () => {


### PR DESCRIPTION
## Summary

Move image-moderation enforcement from `IMAGE_MODERATION_ENFORCED` to the existing runtime feature-flag file as `imageModerationEnforced`. The OpenAI API key remains environment configuration and the master switch, so missing credentials still disable moderation completely. Flag-off behavior remains shadow mode and provider failures still fail open.

## Files

- `src/config/runtime-feature-flags.ts`: add and parse the default-off runtime flag.
- `src/config/feature-flags.ts`: expose the server evaluator.
- `src/server/api/routers/dashboard-db/image.ts`: read enforcement from the runtime evaluator.
- `src/env.js`: remove the retired env flag and now-unused boolean parser.
- `scripts/run-integration-local.mjs`: remove obsolete integration env setup.
- `docs/feature-flags.md`: document the new runtime key.
- `tests/runtime-feature-flags.test.ts`: rename the existing runtime-flag integration test and cover image moderation.
- `tests/dashboard-db-image-assets.test.ts`: drive existing moderation behavior tests through the feature boundary.
- `tests/runtime-config-route.test.ts`: include the new default-off runtime snapshot.

## Validation

- `pnpm main test -- runtime-feature-flags.test.ts dashboard-db-image-assets.test.ts runtime-config-route.test.ts set-feature-flag-script.test.ts use-feature.test.tsx`
- `pnpm main typecheck`
- `pnpm main lint` (passes with one pre-existing hook warning in `dashboard-db-provider.tsx`)
- `git diff --check`

## Rollout

The new flag defaults off when absent. After deployment, enforcement can be enabled without a restart:

```sh
docker compose exec app node apps/main/scripts/set-feature-flag.mjs imageModerationEnforced true
```