### PR TITLE
Prioritize profile gallery images

### DIFF
--- a/apps/main/src/app/dashboard/profile/_components/profile-image-manager.tsx
+++ b/apps/main/src/app/dashboard/profile/_components/profile-image-manager.tsx
@@ -18,6 +18,7 @@ export function ProfileImageManager({
       <ImageManager
         type="profile"
         images={images}
+        prioritizeImages
         referenceId={profileId}
         onMutationSuccess={onMutationSuccess}
       />

--- a/apps/main/src/components/image-manager.tsx
+++ b/apps/main/src/components/image-manager.tsx
@@ -42,6 +42,7 @@ interface ImageManagerProps {
   images: ImageCollectionItem[];
   onImagesChange?: (images: ImageCollectionItem[]) => void;
   onMutationSuccess?: () => void;
+  prioritizeImages?: boolean;
   referenceId: string;
   type: ImageType;
 }
@@ -49,12 +50,14 @@ interface ImageManagerProps {
 function SortableImage({
   image,
   dragControls,
+  priority,
 }: {
   image: ImageCollectionItem;
   dragControls: (
     attributes: DraggableAttributes,
     listeners: Record<string, unknown>,
   ) => React.ReactNode;
+  priority: boolean;
 }) {
   const {
     attributes,
@@ -78,6 +81,7 @@ function SortableImage({
         alt="Daylily image"
         size="thumbnail"
         className="rounded-lg border"
+        priority={priority}
       />
       {dragControls(attributes ?? {}, listeners ?? {})}
     </div>
@@ -88,6 +92,7 @@ export function ImageManager({
   images,
   onImagesChange,
   onMutationSuccess,
+  prioritizeImages = false,
   referenceId,
   type,
 }: ImageManagerProps) {
@@ -199,6 +204,7 @@ export function ImageManager({
               >
                 <SortableImage
                   image={image}
+                  priority={prioritizeImages}
                   dragControls={(attributes, listeners) => (
                     <>
                       <Button

--- a/apps/main/tests/image-manager-priority.test.tsx
+++ b/apps/main/tests/image-manager-priority.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ImageManager } from "@/components/image-manager";
+import type { ImageCollectionItem } from "@/app/dashboard/_lib/dashboard-db/images-collection";
+
+vi.mock("@/app/dashboard/_lib/dashboard-db/images-collection", () => ({
+  deleteImage: vi.fn(),
+  reorderImages: vi.fn(),
+}));
+
+const images: ImageCollectionItem[] = ["first", "second"].map((id, order) => ({
+  id,
+  url: `/assets/${id}.webp`,
+  order,
+  listingId: null,
+  userProfileId: "profile-1",
+  status: null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+}));
+
+describe("ImageManager image priority", () => {
+  it("loads every managed image eagerly when the gallery opts in", () => {
+    render(
+      <ImageManager
+        images={images}
+        referenceId="profile-1"
+        type="profile"
+        prioritizeImages
+      />,
+    );
+
+    for (const image of screen.getAllByRole("img", {
+      name: "Daylily image",
+    })) {
+      expect(image).toHaveAttribute("loading", "eager");
+      expect(image).toHaveAttribute("fetchpriority", "high");
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fix the profile-gallery LCP warning discovered by the profile-management Atlas diagnostic gate. Profile galleries contain at most five thumbnails and now opt those images into eager, high-priority loading; listing image managers retain their lazy default.

This PR is temporarily stacked on #341, which is stacked on #340. After the prerequisites merge, retarget this PR to main.

## Files

- apps/main/src/app/dashboard/profile/_components/profile-image-manager.tsx: opts the bounded profile gallery into prioritized loading.
- apps/main/src/components/image-manager.tsx: adds an opt-in priority path while preserving the existing lazy default for all other galleries.
- apps/main/tests/image-manager-priority.test.tsx: verifies every image becomes eager/high priority only when the manager opts in.

## Verification

- RED: the focused test showed both managed images rendered loading=lazy and fetchpriority=auto.
- GREEN: focused Vitest passed 1/1.
- Typecheck passed.
- Focused Prettier check and diff check passed.