### PR TITLE
Fix profile URL warning dialog

### DIFF
--- a/apps/main/src/components/slug-change-confirm-dialog.tsx
+++ b/apps/main/src/components/slug-change-confirm-dialog.tsx
@@ -2,6 +2,7 @@ import {
   AlertDialog,
   AlertDialogCancel,
   AlertDialogContent,
+  AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
@@ -36,18 +37,18 @@ export function SlugChangeConfirmDialog({
         </AlertDialogHeader>
 
         <div className="space-y-4">
-          <P>
+          <AlertDialogDescription className="text-foreground leading-7">
             Changing your profile URL can break existing links to your profile,
             including links shared previously or indexed by search engines.
-          </P>
+          </AlertDialogDescription>
           <div className="bg-muted rounded-md p-3">
-            <Muted className="flex flex-col gap-y-2">
-              <div>
+            <Muted>
+              <span className="block">
                 <span className="font-medium">Current URL: </span>
                 <InlineCode>
                   {cleanBaseUrl}/{currentSlug}
                 </InlineCode>
-              </div>
+              </span>
             </Muted>
           </div>
           <P>Do you want to unlock URL editing?</P>

--- a/apps/main/tests/slug-change-confirm-dialog.test.tsx
+++ b/apps/main/tests/slug-change-confirm-dialog.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SlugChangeConfirmDialog } from "@/components/slug-change-confirm-dialog";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SlugChangeConfirmDialog", () => {
+  it("describes the URL warning without invalid HTML or accessibility warnings", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <SlugChangeConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+        currentSlug="rolling-oaks"
+        baseUrl="https://daylilycatalog.com"
+      />,
+    );
+
+    const dialog = screen.getByRole("alertdialog", {
+      name: "Before You Edit Your URL",
+    });
+    expect
+      .soft(dialog)
+      .toHaveAccessibleDescription(
+        /Changing your profile URL can break existing links/,
+      );
+    expect(dialog).toHaveTextContent(
+      "Current URL: daylilycatalog.com/rolling-oaks",
+    );
+
+    const diagnostics = [...consoleError.mock.calls, ...consoleWarn.mock.calls]
+      .flat()
+      .join("\n");
+    expect.soft(diagnostics).not.toContain("cannot be a descendant of");
+    expect.soft(diagnostics).not.toContain("cannot contain a nested");
+    expect
+      .soft(diagnostics)
+      .not.toContain("Missing `Description` or `aria-describedby={undefined}`");
+  });
+});


### PR DESCRIPTION
## Description

Fix the profile URL unlock warning discovered during the browser-first profile Atlas audit. The dialog now has valid HTML and an accessible description, eliminating the Next hydration diagnostics and Radix missing-description warning.

## Files

- apps/main/src/components/slug-change-confirm-dialog.tsx: uses AlertDialogDescription for the warning and valid inline markup for the current URL.
- apps/main/tests/slug-change-confirm-dialog.test.tsx: verifies the visible alert dialog description and guards against the React and Radix diagnostics.

## Verification

- Focused Vitest: 1/1 passed.
- Typecheck passed.
- Visible Chrome: profile URL warning opens normally; accessible description resolves; zero Next development issues; zero hydration, invalid-nesting, or missing-description diagnostics.