### PR TITLE
Defer EditorJS read-only mode until ready

### DIFF
--- a/apps/main/src/components/editor.tsx
+++ b/apps/main/src/components/editor.tsx
@@ -73,7 +73,7 @@ export function Editor({
         },
         placeholder: "Type something...",
         inlineToolbar: true,
-        readOnly: readOnly,
+        readOnly: false,
         data: initialContentRef.current,
         tools: {
           header: {
@@ -91,6 +91,18 @@ export function Editor({
       });
 
       editorRef.current = editor;
+
+      if (readOnly) {
+        void editor.isReady
+          .then(() => {
+            if (isCancelled || editorRef.current !== editor) {
+              return;
+            }
+
+            return editor.readOnly.toggle(true);
+          })
+          .catch(() => undefined);
+      }
     })();
 
     return () => {

--- a/apps/main/tests/editor-read-only.test.tsx
+++ b/apps/main/tests/editor-read-only.test.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { act, render, waitFor } from "@testing-library/react";
+import type EditorJS from "@editorjs/editorjs";
+import type { EditorConfig } from "@editorjs/editorjs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Editor } from "@/components/editor";
+
+const editorState = vi.hoisted(() => ({
+  config: undefined as EditorConfig | undefined,
+  destroy: vi.fn(),
+  ready: Promise.resolve(),
+  resolveReady: (() => undefined) as () => void,
+  toggleReadOnly: vi.fn(),
+}));
+
+vi.mock("@editorjs/editorjs", () => ({
+  default: class EditorJSMock {
+    isReady = editorState.ready;
+    destroy = editorState.destroy;
+    readOnly = { toggle: editorState.toggleReadOnly };
+
+    constructor(config: EditorConfig) {
+      editorState.config = config;
+    }
+  },
+}));
+
+vi.mock("@editorjs/header", () => ({ default: class Header {} }));
+vi.mock("@editorjs/table", () => ({ default: class Table {} }));
+vi.mock("@editorjs/list", () => ({ default: class List {} }));
+vi.mock("@editorjs/inline-code", () => ({ default: class InlineCode {} }));
+
+describe("Editor read-only lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    editorState.config = undefined;
+    editorState.ready = new Promise<void>((resolve) => {
+      editorState.resolveReady = resolve;
+    });
+  });
+
+  it("enters read-only mode only after EditorJS is ready", async () => {
+    const editorRef = React.createRef<EditorJS | null>();
+
+    render(<Editor editorRef={editorRef} readOnly />);
+
+    await waitFor(() => expect(editorState.config).toBeDefined());
+
+    expect(editorState.config?.readOnly).not.toBe(true);
+    expect(editorState.toggleReadOnly).not.toHaveBeenCalled();
+
+    await act(async () => {
+      editorState.resolveReady();
+      await editorState.ready;
+    });
+
+    await waitFor(() =>
+      expect(editorState.toggleReadOnly).toHaveBeenCalledWith(true),
+    );
+  });
+
+  it("does not toggle read-only after unmount", async () => {
+    const editorRef = React.createRef<EditorJS | null>();
+    const { unmount } = render(<Editor editorRef={editorRef} readOnly />);
+
+    await waitFor(() => expect(editorState.config).toBeDefined());
+    unmount();
+
+    await act(async () => {
+      editorState.resolveReady();
+      await editorState.ready;
+    });
+
+    expect(editorState.toggleReadOnly).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- avoid EditorJS initializing read-only mode before its Toolbox event subscription exists
- enable read-only through the EditorJS API immediately after readiness
- guard the readiness continuation against unmount and catch toggle failures
- remove the reproduced public-catalog EventDispatcher warning without changing the rendered About content

## Files
- `apps/main/src/components/editor.tsx`: defers read-only activation until EditorJS is ready while preserving editable-form behavior
- `apps/main/tests/editor-read-only.test.tsx`: verifies post-ready activation and unmount-before-ready cancellation

## Verification
- focused component tests: 2 passed
- full Vitest suite: 589 passed
- typecheck: passed
- lint: passed with one pre-existing unrelated warning
- visible Chrome: Catalogs → PlantFancyGardens produced no warning; About had no editable nodes or toolbar immediately or after 1.2s
- Atlas: no EventDispatcher/editor warning in the fresh public-catalog run; unrelated image-decode/LCP/404 diagnostics remain separate slices