### PR TITLE
Validate profile URLs before availability checks

### DIFF
--- a/apps/main/src/components/forms/profile-form.tsx
+++ b/apps/main/src/components/forms/profile-form.tsx
@@ -18,7 +18,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { type RouterOutputs } from "@/trpc/react";
 import { api } from "@/trpc/react";
 import { getBaseUrl } from "@/lib/utils/getBaseUrl";
-import { profileFormSchema } from "@/types/schemas/profile";
+import { profileFormSchema, slugSchema } from "@/types/schemas/profile";
 import { useZodForm } from "@/hooks/use-zod-form";
 import { useManagedFormSave } from "@/hooks/use-managed-form-save";
 import { useParentCommitFlag } from "@/hooks/use-parent-commit-flag";
@@ -285,22 +285,28 @@ function useProfileFormController({
 
   const debouncedCheckSlug = useDebouncedCallback(
     (value: string | null | undefined) => {
-      if (value && value !== profile.userId) {
-        setSlugState((current) => ({ ...current, isChecking: true }));
-        void checkSlug.refetch().then((result) => {
-          setSlugState((current) => ({ ...current, isChecking: false }));
-          if (result.data?.available) {
-            form.clearErrors("slug");
-            return;
-          }
-          if (result.data && !result.data.available) {
-            form.setError("slug", {
-              type: "manual",
-              message: "This URL is already taken. Please choose another one.",
-            });
-          }
-        });
+      if (
+        !value ||
+        value === profile.userId ||
+        !slugSchema.safeParse(value).success
+      ) {
+        return;
       }
+
+      setSlugState((current) => ({ ...current, isChecking: true }));
+      void checkSlug.refetch().then((result) => {
+        setSlugState((current) => ({ ...current, isChecking: false }));
+        if (result.data?.available) {
+          form.clearErrors("slug");
+          return;
+        }
+        if (result.data && !result.data.available) {
+          form.setError("slug", {
+            type: "manual",
+            message: "This URL is already taken. Please choose another one.",
+          });
+        }
+      });
     },
     500,
   );
@@ -471,7 +477,10 @@ function ProfileSlugField() {
                     field.onChange(value);
                     debouncedCheckSlug(value);
                   }}
-                  onBlur={field.onBlur}
+                  onBlur={() => {
+                    field.onBlur();
+                    void form.trigger("slug");
+                  }}
                   readOnly={!slugState.isEditingUnlocked}
                   disabled={saveState.isUpdating || !isPro}
                   placeholder={profile.userId}

--- a/apps/main/src/components/forms/profile-form.tsx
+++ b/apps/main/src/components/forms/profile-form.tsx
@@ -477,9 +477,13 @@ function ProfileSlugField() {
                     field.onChange(value);
                     debouncedCheckSlug(value);
                   }}
-                  onBlur={() => {
+                  onBlur={(event) => {
                     field.onBlur();
-                    void form.trigger("slug");
+                    if (
+                      !slugSchema.safeParse(event.currentTarget.value).success
+                    ) {
+                      void form.trigger("slug");
+                    }
                   }}
                   readOnly={!slugState.isEditingUnlocked}
                   disabled={saveState.isUpdating || !isPro}

--- a/apps/main/tests/integration/profile-slug-validation.integration.ts
+++ b/apps/main/tests/integration/profile-slug-validation.integration.ts
@@ -37,4 +37,13 @@ test("invalid profile URLs are validated before checking availability", async ({
 
   await slugInput.fill("available-profile");
   await expect.poll(() => availabilityRequests.length).toBe(1);
+
+  await slugInput.fill("dashboard");
+  await expect(
+    page.getByText("This URL is already taken. Please choose another one."),
+  ).toBeVisible();
+  await slugInput.blur();
+  await expect(
+    page.getByText("This URL is already taken. Please choose another one."),
+  ).toBeVisible();
 });

--- a/apps/main/tests/integration/profile-slug-validation.integration.ts
+++ b/apps/main/tests/integration/profile-slug-validation.integration.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "./fixtures";
+
+test("invalid profile URLs are validated before checking availability", async ({
+  page,
+}) => {
+  const availabilityRequests: string[] = [];
+  page.on("request", (request) => {
+    if (
+      decodeURIComponent(request.url()).includes(
+        "dashboardDb.userProfile.checkSlug",
+      )
+    ) {
+      availabilityRequests.push(request.url());
+    }
+  });
+
+  await page.goto("/dashboard/profile");
+  const slugInput = page.locator('input[name="slug"]');
+  await expect(slugInput).toHaveValue("integration-seller");
+
+  await slugInput.click();
+  const warning = page.getByRole("alertdialog", {
+    name: "Before You Edit Your URL",
+  });
+  await warning.getByRole("button", { name: "Unlock URL editing" }).click();
+
+  await slugInput.fill("bad");
+  await slugInput.blur();
+
+  await expect(
+    page.getByText("URL must be at least 5 characters"),
+  ).toBeVisible();
+  expect(availabilityRequests).toEqual([]);
+  await expect(
+    page.getByRole("button", { name: /Open issues overlay/i }),
+  ).toHaveCount(0);
+
+  await slugInput.fill("available-profile");
+  await expect.poll(() => availabilityRequests.length).toBe(1);
+});


### PR DESCRIPTION
## Description

Fix invalid profile URL handling discovered by the profile-management flywheel audit. Invalid local input now shows inline feedback before any availability request, preventing the failed tRPC query from becoming a Next development issue.

This PR is temporarily stacked on #340 so both discovered profile issues can be verified together. After #340 merges, retarget this PR to main.

## Files

- apps/main/src/components/forms/profile-form.tsx: validates the slug on blur and skips remote availability checks until the shared slug schema accepts the value.
- apps/main/tests/integration/profile-slug-validation.integration.ts: drives the real authenticated profile UI, proves invalid input stays local with no Next issue, and proves valid input still checks availability.

## Verification

- RED: the integration test failed because no inline error appeared; the invalid value reached tRPC and created a browser error.
- GREEN: focused full-app integration passed in 3.7s.
- Typecheck passed.
- Focused Prettier check passed.