### PR TITLE
Add the listing media Atlas flow

### DIFF
--- a/apps/main/playwright.atlas.config.ts
+++ b/apps/main/playwright.atlas.config.ts
@@ -47,7 +47,11 @@ export default defineConfig({
     },
     {
       name: "member",
-      testMatch: ["listing-management.atlas.ts", "list-management.atlas.ts"],
+      testMatch: [
+        "listing-management.atlas.ts",
+        "listing-media.atlas.ts",
+        "list-management.atlas.ts",
+      ],
       dependencies: ["member-auth"],
       use: { storageState: authState },
     },

--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -17,6 +17,7 @@ const publicState = stateFor("tests/atlas/public-catalog.atlas.ts");
 const cultivarState = stateFor("tests/atlas/cultivar-search.atlas.ts");
 const onboardingState = stateFor("tests/atlas/onboarding-membership.atlas.ts");
 const listingState = stateFor("tests/atlas/listing-management.atlas.ts");
+const listingMediaState = stateFor("tests/atlas/listing-media.atlas.ts");
 const listState = stateFor("tests/atlas/list-management.atlas.ts");
 const buyerState = stateFor("tests/atlas/buyer-inquiry.atlas.ts");
 const testRef = (layer, file) => ({
@@ -535,6 +536,108 @@ export const ATLAS_FLOWS = [
             "Listing membership picker",
             "The real lists available while editing a listing.",
             "/dashboard/listings?size=10",
+            false,
+          ),
+        ],
+      },
+    ],
+  },
+  {
+    id: "listing-media",
+    audience: "member",
+    title: "Manage listing images",
+    description:
+      "Review, preview, reorder, remove, and prepare listing photos without sending an upload.",
+    tests: {
+      unit: [testRef("unit", "tests/use-image-upload.test.ts")],
+      integration: [
+        testRef("integration", "tests/image-upload.test.tsx"),
+        testRef("integration", "tests/dashboard-db-image-router.test.ts"),
+      ],
+      e2e: [testRef("e2e", "tests/e2e/listing-image-manager.e2e.ts")],
+    },
+    steps: [
+      {
+        title: "Review listing photos",
+        states: [
+          listingMediaState(
+            "listing-media-desktop-populated",
+            "Desktop populated image grid",
+            "Nine real listing photos in the four-column desktop manager.",
+            "/dashboard/listings?size=10&query=18-33",
+            false,
+          ),
+          listingMediaState(
+            "listing-media-mobile-populated",
+            "Mobile populated image grid",
+            "The same listing photos in the two-column mobile manager.",
+            "/dashboard/listings?size=10&query=18-33",
+            false,
+          ),
+          listingMediaState(
+            "listing-media-desktop-empty",
+            "Desktop empty image manager",
+            "A listing with no owned photos and its available upload dropzone.",
+            "/dashboard/listings?size=10&query=Bee-ba-tized",
+            false,
+          ),
+          listingMediaState(
+            "listing-media-mobile-empty",
+            "Mobile empty image manager",
+            "The empty owned-photo state and upload dropzone on a phone.",
+            "/dashboard/listings?size=10&query=Bee-ba-tized",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Inspect a photo",
+        states: [
+          listingMediaState(
+            "listing-media-desktop-preview",
+            "Desktop full-size preview",
+            "A listing photo opened in the real gallery preview.",
+            "/dashboard/listings?size=10&query=18-33",
+            false,
+          ),
+          listingMediaState(
+            "listing-media-mobile-preview",
+            "Mobile full-size preview",
+            "The same gallery preview at the phone viewport.",
+            "/dashboard/listings?size=10&query=18-33",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Prepare a change",
+        states: [
+          listingMediaState(
+            "listing-media-delete-confirmation",
+            "Delete image confirmation",
+            "The destructive confirmation before any listing photo is removed.",
+            "/dashboard/listings?size=10&query=18-33",
+            false,
+          ),
+          listingMediaState(
+            "listing-media-reorder-active",
+            "Pointer reorder target",
+            "The first photo held between the first two slots with the sortable control active, before dropping.",
+            "/dashboard/listings?size=10&query=18-33",
+            false,
+          ),
+          listingMediaState(
+            "listing-media-desktop-crop",
+            "Desktop selected-file crop",
+            "A local image selected for cropping before any upload request.",
+            "/dashboard/listings?size=10&query=Bee-ba-tized",
+            false,
+          ),
+          listingMediaState(
+            "listing-media-mobile-crop",
+            "Mobile selected-file crop",
+            "The same pre-upload crop controls on a phone.",
+            "/dashboard/listings?size=10&query=Bee-ba-tized",
             false,
           ),
         ],

--- a/apps/main/src/components/image-preview-dialog.tsx
+++ b/apps/main/src/components/image-preview-dialog.tsx
@@ -2,7 +2,13 @@
 
 import { Expand } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { ImageGallery } from "@/components/image-gallery";
 import { cn } from "@/lib/utils";
 import type { OptimizedImageSource } from "@/components/optimized-image";
@@ -39,6 +45,11 @@ export function ImagePreviewDialog({
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-xl">
+        <DialogTitle className="sr-only">Image preview</DialogTitle>
+        <DialogDescription className="sr-only">
+          Full-size preview of {images.length} image
+          {images.length === 1 ? "." : "s."}
+        </DialogDescription>
         <ImageGallery images={images} />
       </DialogContent>
     </Dialog>

--- a/apps/main/tests/atlas/listing-media.atlas.ts
+++ b/apps/main/tests/atlas/listing-media.atlas.ts
@@ -1,0 +1,203 @@
+import path from "node:path";
+import type { Page } from "@playwright/test";
+import { DashboardListings } from "../e2e/pages/dashboard-listings";
+import { EditListingDialog } from "../e2e/pages/edit-listing-dialog";
+import { ImageManager } from "../e2e/pages/image-manager";
+import { captureAtlasState, expect, test } from "./atlas-test";
+
+const desktop = { height: 768, width: 1024 };
+const mobile = { height: 874, width: 402 };
+const populatedListingTitle = "18-33";
+const emptyListingTitle = "Bee-ba-tized";
+const uploadPath = path.resolve(
+  import.meta.dirname,
+  "../../public/assets/catalog-blooms.webp",
+);
+
+async function openListingMedia(
+  page: Page,
+  viewport: typeof desktop,
+  listingTitle: string,
+  expectedImageCount: number,
+) {
+  await page.setViewportSize(viewport);
+  await page.goto(
+    `/dashboard/listings?size=10&query=${encodeURIComponent(listingTitle)}`,
+  );
+
+  const listings = new DashboardListings(page);
+  await listings.isReady();
+  await expect(listings.listingTableReady).toBeVisible({ timeout: 30_000 });
+  await expect(listings.rows()).toHaveCount(1);
+  await expect(listings.listingRow(listingTitle)).toBeVisible();
+
+  const rowAction = page.locator(
+    '[data-testid="listing-row-actions-trigger"]:visible',
+  );
+  await expect(rowAction).toHaveCount(1);
+  await rowAction.scrollIntoViewIfNeeded();
+  await rowAction.click();
+
+  const menu = page.locator(
+    '[data-slot="dropdown-menu-content"][data-state="open"]',
+  );
+  await expect(menu).toBeVisible();
+  await menu.getByTestId("listing-row-action-edit").click();
+
+  const editor = new EditListingDialog(page);
+  await editor.isReady();
+  await expect(editor.titleInput).toHaveValue(listingTitle);
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("editing") !== null,
+  );
+
+  const images = new ImageManager(page);
+  await expect(images.imageItems()).toHaveCount(expectedImageCount);
+  return { editor, images };
+}
+
+async function capturePopulated(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const { images } = await openListingMedia(
+    page,
+    viewport,
+    populatedListingTitle,
+    9,
+  );
+  await expect(images.imageGrid()).toBeVisible();
+  await captureAtlasState(page, stateId);
+}
+
+async function captureEmpty(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const { images } = await openListingMedia(
+    page,
+    viewport,
+    emptyListingTitle,
+    0,
+  );
+  await expect(images.imageGrid()).toHaveCount(0);
+  await expect(
+    page.getByText("Drag and drop an image here, or click to select one", {
+      exact: true,
+    }),
+  ).toBeVisible();
+  await captureAtlasState(page, stateId);
+}
+
+async function capturePreview(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const { images } = await openListingMedia(
+    page,
+    viewport,
+    populatedListingTitle,
+    9,
+  );
+  const firstImageId = await images
+    .imageItems()
+    .first()
+    .getAttribute("data-image-id");
+  if (!firstImageId) throw new Error("Expected a seeded listing image id.");
+
+  await images.openImagePreviewById(firstImageId);
+  await expect(page.getByRole("img", { name: "Gallery image" })).toBeVisible();
+  await captureAtlasState(page, stateId);
+}
+
+async function captureCrop(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  await openListingMedia(page, viewport, emptyListingTitle, 0);
+  await page.locator("#image-upload-input").setInputFiles(uploadPath);
+  await expect(page.getByRole("img", { name: "Crop preview" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Upload" })).toBeEnabled();
+  await captureAtlasState(page, stateId);
+}
+
+test("Desktop populated image grid", async ({ page }) => {
+  await capturePopulated(page, desktop, "listing-media-desktop-populated");
+});
+
+test("Mobile populated image grid", async ({ page }) => {
+  await capturePopulated(page, mobile, "listing-media-mobile-populated");
+});
+
+test("Desktop empty image manager", async ({ page }) => {
+  await captureEmpty(page, desktop, "listing-media-desktop-empty");
+});
+
+test("Mobile empty image manager", async ({ page }) => {
+  await captureEmpty(page, mobile, "listing-media-mobile-empty");
+});
+
+test("Desktop full-size preview", async ({ page }) => {
+  await capturePreview(page, desktop, "listing-media-desktop-preview");
+});
+
+test("Mobile full-size preview", async ({ page }) => {
+  await capturePreview(page, mobile, "listing-media-mobile-preview");
+});
+
+test("Delete image confirmation", async ({ page }) => {
+  const { images } = await openListingMedia(
+    page,
+    desktop,
+    populatedListingTitle,
+    9,
+  );
+  await images.imageItems().first().getByTestId("image-delete-button").click();
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+  await captureAtlasState(page, "listing-media-delete-confirmation");
+});
+
+test("Pointer reorder target", async ({ page }) => {
+  const { images } = await openListingMedia(
+    page,
+    desktop,
+    populatedListingTitle,
+    9,
+  );
+  const firstItem = images.imageItems().first();
+  const firstHandle = firstItem.getByTestId("image-drag-handle");
+  const handleBox = await firstHandle.boundingBox();
+  if (!handleBox) throw new Error("Expected a visible image drag handle.");
+
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2 + 100,
+    handleBox.y + handleBox.height / 2,
+    { steps: 5 },
+  );
+  await expect(firstHandle).toHaveAttribute("aria-pressed", "true");
+  await expect(firstItem.locator(":scope > div")).toHaveAttribute(
+    "style",
+    /translate3d\((?!0px)/,
+  );
+
+  await captureAtlasState(page, "listing-media-reorder-active");
+  await page.keyboard.press("Escape");
+  await page.mouse.up();
+});
+
+test("Desktop selected-file crop", async ({ page }) => {
+  await captureCrop(page, desktop, "listing-media-desktop-crop");
+});
+
+test("Mobile selected-file crop", async ({ page }) => {
+  await captureCrop(page, mobile, "listing-media-mobile-crop");
+});

--- a/apps/main/tests/image-preview-dialog.test.tsx
+++ b/apps/main/tests/image-preview-dialog.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ImagePreviewDialog } from "@/components/image-preview-dialog";
+
+vi.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt = "",
+    priority: _priority,
+    unoptimized: _unoptimized,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    priority?: boolean;
+    unoptimized?: boolean;
+  }) => React.createElement("img", { alt, ...props }),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ImagePreviewDialog", () => {
+  it("opens a named, described gallery without Radix accessibility warnings", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    render(
+      <ImagePreviewDialog
+        images={[
+          {
+            id: "image-1",
+            url: "https://media.example/image-1.jpg",
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "View 1 image" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Image preview" });
+    expect(dialog).toHaveAccessibleDescription("Full-size preview of 1 image.");
+    expect(screen.getByRole("img", { name: "Gallery image" })).toBeVisible();
+
+    const errors = consoleError.mock.calls.flat().join("\n");
+    expect(errors).not.toContain("DialogContent requires a `DialogTitle`");
+    expect(errors).not.toContain(
+      "Missing `Description` or `aria-describedby={undefined}`",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- add a realistic member Atlas flow for listing-image management
- capture ten full-page or complete-component states across mobile and desktop
- connect the flow to its existing unit, integration, and happy-path E2E confidence

## Files

- `apps/main/playwright.atlas.config.ts` registers the member-authenticated Atlas spec
- `apps/main/scripts/atlas-flows.mjs` describes the flow, steps, states, reproduction commands, and connected tests
- `apps/main/tests/atlas/listing-media.atlas.ts` captures populated, empty, preview, delete-confirmation, active-reorder, and pre-upload crop states

## Safety

- uses a disposable copy of the realistic seed
- never confirms delete or reorder
- selects a local fixture only to show the crop UI and never sends an upload
- does not change production application behavior

## Verification

- `pnpm exec vitest run --maxWorkers=1 tests/atlas-flows.test.ts`
- `node apps/main/scripts/run-atlas-flow.mjs listing-media --output=local/atlas/listing-media-pr` — 11/11 passed
- all ten generated screenshots inspected
- canonical realistic seed checksum and timestamp unchanged

## Stack

This PR intentionally targets `agent/image-preview-dialog-accessibility` / #336. The preview states require that small application accessibility fix. Merge #336 first, then retarget or merge this PR.
