### PR TITLE
Cover list management in full-app integration

### DIFF
--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -55,6 +55,7 @@ export const ATLAS_FLOWS = [
       e2e: [
         testRef("e2e", "tests/e2e/public-catalog-advanced-search.e2e.ts"),
         testRef("e2e", "tests/e2e/cultivar-page-flow.e2e.ts"),
+        testRef("e2e", "tests/e2e/public-profile-first-response.e2e.ts"),
         testRef("e2e", "tests/e2e/smoke.e2e.ts"),
       ],
     },
@@ -539,6 +540,7 @@ export const ATLAS_FLOWS = [
         ),
       ],
       e2e: [
+        testRef("e2e", "tests/e2e/dashboard-listings-search-touch.e2e.ts"),
         testRef("e2e", "tests/e2e/listings-page-features.e2e.ts"),
         testRef("e2e", "tests/e2e/create-edit-listing-flow.e2e.ts"),
       ],
@@ -860,6 +862,9 @@ export const ATLAS_FLOWS = [
           "tests/manage-list-page-membership-commit.test.tsx",
         ),
         testRef("integration", "tests/use-list-resource.test.tsx"),
+        fullAppIntegrationRef(
+          "tests/integration/list-management.integration.ts",
+        ),
       ],
       e2e: [
         testRef("e2e", "tests/e2e/lists-page-features.e2e.ts"),

--- a/apps/main/tests/atlas-flows.test.ts
+++ b/apps/main/tests/atlas-flows.test.ts
@@ -92,6 +92,7 @@ describe("Atlas flow contract", () => {
   it("provides copy-paste confidence commands for a complete flow", () => {
     expect(confidenceCommandsForFlow(getAtlasFlow("list-management"))).toEqual([
       "pnpm main exec vitest run --maxWorkers=1 tests/manage-list-columns.test.ts tests/add-listings-combobox.test.tsx tests/dashboard-db-list-membership-sync.test.tsx tests/list-form-boundary-save.test.tsx tests/manage-list-page-membership-commit.test.tsx tests/use-list-resource.test.tsx",
+      "node apps/main/scripts/run-integration-local.mjs tests/integration/list-management.integration.ts",
       "pnpm main exec playwright test --retries=0 tests/e2e/lists-page-features.e2e.ts tests/e2e/manage-list-page-features.e2e.ts",
     ]);
   });

--- a/apps/main/tests/integration/list-management.integration.ts
+++ b/apps/main/tests/integration/list-management.integration.ts
@@ -1,0 +1,67 @@
+import { DashboardLists } from "../e2e/pages/dashboard-lists";
+import { ManageListPage } from "../e2e/pages/manage-list-page";
+import { expect, test } from "./fixtures";
+
+test("seller creates and manages a list through the app", async ({ page }) => {
+  const createdTitle = "Integration Created List";
+  const editedTitle = "Integration Managed List";
+  const description = "A list saved through the real application.";
+  const listingTitle = "Existing Bloom";
+  const lists = new DashboardLists(page);
+  const manageList = new ManageListPage(page);
+  const toast = (message: string) =>
+    page.locator("[data-sonner-toast]").filter({ hasText: message }).first();
+
+  await lists.goto();
+  await lists.isReady();
+
+  await lists.createListButton.click();
+  const createSurface = lists.createSurface();
+  await expect(createSurface).toBeVisible();
+  await createSurface.getByLabel("Title").fill(createdTitle);
+  await createSurface
+    .getByRole("button", { name: "Create List", exact: true })
+    .click();
+  await expect(toast("List created")).toBeVisible();
+
+  const editingId = new URL(page.url()).searchParams.get("editing");
+  expect(editingId).toBeTruthy();
+
+  await expect(lists.editDialog()).toBeVisible();
+  await lists.editTitleInput().fill(editedTitle);
+  await lists.editDescriptionInput().fill(description);
+  await lists.surfaceSaveButton().click();
+  await expect(toast("List updated")).toBeVisible();
+  await expect(lists.editDialog()).toBeHidden();
+
+  await lists.setGlobalSearch(editedTitle);
+  await expect(lists.listRow(editedTitle)).toBeVisible();
+  await lists.openFirstVisibleRowActions();
+  const manageHref = await lists.manageRowActionHref();
+  expect(manageHref).toBe(`/dashboard/lists/${editingId}`);
+
+  await page.goto(manageHref!);
+  await expect(manageList.heading).toContainText(editedTitle);
+  await expect(manageList.titleInput).toHaveValue(editedTitle);
+  await expect(manageList.descriptionInput).toHaveValue(description);
+  await expect(manageList.addListingsTrigger).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "No listings", exact: true }),
+  ).toBeVisible();
+
+  await manageList.openAddListingsDialog();
+  await manageList.searchAddListings(listingTitle);
+  await manageList.selectListingToAdd(listingTitle);
+  await expect(manageList.listingRow(listingTitle)).toBeVisible();
+  await expect(manageList.saveChangesButton).toBeEnabled();
+  await manageList.saveChanges();
+  await expect(toast("List updated")).toBeVisible();
+  await expect(manageList.saveChangesButton).toBeDisabled();
+
+  await page.reload();
+  await manageList.isReady();
+  await expect(manageList.heading).toContainText(editedTitle);
+  await expect(manageList.titleInput).toHaveValue(editedTitle);
+  await expect(manageList.descriptionInput).toHaveValue(description);
+  await expect(manageList.listingRow(listingTitle)).toBeVisible();
+});

--- a/apps/main/tests/integration/list-management.integration.ts
+++ b/apps/main/tests/integration/list-management.integration.ts
@@ -23,6 +23,7 @@ test("seller creates and manages a list through the app", async ({ page }) => {
     .getByRole("button", { name: "Create List", exact: true })
     .click();
   await expect(toast("List created")).toBeVisible();
+  await expect(page).toHaveURL(/\/dashboard\/lists\?editing=[^&]+$/);
 
   const editingId = new URL(page.url()).searchParams.get("editing");
   expect(editingId).toBeTruthy();


### PR DESCRIPTION
## What changed
- add one full-app Playwright integration test for creating, editing, and reloading a list through the real UI
- prove adding an existing listing persists after save and page reload
- expose the new test from the list-management Atlas flow
- expose the existing public-profile first-response and iPad listing-search E2E tests from their relevant Atlas flows

## Why
List management had focused component tests and connected E2E coverage, but no fast full-app integration path. This gives agents an offline-from-third-parties browser confidence loop for the core list workflow while keeping the connected E2Es intact.

## Verification
- new full-app test: 1/1 passed in 5.6s browser time
- complete full-app integration suite: 8/8 passed in 37.0s
- Atlas registry contract: 15/15 passed
- TypeScript typecheck
- Prettier check
- git diff --check

Test and Atlas tooling only; no production application code changes.