### PR TITLE
Prioritize visible catalog search images

### DIFF
--- a/apps/main/src/components/public-catalog-search/public-catalog-search-table.tsx
+++ b/apps/main/src/components/public-catalog-search/public-catalog-search-table.tsx
@@ -25,9 +25,12 @@ export function PublicCatalogSearchTable({
           : "lg:grid-cols-3 xl:grid-cols-3",
       )}
     >
-      {rows.map((row) => (
+      {rows.map((row, index) => (
         <div key={row.original.id}>
-          <ListingCard listing={row.original} />
+          <ListingCard
+            listing={row.original}
+            priority={index < desktopColumns}
+          />
         </div>
       ))}
     </div>

--- a/apps/main/tests/public-catalog-search-table-image-priority.test.tsx
+++ b/apps/main/tests/public-catalog-search-table-image-priority.test.tsx
@@ -1,0 +1,55 @@
+import { render } from "@testing-library/react";
+import type { Table } from "@tanstack/react-table";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PublicCatalogSearchTable } from "@/components/public-catalog-search/public-catalog-search-table";
+import type { PublicCatalogListing } from "@/components/public-catalog-search/public-catalog-search-types";
+
+const mockListingCard = vi.fn();
+
+vi.mock("@/components/listing-card", () => ({
+  ListingCard: ({
+    listing,
+    priority,
+  }: {
+    listing: PublicCatalogListing;
+    priority?: boolean;
+  }) => {
+    mockListingCard({ id: listing.id, priority });
+    return <div>{listing.id}</div>;
+  },
+}));
+
+describe("PublicCatalogSearchTable image priority", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { desktopColumns: 2 as const, priorities: [true, true, false, false] },
+    { desktopColumns: 3 as const, priorities: [true, true, true, false] },
+  ])(
+    "prioritizes only the first visible $desktopColumns-column desktop row",
+    ({ desktopColumns, priorities }) => {
+      const listings = ["first", "second", "third", "fourth"].map((id) => ({
+        id,
+      })) as PublicCatalogListing[];
+      const table = {
+        getRowModel: () => ({
+          rows: listings.map((original) => ({ original })),
+        }),
+      } as unknown as Table<PublicCatalogListing>;
+
+      render(
+        <PublicCatalogSearchTable
+          table={table}
+          desktopColumns={desktopColumns}
+        />,
+      );
+
+      expect(
+        mockListingCard.mock.calls.map(([props]) => props.priority),
+      ).toEqual(priorities);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- prioritize only the first visible desktop row of public catalog search images
- keep later listing rows lazy-loaded
- remove the reproduced Next.js LCP warning without changing the rendered UI

## Files
- `apps/main/src/components/public-catalog-search/public-catalog-search-table.tsx`: passes image priority to ListingCard for the first row using the known desktop column count
- `apps/main/tests/public-catalog-search-table-image-priority.test.tsx`: verifies the 2-column and 3-column priority boundaries

## Verification
- focused component test: 2 passed
- full Vitest suite: 589 passed
- typecheck: passed
- lint: passed with one pre-existing unrelated warning
- visible Chrome: reproduced warning before; identical Absolute Ripper search reload had no warning after
- Atlas: Search results, Advanced filters, and Search page two now pass with inspected full-page screenshots