### PR TITLE
Add the profile management Atlas flow

### DIFF
--- a/apps/main/playwright.atlas.config.ts
+++ b/apps/main/playwright.atlas.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
         "listing-management.atlas.ts",
         "listing-media.atlas.ts",
         "list-management.atlas.ts",
+        "profile-management.atlas.ts",
       ],
       dependencies: ["member-auth"],
       use: { storageState: authState },

--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -20,6 +20,7 @@ const listingState = stateFor("tests/atlas/listing-management.atlas.ts");
 const listingMediaState = stateFor("tests/atlas/listing-media.atlas.ts");
 const listState = stateFor("tests/atlas/list-management.atlas.ts");
 const buyerState = stateFor("tests/atlas/buyer-inquiry.atlas.ts");
+const profileState = stateFor("tests/atlas/profile-management.atlas.ts");
 const testRef = (layer, file) => ({
   path: file,
   command:
@@ -389,6 +390,114 @@ export const ATLAS_FLOWS = [
             "Checkout review",
             "The account email and membership terms immediately before Stripe.",
             "/onboarding?step=checkout",
+            false,
+          ),
+        ],
+      },
+    ],
+  },
+  {
+    id: "profile-management",
+    audience: "member",
+    title: "Manage a grower profile",
+    description:
+      "Review realistic grower details, prepare profile edits, and inspect profile media at mobile and iPad sizes without saving changes.",
+    tests: {
+      unit: [testRef("unit", "tests/profile-slug-rules.test.ts")],
+      integration: [
+        testRef("integration", "tests/slug-change-confirm-dialog.test.tsx"),
+        testRef(
+          "integration",
+          "tests/dashboard-db-user-profile-router.test.ts",
+        ),
+        testRef(
+          "integration",
+          "tests/dashboard-db-user-profile-slug-router.test.ts",
+        ),
+        testRef("integration", "tests/image-preview-dialog.test.tsx"),
+      ],
+      e2e: [testRef("e2e", "tests/e2e/new-user-journey.e2e.ts")],
+    },
+    steps: [
+      {
+        title: "Review the profile",
+        states: [
+          profileState(
+            "profile-management-desktop-populated",
+            "Desktop populated profile",
+            "Realistic grower details, five profile images, and catalog content at the supported iPad width.",
+            "/dashboard/profile",
+          ),
+          profileState(
+            "profile-management-mobile-populated",
+            "Mobile populated profile",
+            "The same realistic grower profile and media at the supported phone width.",
+            "/dashboard/profile",
+          ),
+        ],
+      },
+      {
+        title: "Prepare profile edits",
+        states: [
+          profileState(
+            "profile-management-desktop-dirty",
+            "Desktop unsaved profile edit",
+            "A changed garden name with Save Changes enabled, before any mutation.",
+            "/dashboard/profile",
+            false,
+          ),
+          profileState(
+            "profile-management-mobile-dirty",
+            "Mobile unsaved profile edit",
+            "The same unsaved profile state at the supported phone width.",
+            "/dashboard/profile",
+            false,
+          ),
+          profileState(
+            "profile-management-desktop-url-warning",
+            "Desktop profile URL warning",
+            "The described warning shown before profile URL editing is unlocked.",
+            "/dashboard/profile",
+            false,
+          ),
+          profileState(
+            "profile-management-mobile-url-warning",
+            "Mobile profile URL warning",
+            "The same profile URL warning at the supported phone width.",
+            "/dashboard/profile",
+            false,
+          ),
+          profileState(
+            "profile-management-desktop-url-invalid",
+            "Desktop invalid profile URL",
+            "Inline minimum-length feedback for an unsaved profile URL.",
+            "/dashboard/profile",
+            false,
+          ),
+          profileState(
+            "profile-management-mobile-url-invalid",
+            "Mobile invalid profile URL",
+            "The same invalid profile URL feedback at the supported phone width.",
+            "/dashboard/profile",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Inspect profile media",
+        states: [
+          profileState(
+            "profile-management-desktop-preview",
+            "Desktop profile image preview",
+            "A seeded profile image opened in the complete gallery preview.",
+            "/dashboard/profile",
+            false,
+          ),
+          profileState(
+            "profile-management-mobile-preview",
+            "Mobile profile image preview",
+            "The same gallery preview at the supported phone width.",
+            "/dashboard/profile",
             false,
           ),
         ],

--- a/apps/main/tests/atlas-flows.test.ts
+++ b/apps/main/tests/atlas-flows.test.ts
@@ -72,6 +72,23 @@ describe("Atlas flow contract", () => {
     );
   });
 
+  it("declares the profile-management journey at both supported sizes", () => {
+    const profile = getAtlasFlow("profile-management");
+
+    expect(profile.steps.map(({ title }) => title)).toEqual([
+      "Review the profile",
+      "Prepare profile edits",
+      "Inspect profile media",
+    ]);
+    expect(statesForFlow(profile)).toHaveLength(10);
+    expect(
+      getAtlasState("profile-management-desktop-populated").urlReproducible,
+    ).toBe(true);
+    expect(
+      getAtlasState("profile-management-mobile-url-warning").urlReproducible,
+    ).toBe(false);
+  });
+
   it("provides copy-paste confidence commands for a complete flow", () => {
     expect(confidenceCommandsForFlow(getAtlasFlow("list-management"))).toEqual([
       "pnpm main exec vitest run --maxWorkers=1 tests/manage-list-columns.test.ts tests/add-listings-combobox.test.tsx tests/dashboard-db-list-membership-sync.test.tsx tests/list-form-boundary-save.test.tsx tests/manage-list-page-membership-commit.test.tsx tests/use-list-resource.test.tsx",
@@ -99,12 +116,12 @@ describe("Atlas flow contract", () => {
       "Inspect a cultivar",
     ]);
     expect(statesForFlow(cultivarSearch)).toHaveLength(14);
-    expect(getAtlasState("cultivar-search-desktop-info-card").urlReproducible).toBe(
-      false,
-    );
-    expect(getAtlasState("cultivar-search-mobile-info-card").urlReproducible).toBe(
-      false,
-    );
+    expect(
+      getAtlasState("cultivar-search-desktop-info-card").urlReproducible,
+    ).toBe(false);
+    expect(
+      getAtlasState("cultivar-search-mobile-info-card").urlReproducible,
+    ).toBe(false);
   });
 
   it.each([

--- a/apps/main/tests/atlas/profile-management.atlas.ts
+++ b/apps/main/tests/atlas/profile-management.atlas.ts
@@ -1,0 +1,156 @@
+import type { Page } from "@playwright/test";
+import { DashboardProfile } from "../e2e/pages/dashboard-profile";
+import { ImageManager } from "../e2e/pages/image-manager";
+import { captureAtlasState, expect, test } from "./atlas-test";
+
+const desktop = { height: 768, width: 1024 };
+const mobile = { height: 874, width: 402 };
+
+async function openProfile(page: Page, viewport: typeof desktop) {
+  await page.setViewportSize(viewport);
+  await page.goto("/dashboard/profile");
+
+  const profile = new DashboardProfile(page);
+  await profile.isReady();
+  await expect(profile.gardenNameInput).not.toHaveValue("");
+  await expect(profile.slugInput).not.toHaveValue("");
+  await expect(profile.saveChangesButton).toBeDisabled();
+  await expect(profile.contentEditor).toBeVisible();
+
+  const images = new ImageManager(page);
+  await expect(images.imageItems()).toHaveCount(5);
+  return { images, profile };
+}
+
+async function capturePopulated(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  await openProfile(page, viewport);
+  await captureAtlasState(page, stateId);
+}
+
+async function captureDirty(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const { profile } = await openProfile(page, viewport);
+  await profile.gardenNameInput.fill("Rolling Oaks Daylilies — Unsaved");
+  await expect(profile.saveChangesButton).toBeEnabled();
+  await captureAtlasState(page, stateId);
+}
+
+async function openUrlWarning(page: Page, viewport: typeof desktop) {
+  const { profile } = await openProfile(page, viewport);
+  await profile.slugInput.click();
+
+  const dialog = page.getByRole("alertdialog", {
+    name: "Before You Edit Your URL",
+  });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText(
+    "Changing your profile URL can break existing links",
+  );
+  return { dialog, profile };
+}
+
+async function captureUrlWarning(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  await openUrlWarning(page, viewport);
+  await captureAtlasState(page, stateId);
+}
+
+async function captureInvalidUrl(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const { dialog, profile } = await openUrlWarning(page, viewport);
+  await dialog.getByRole("button", { name: "Unlock URL editing" }).click();
+  await expect(dialog).toBeHidden();
+  await profile.slugInput.fill("bad");
+  await profile.slugInput.blur();
+  await expect(
+    page.getByText("URL must be at least 5 characters"),
+  ).toBeVisible();
+  await expect(profile.saveChangesButton).toBeEnabled();
+  await captureAtlasState(page, stateId);
+}
+
+async function capturePreview(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const { images } = await openProfile(page, viewport);
+  const firstImageId = await images
+    .imageItems()
+    .first()
+    .getAttribute("data-image-id");
+  if (!firstImageId) throw new Error("Expected a seeded profile image id.");
+
+  await images.openImagePreviewById(firstImageId);
+  await expect(page.getByRole("img", { name: "Gallery image" })).toBeVisible();
+  await captureAtlasState(page, stateId);
+}
+
+test("Desktop populated profile", async ({ page }) => {
+  await capturePopulated(page, desktop, "profile-management-desktop-populated");
+});
+
+test("Mobile populated profile", async ({ page }) => {
+  await capturePopulated(page, mobile, "profile-management-mobile-populated");
+});
+
+test("Desktop unsaved profile edit", async ({ page }) => {
+  await captureDirty(page, desktop, "profile-management-desktop-dirty");
+});
+
+test("Mobile unsaved profile edit", async ({ page }) => {
+  await captureDirty(page, mobile, "profile-management-mobile-dirty");
+});
+
+test("Desktop profile URL warning", async ({ page }) => {
+  await captureUrlWarning(
+    page,
+    desktop,
+    "profile-management-desktop-url-warning",
+  );
+});
+
+test("Mobile profile URL warning", async ({ page }) => {
+  await captureUrlWarning(
+    page,
+    mobile,
+    "profile-management-mobile-url-warning",
+  );
+});
+
+test("Desktop invalid profile URL", async ({ page }) => {
+  await captureInvalidUrl(
+    page,
+    desktop,
+    "profile-management-desktop-url-invalid",
+  );
+});
+
+test("Mobile invalid profile URL", async ({ page }) => {
+  await captureInvalidUrl(
+    page,
+    mobile,
+    "profile-management-mobile-url-invalid",
+  );
+});
+
+test("Desktop profile image preview", async ({ page }) => {
+  await capturePreview(page, desktop, "profile-management-desktop-preview");
+});
+
+test("Mobile profile image preview", async ({ page }) => {
+  await capturePreview(page, mobile, "profile-management-mobile-preview");
+});


### PR DESCRIPTION
## What changed

Adds a realistic, non-mutating profile-management Atlas flow at the supported mobile and iPad widths. It captures populated, dirty, URL warning, invalid URL, and image-preview states and links the flow to its existing confidence tests.

## Why

Agents need one place to inspect the complete profile-management UI before and after changes, while using the same controls and realistic data a member sees.

## Files

- `apps/main/playwright.atlas.config.ts` registers the authenticated profile-management Atlas spec.
- `apps/main/scripts/atlas-flows.mjs` defines the flow, its three user steps, ten screenshots, reproduction metadata, and unit/integration/E2E confidence links.
- `apps/main/tests/atlas-flows.test.ts` verifies the flow contract, supported viewports, and URL-reproducible versus interaction-only states.
- `apps/main/tests/atlas/profile-management.atlas.ts` uses the real profile UI to capture populated, unsaved, URL-warning, invalid-URL, and image-preview states without saving mutations.

## Verification

- `pnpm main test -- tests/atlas-browser-diagnostics.test.ts tests/atlas-flows.test.ts` — 19/19 passed
- `pnpm typecheck` — passed
- Prettier and `git diff --check` — passed
- Complete Atlas run — 11/11 passed in 1.3 minutes
- Ten screenshots inspected; only the expected Clerk development-key diagnostic was present