### PR TITLE
Describe the image preview dialog

### DIFF
--- a/apps/main/src/components/image-preview-dialog.tsx
+++ b/apps/main/src/components/image-preview-dialog.tsx
@@ -2,7 +2,13 @@
 
 import { Expand } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { ImageGallery } from "@/components/image-gallery";
 import { cn } from "@/lib/utils";
 import type { OptimizedImageSource } from "@/components/optimized-image";
@@ -39,6 +45,11 @@ export function ImagePreviewDialog({
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-xl">
+        <DialogTitle className="sr-only">Image preview</DialogTitle>
+        <DialogDescription className="sr-only">
+          Full-size preview of {images.length} image
+          {images.length === 1 ? "." : "s."}
+        </DialogDescription>
         <ImageGallery images={images} />
       </DialogContent>
     </Dialog>

--- a/apps/main/tests/image-preview-dialog.test.tsx
+++ b/apps/main/tests/image-preview-dialog.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ImagePreviewDialog } from "@/components/image-preview-dialog";
+
+vi.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt = "",
+    priority: _priority,
+    unoptimized: _unoptimized,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    priority?: boolean;
+    unoptimized?: boolean;
+  }) => React.createElement("img", { alt, ...props }),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ImagePreviewDialog", () => {
+  it("opens a named, described gallery without Radix accessibility warnings", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    render(
+      <ImagePreviewDialog
+        images={[
+          {
+            id: "image-1",
+            url: "https://media.example/image-1.jpg",
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "View 1 image" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Image preview" });
+    expect(dialog).toHaveAccessibleDescription("Full-size preview of 1 image.");
+    expect(screen.getByRole("img", { name: "Gallery image" })).toBeVisible();
+
+    const errors = consoleError.mock.calls.flat().join("\n");
+    expect(errors).not.toContain("DialogContent requires a `DialogTitle`");
+    expect(errors).not.toContain(
+      "Missing `Description` or `aria-describedby={undefined}`",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- give the listing image preview dialog a screen-reader-only title and description
- add a focused interaction test for the dialog's accessible name, description, and gallery

## Files

- `apps/main/src/components/image-preview-dialog.tsx` adds the Radix dialog semantics without changing the visible layout
- `apps/main/tests/image-preview-dialog.test.tsx` covers the real open-dialog interaction and regression

## Why

The listing-media Atlas exposed Radix accessibility warnings because the preview dialog had no title or description. The development warning overlay also prevented the Atlas from accepting the preview state. This fixes the underlying application issue instead of hiding the warning in the tooling.

## Verification

- `pnpm exec vitest run --maxWorkers=1 tests/image-preview-dialog.test.tsx`
- `pnpm typecheck`
- `pnpm lint` (passes with one unrelated existing hook warning)
- visible Chrome: preview opens with the expected accessible name and description and no Radix warning
