### PR TITLE
Cover tag printing in full-app integration

### DIFF
--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -680,6 +680,7 @@ export const ATLAS_FLOWS = [
       integration: [
         testRef("integration", "tests/tag-designer-panel.test.tsx"),
         testRef("integration", "tests/tag-print-table.test.ts"),
+        fullAppIntegrationRef("tests/integration/tag-printing.integration.ts"),
       ],
       e2e: [],
     },

--- a/apps/main/tests/integration/tag-printing.integration.ts
+++ b/apps/main/tests/integration/tag-printing.integration.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "./fixtures";
+
+test("seller prepares a grower-details tag sheet", async ({ page }) => {
+  const listingTitle = "Existing Bloom";
+
+  await page.goto("/dashboard/tags");
+  await expect(
+    page.getByRole("heading", { name: "Choose a template" }),
+  ).toBeVisible();
+
+  await page.getByPlaceholder("Filter listings to tag...").fill(listingTitle);
+  const listingRow = page.getByRole("row", {
+    name: `Select row ${listingTitle}`,
+    exact: true,
+  });
+  await expect(listingRow).toBeVisible();
+  await listingRow.getByRole("checkbox", { name: "Select row" }).click();
+
+  await expect(page.getByText("1 selected listing.")).toBeVisible();
+  const tagPreview = page.getByRole("main").getByRole("article");
+  await expect(tagPreview).toContainText(listingTitle);
+  await expect(tagPreview).toContainText("Test Garden, 2026");
+
+  await page.getByRole("button", { name: /Grower details/i }).click();
+  await expect(page.getByLabel("Tag Size")).toHaveValue("card-2x4");
+  await expect(
+    page.getByRole("button", { name: /Grower details/i }),
+  ).toHaveAttribute("aria-pressed", "true");
+
+  await page.getByRole("button", { name: "Make sheet" }).click();
+  const sheetCreator = page.getByRole("dialog", { name: "Sheet Creator" });
+  await expect(sheetCreator).toBeVisible();
+  await expect(sheetCreator).toContainText(
+    'Tag size on sheet (fixed to active tag size): 4.00" × 2.00"',
+  );
+  await expect(sheetCreator).toContainText(
+    "1 label selected, 1 copy of each, 1 total label.",
+  );
+  await expect(sheetCreator).toContainText("1 tag per sheet, 1 sheet needed.");
+  await expect(sheetCreator.getByRole("article")).toContainText(listingTitle);
+  await expect(sheetCreator.getByRole("article")).toContainText(
+    "Test Garden, 2026",
+  );
+});


### PR DESCRIPTION
## What changed

- add one full-app integration test for selecting a listing, choosing the Grower details preset, and preparing a printable sheet
- link that test from the existing tag-printing Atlas flow

## Why

The redesigned tag page already had exhaustive Atlas screenshots and focused component coverage, but no full-app confidence that a seller could complete its central happy path through the real UI.

## Impact

This changes test and flywheel metadata only. Production application behavior is unchanged.

## Verification

- `node apps/main/scripts/run-integration-local.mjs tests/integration/tag-printing.integration.ts`
- complete full-app integration suite: 10/10 passing in 47.9s
- `pnpm --filter @daylily-catalog/main exec vitest run tests/atlas-flows.test.ts`
- `pnpm --filter @daylily-catalog/main typecheck`
- regenerated all seven tag-printing Atlas states and verified the gallery links the new full-app command
- authenticated Chrome walkthrough on the realistic seeded catalog with no application errors or Next development issues
