### PR TITLE
Add Grower ID tag template

### DIFF
--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-html.ts
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-html.ts
@@ -2,6 +2,10 @@
 
 import {
   QR_SIZE_INCHES,
+  TAG_RASTER_CELL_LINE_HEIGHT,
+  TAG_RASTER_CELL_PADDING_BOTTOM_EM,
+  TAG_RASTER_CELL_PADDING_TOP_EM,
+  TAG_RASTER_ROW_GAP_PX,
   TAG_SPACER_HEIGHT_INCHES,
   buildQrCodeSvgMarkup,
   resolveCellFontSizePx,
@@ -48,10 +52,14 @@ export function createTagPrintDocumentHtml({
 }) {
   const isRasterMode = mode === "raster";
   const rowAlignItems = isRasterMode ? "start" : "baseline";
-  const rowMarginTopPixels = isRasterMode ? 2 : 1;
-  const cellLineHeight = isRasterMode ? 1.28 : 1.2;
-  const cellPaddingTop = isRasterMode ? "0.03em" : "0";
-  const cellPaddingBottom = isRasterMode ? "0.08em" : "0";
+  const rowMarginTopPixels = isRasterMode ? TAG_RASTER_ROW_GAP_PX : 1;
+  const cellLineHeight = isRasterMode ? TAG_RASTER_CELL_LINE_HEIGHT : 1.2;
+  const cellPaddingTop = isRasterMode
+    ? `${TAG_RASTER_CELL_PADDING_TOP_EM}em`
+    : "0";
+  const cellPaddingBottom = isRasterMode
+    ? `${TAG_RASTER_CELL_PADDING_BOTTOM_EM}em`
+    : "0";
 
   const tagMarkup = tags
     .map((tag) => {
@@ -70,6 +78,7 @@ export function createTagPrintDocumentHtml({
                   widthInches,
                   hasQrCode,
                   heightInches,
+                  tag.rows,
                 ),
               };
               return `<div class="cell" style="${cellStyleAsCss(fittedCell)}">${escapeHtml(cell.text)}</div>`;
@@ -232,6 +241,7 @@ export function getSheetMarkup({
                       slotWidthInches,
                       hasQrCode,
                       slotHeightInches,
+                      tag.rows,
                     ),
                   };
                   return `<div class="cell" style="${cellStyleAsCss(fittedCell)}">${escapeHtml(cell.text)}</div>`;

--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-html.ts
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-html.ts
@@ -69,6 +69,7 @@ export function createTagPrintDocumentHtml({
                   row,
                   widthInches,
                   hasQrCode,
+                  heightInches,
                 ),
               };
               return `<div class="cell" style="${cellStyleAsCss(fittedCell)}">${escapeHtml(cell.text)}</div>`;
@@ -230,6 +231,7 @@ export function getSheetMarkup({
                       row,
                       slotWidthInches,
                       hasQrCode,
+                      slotHeightInches,
                     ),
                   };
                   return `<div class="cell" style="${cellStyleAsCss(fittedCell)}">${escapeHtml(cell.text)}</div>`;

--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-model.ts
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-model.ts
@@ -203,12 +203,21 @@ export const MIN_TAG_HEIGHT_INCHES = 0.5;
 export const MAX_TAG_HEIGHT_INCHES = 4;
 export const CSS_PIXELS_PER_INCH = 96;
 const TAG_HORIZONTAL_PADDING_INCHES = 0.16;
+export const TAG_VERTICAL_PADDING_INCHES = 0.12;
 const TAG_COLUMN_GAP_INCHES = 0.06;
 const MIN_FIT_FONT_SIZE_PX = 6;
 const AUTO_GROW_TITLE_FONT_SIZE_PX_PER_INCH = 42;
 const MAX_AUTO_GROW_TITLE_FONT_SIZE_PX = 56;
 const AVERAGE_CHARACTER_WIDTH_EM = 0.56;
 const FIT_FONT_SCALE_BUFFER = 0.95;
+export const TAG_RASTER_CELL_LINE_HEIGHT = 1.28;
+export const TAG_RASTER_CELL_PADDING_TOP_EM = 0.03;
+export const TAG_RASTER_CELL_PADDING_BOTTOM_EM = 0.08;
+export const TAG_RASTER_ROW_GAP_PX = 2;
+const TAG_RASTER_CELL_HEIGHT_EM =
+  TAG_RASTER_CELL_LINE_HEIGHT +
+  TAG_RASTER_CELL_PADDING_TOP_EM +
+  TAG_RASTER_CELL_PADDING_BOTTOM_EM;
 export const QR_SIZE_INCHES = 0.5;
 const QR_OFFSET_INCHES = 0.06;
 const QR_TEXT_GAP_INCHES = 0.04;
@@ -454,8 +463,34 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }
 
+function estimateBoldTitleWidthEm(text: string) {
+  return [...text].reduce((width, character) => {
+    if (character === " ") return width + 0.28;
+    if (character === "W") return width + 1;
+    if (character === "M" || character === "w") return width + 0.84;
+    if (character === "m") return width + 0.89;
+    if ("GOQ".includes(character)) return width + 0.79;
+    if ("ABCDHKNRUVXY".includes(character)) return width + 0.73;
+    if ("EPSZ".includes(character)) return width + 0.68;
+    if ("FJLT".includes(character)) return width + 0.62;
+    if (character === "I") return width + 0.29;
+    if (/[0-9]/.test(character)) return width + 0.56;
+    if ("bdghnopqu".includes(character)) return width + 0.62;
+    if ("aceksvxyz".includes(character)) return width + 0.56;
+    if (character === "r") return width + 0.39;
+    if ("ft".includes(character)) return width + 0.34;
+    if ("ilj".includes(character)) return width + 0.28;
+    if ("'.,:;|!-()[]".includes(character)) return width + 0.34;
+    return width + 0.95;
+  }, 0);
+}
+
 function normalizeInches(value: number) {
   return Number(value.toFixed(2));
+}
+
+function floorToHundredth(value: number) {
+  return Math.floor(value * 100) / 100;
 }
 
 function toFiniteNumber(value: unknown) {
@@ -1254,12 +1289,19 @@ export function downloadSelectedListingsCsv(
   URL.revokeObjectURL(url);
 }
 
-export function resolveCellFontSizePx(
+function shouldGrowCellToFillWidth(cell: ResolvedCell, row: ResolvedRow) {
+  return (
+    row.cells.length === 1 &&
+    cell.bold &&
+    cell.fontSize >= LARGE_LINE_FONT_SIZE_PX
+  );
+}
+
+function resolveWidthFittedCellFontSizePx(
   cell: ResolvedCell,
   row: ResolvedRow,
   tagWidthInches: number,
   hasQrCode: boolean,
-  tagHeightInches = 1,
 ) {
   const shouldFit = cell.fit ?? true;
   if (cell.wrap) return cell.fontSize;
@@ -1280,32 +1322,106 @@ export function resolveCellFontSizePx(
 
   const cellWidthInches = innerWidthInches * (cell.width / rowTotalWidthUnits);
   const cellWidthPx = Math.max(cellWidthInches * CSS_PIXELS_PER_INCH, 1);
-  const estimatedTextWidthPx =
-    Math.max(cell.text.length, 1) * cell.fontSize * AVERAGE_CHARACTER_WIDTH_EM;
-  const shouldGrowToFillWidth =
-    row.cells.length === 1 &&
-    cell.bold &&
-    cell.fontSize >= LARGE_LINE_FONT_SIZE_PX;
-  const titleHeightLimitPx = Math.min(
-    MAX_AUTO_GROW_TITLE_FONT_SIZE_PX,
-    Math.max(
-      MIN_FIT_FONT_SIZE_PX,
-      tagHeightInches * AUTO_GROW_TITLE_FONT_SIZE_PX_PER_INCH,
-    ),
-  );
+  const shouldGrowToFillWidth = shouldGrowCellToFillWidth(cell, row);
+  const estimatedTextWidthPx = shouldGrowToFillWidth
+    ? Math.max(estimateBoldTitleWidthEm(cell.text), 1) * cell.fontSize
+    : Math.max(cell.text.length, 1) *
+      cell.fontSize *
+      AVERAGE_CHARACTER_WIDTH_EM;
 
   if (!shouldGrowToFillWidth && estimatedTextWidthPx <= cellWidthPx) {
     return cell.fontSize;
   }
 
-  return Number(
+  return floorToHundredth(
     clamp(
       (cellWidthPx / estimatedTextWidthPx) *
         cell.fontSize *
         FIT_FONT_SCALE_BUFFER,
       MIN_FIT_FONT_SIZE_PX,
-      shouldGrowToFillWidth ? titleHeightLimitPx : cell.fontSize,
-    ).toFixed(2),
+      shouldGrowToFillWidth ? MAX_AUTO_GROW_TITLE_FONT_SIZE_PX : cell.fontSize,
+    ),
+  );
+}
+
+function resolveTitleHeightLimitPx(
+  rows: ResolvedRow[],
+  tagWidthInches: number,
+  hasQrCode: boolean,
+  tagHeightInches: number,
+) {
+  const titleRows = rows.filter(
+    (row) =>
+      row.cells[0] !== undefined &&
+      shouldGrowCellToFillWidth(row.cells[0], row),
+  );
+  if (titleRows.length === 0) return MAX_AUTO_GROW_TITLE_FONT_SIZE_PX;
+
+  const fixedRowsHeightPx = rows.reduce((height, row) => {
+    if (row.isSpacer) {
+      return height + TAG_SPACER_HEIGHT_INCHES * CSS_PIXELS_PER_INCH;
+    }
+    if (
+      row.cells[0] !== undefined &&
+      shouldGrowCellToFillWidth(row.cells[0], row)
+    ) {
+      return height;
+    }
+    const rowFontSize = Math.max(
+      ...row.cells.map((cell) =>
+        resolveWidthFittedCellFontSizePx(cell, row, tagWidthInches, hasQrCode),
+      ),
+      0,
+    );
+    return height + rowFontSize * TAG_RASTER_CELL_HEIGHT_EM;
+  }, 0);
+  const rowGapsHeightPx = Math.max(rows.length - 1, 0) * TAG_RASTER_ROW_GAP_PX;
+  const availableHeightPx =
+    (tagHeightInches - TAG_VERTICAL_PADDING_INCHES) * CSS_PIXELS_PER_INCH;
+  const remainingTitleHeightPx = Math.max(
+    availableHeightPx - fixedRowsHeightPx - rowGapsHeightPx,
+    0,
+  );
+  const sharedTitleFontSizePx =
+    remainingTitleHeightPx / titleRows.length / TAG_RASTER_CELL_HEIGHT_EM;
+
+  return clamp(
+    Math.min(
+      sharedTitleFontSizePx,
+      tagHeightInches * AUTO_GROW_TITLE_FONT_SIZE_PX_PER_INCH,
+      MAX_AUTO_GROW_TITLE_FONT_SIZE_PX,
+    ),
+    MIN_FIT_FONT_SIZE_PX,
+    MAX_AUTO_GROW_TITLE_FONT_SIZE_PX,
+  );
+}
+
+export function resolveCellFontSizePx(
+  cell: ResolvedCell,
+  row: ResolvedRow,
+  tagWidthInches: number,
+  hasQrCode: boolean,
+  tagHeightInches = 1,
+  rows: ResolvedRow[] = [row],
+) {
+  const widthFittedFontSize = resolveWidthFittedCellFontSizePx(
+    cell,
+    row,
+    tagWidthInches,
+    hasQrCode,
+  );
+  if (!shouldGrowCellToFillWidth(cell, row)) return widthFittedFontSize;
+
+  return floorToHundredth(
+    Math.min(
+      widthFittedFontSize,
+      resolveTitleHeightLimitPx(
+        rows,
+        tagWidthInches,
+        hasQrCode,
+        tagHeightInches,
+      ),
+    ),
   );
 }
 
@@ -1321,7 +1437,7 @@ export function getTagPreviewWarnings({
   let hasSmallText = false;
   let hasVerticalOverflow = false;
   const availableHeightPx = Math.max(
-    (heightInches - 0.12) * CSS_PIXELS_PER_INCH,
+    (heightInches - TAG_VERTICAL_PADDING_INCHES) * CSS_PIXELS_PER_INCH,
     1,
   );
 
@@ -1336,13 +1452,23 @@ export function getTagPreviewWarnings({
       }
 
       const fittedSizes = row.cells.map((cell) =>
-        resolveCellFontSizePx(cell, row, widthInches, hasQrCode, heightInches),
+        resolveCellFontSizePx(
+          cell,
+          row,
+          widthInches,
+          hasQrCode,
+          heightInches,
+          tag.rows,
+        ),
       );
       if (fittedSizes.some((fontSize) => fontSize < 10)) {
         hasSmallText = true;
       }
-      estimatedHeightPx += Math.max(...fittedSizes, 0) * 1.2;
+      estimatedHeightPx +=
+        Math.max(...fittedSizes, 0) * TAG_RASTER_CELL_HEIGHT_EM;
     }
+    estimatedHeightPx +=
+      Math.max(tag.rows.length - 1, 0) * TAG_RASTER_ROW_GAP_PX;
 
     if (estimatedHeightPx > availableHeightPx) {
       hasVerticalOverflow = true;

--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-model.ts
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-model.ts
@@ -189,6 +189,7 @@ export const TAG_SHEET_CREATOR_STORAGE_KEY = "tag-sheet-creator-state-v1";
 const TEMPLATE_DEFAULT_ID = "default-template";
 export const TEMPLATE_CUSTOM_ID = "custom-template";
 const TEMPLATE_SIMPLE_NAME_ID = "template-simple-name";
+const TEMPLATE_GROWER_ID_ID = "template-grower-id";
 const TEMPLATE_SALE_TAG_ID = "template-sale-tag";
 const TEMPLATE_GROWER_DETAILS_ID = "template-grower-details";
 const LARGE_LINE_FONT_SIZE_PX = 22;
@@ -204,6 +205,8 @@ export const CSS_PIXELS_PER_INCH = 96;
 const TAG_HORIZONTAL_PADDING_INCHES = 0.16;
 const TAG_COLUMN_GAP_INCHES = 0.06;
 const MIN_FIT_FONT_SIZE_PX = 6;
+const AUTO_GROW_TITLE_FONT_SIZE_PX_PER_INCH = 42;
+const MAX_AUTO_GROW_TITLE_FONT_SIZE_PX = 56;
 const AVERAGE_CHARACTER_WIDTH_EM = 0.56;
 const FIT_FONT_SCALE_BUFFER = 0.95;
 export const QR_SIZE_INCHES = 0.5;
@@ -350,6 +353,7 @@ function createTemplateCell(
 
 const SIMPLE_NAME_TEMPLATE = "# {{title}}";
 const GARDEN_ID_TEMPLATE = "# {{title}}\n{{hybridizerYear}}\n- {{ploidy}}";
+const GROWER_ID_TEMPLATE = "# {{title}}\n{{hybridizerYear}} {{ploidy}}";
 const SALE_TAG_TEMPLATE =
   "# {{title}}\n{{hybridizerYear}}\n## {{ploidy}} | {{price}}";
 const GROWER_DETAILS_TEMPLATE =
@@ -407,6 +411,17 @@ export const BUILTIN_TAG_LAYOUT_TEMPLATES: Array<
     id: TEMPLATE_DEFAULT_ID,
     name: "Garden ID",
     layout: DEFAULT_TAG_DESIGNER_STATE,
+  },
+  {
+    id: TEMPLATE_GROWER_ID_ID,
+    name: "Grower ID",
+    layout: {
+      sizePresetId: "brother-tze-1",
+      customWidthInches: 3.5,
+      customHeightInches: 1,
+      showQrCode: true,
+      rows: createBuiltinTemplateRows("grower-id-row", GROWER_ID_TEMPLATE),
+    },
   },
   {
     id: TEMPLATE_SALE_TAG_ID,
@@ -819,8 +834,8 @@ Return only the finished template text. Each line becomes one printed line.
 Tag size: ${widthInches.toFixed(2)}" × ${heightInches.toFixed(2)}".
 QR code: ${showQrCode ? "on; it always occupies the right side" : "off"}.
 Use no more than ${recommendedRows} nonblank rows and no more than two columns per row.
-Text never wraps and shrinks to fit its line. Start a line with:
-- # for large bold
+Text never wraps and fits to its available width. Start a line with:
+- # for a large bold title that grows to fill the available width
 - ## for medium bold
 - - for small detail text
 Use | to space columns apart. Insert listing data with {{fieldName}}
@@ -1244,6 +1259,7 @@ export function resolveCellFontSizePx(
   row: ResolvedRow,
   tagWidthInches: number,
   hasQrCode: boolean,
+  tagHeightInches = 1,
 ) {
   const shouldFit = cell.fit ?? true;
   if (cell.wrap) return cell.fontSize;
@@ -1266,8 +1282,21 @@ export function resolveCellFontSizePx(
   const cellWidthPx = Math.max(cellWidthInches * CSS_PIXELS_PER_INCH, 1);
   const estimatedTextWidthPx =
     Math.max(cell.text.length, 1) * cell.fontSize * AVERAGE_CHARACTER_WIDTH_EM;
+  const shouldGrowToFillWidth =
+    row.cells.length === 1 &&
+    cell.bold &&
+    cell.fontSize >= LARGE_LINE_FONT_SIZE_PX;
+  const titleHeightLimitPx = Math.min(
+    MAX_AUTO_GROW_TITLE_FONT_SIZE_PX,
+    Math.max(
+      MIN_FIT_FONT_SIZE_PX,
+      tagHeightInches * AUTO_GROW_TITLE_FONT_SIZE_PX_PER_INCH,
+    ),
+  );
 
-  if (estimatedTextWidthPx <= cellWidthPx) return cell.fontSize;
+  if (!shouldGrowToFillWidth && estimatedTextWidthPx <= cellWidthPx) {
+    return cell.fontSize;
+  }
 
   return Number(
     clamp(
@@ -1275,7 +1304,7 @@ export function resolveCellFontSizePx(
         cell.fontSize *
         FIT_FONT_SCALE_BUFFER,
       MIN_FIT_FONT_SIZE_PX,
-      cell.fontSize,
+      shouldGrowToFillWidth ? titleHeightLimitPx : cell.fontSize,
     ).toFixed(2),
   );
 }
@@ -1307,7 +1336,7 @@ export function getTagPreviewWarnings({
       }
 
       const fittedSizes = row.cells.map((cell) =>
-        resolveCellFontSizePx(cell, row, widthInches, hasQrCode),
+        resolveCellFontSizePx(cell, row, widthInches, hasQrCode, heightInches),
       );
       if (fittedSizes.some((fontSize) => fontSize < 10)) {
         hasSmallText = true;

--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-model.ts
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-model.ts
@@ -189,7 +189,6 @@ export const TAG_SHEET_CREATOR_STORAGE_KEY = "tag-sheet-creator-state-v1";
 const TEMPLATE_DEFAULT_ID = "default-template";
 export const TEMPLATE_CUSTOM_ID = "custom-template";
 const TEMPLATE_SIMPLE_NAME_ID = "template-simple-name";
-const TEMPLATE_GROWER_ID_ID = "template-grower-id";
 const TEMPLATE_SALE_TAG_ID = "template-sale-tag";
 const TEMPLATE_GROWER_DETAILS_ID = "template-grower-details";
 const LARGE_LINE_FONT_SIZE_PX = 22;
@@ -361,8 +360,9 @@ function createTemplateCell(
 }
 
 const SIMPLE_NAME_TEMPLATE = "# {{title}}";
-const GARDEN_ID_TEMPLATE = "# {{title}}\n{{hybridizerYear}}\n- {{ploidy}}";
-const GROWER_ID_TEMPLATE = "# {{title}}\n{{hybridizerYear}} {{ploidy}}";
+const GARDEN_ID_TEMPLATE = "# {{title}}\n{{hybridizerYear}} {{ploidy}}";
+const PREVIOUS_GARDEN_ID_TEMPLATE =
+  "# {{title}}\n{{hybridizerYear}}\n- {{ploidy}}";
 const SALE_TAG_TEMPLATE =
   "# {{title}}\n{{hybridizerYear}}\n## {{ploidy}} | {{price}}";
 const GROWER_DETAILS_TEMPLATE =
@@ -384,6 +384,9 @@ const LEGACY_DEFAULT_ROWS: TagRow[] = [
 ];
 const LEGACY_DEFAULT_ROWS_SIGNATURE =
   createRowsLayoutSignature(LEGACY_DEFAULT_ROWS);
+const PREVIOUS_GARDEN_ID_ROWS_SIGNATURE = createRowsLayoutSignature(
+  createRowsFromTagTextTemplate(PREVIOUS_GARDEN_ID_TEMPLATE),
+);
 
 function createBuiltinTemplateRows(idPrefix: string, template: string) {
   return createRowsFromTagTextTemplate(template).map((row, index) => ({
@@ -420,17 +423,6 @@ export const BUILTIN_TAG_LAYOUT_TEMPLATES: Array<
     id: TEMPLATE_DEFAULT_ID,
     name: "Garden ID",
     layout: DEFAULT_TAG_DESIGNER_STATE,
-  },
-  {
-    id: TEMPLATE_GROWER_ID_ID,
-    name: "Grower ID",
-    layout: {
-      sizePresetId: "brother-tze-1",
-      customWidthInches: 3.5,
-      customHeightInches: 1,
-      showQrCode: true,
-      rows: createBuiltinTemplateRows("grower-id-row", GROWER_ID_TEMPLATE),
-    },
   },
   {
     id: TEMPLATE_SALE_TAG_ID,
@@ -954,10 +946,13 @@ export function sanitizeTagDesignerState(
   const rows = (state.rows as Partial<TagRow>[])
     .map((r) => sanitizeRow(r))
     .filter((r): r is TagRow => r !== null);
-  const migratedRows =
-    createRowsLayoutSignature(rows) === LEGACY_DEFAULT_ROWS_SIGNATURE
-      ? DEFAULT_TAG_DESIGNER_STATE.rows
-      : rows;
+  const rowsSignature = createRowsLayoutSignature(rows);
+  const migratedRows = [
+    LEGACY_DEFAULT_ROWS_SIGNATURE,
+    PREVIOUS_GARDEN_ID_ROWS_SIGNATURE,
+  ].includes(rowsSignature)
+    ? DEFAULT_TAG_DESIGNER_STATE.rows
+    : rows;
 
   return {
     sizePresetId: presetExists

--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-panel.tsx
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-panel.tsx
@@ -264,6 +264,7 @@ function TagPreviewCard({
                         row,
                         widthInches,
                         Boolean(tag.qrCodeUrl),
+                        heightInches,
                       )}px`,
                     }}
                   >
@@ -1083,6 +1084,8 @@ interface TagDesignerControlsProps {
 const TEMPLATE_DESCRIPTIONS: Record<string, string> = {
   "template-simple-name": 'Cultivar name · recommended 1" tag',
   "default-template": 'Name, hybridizer/year, and ploidy · recommended 1"',
+  "template-grower-id":
+    'Two-line name, hybridizer/year, and ploidy · recommended 1"',
   "template-sale-tag": 'Name, identity, ploidy, and price · recommended 1"',
   "template-grower-details":
     'Identity and growing traits · recommended 2" × 4" card',
@@ -1354,12 +1357,12 @@ function TagDesignerControls({
                 <p className="text-muted-foreground text-xs">
                   One row per line. Listing fields use{" "}
                   <code>{"{{fieldName}}"}</code>. Text stays on one line and
-                  shrinks to fit.
+                  fits to the available width.
                 </p>
                 <p className="text-muted-foreground text-xs">
-                  <code>#</code> large bold · <code>##</code> medium bold ·{" "}
-                  <code>-</code> small · <code>|</code> left/right columns ·
-                  blank line adds space
+                  <code>#</code> full-width auto-size title · <code>##</code>{" "}
+                  medium bold · <code>-</code> small · <code>|</code> left/right
+                  columns · blank line adds space
                 </p>
               </div>
               <div className="flex flex-wrap gap-2">

--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-panel.tsx
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-panel.tsx
@@ -1084,8 +1084,7 @@ interface TagDesignerControlsProps {
 
 const TEMPLATE_DESCRIPTIONS: Record<string, string> = {
   "template-simple-name": 'Cultivar name · recommended 1" tag',
-  "default-template": 'Name, hybridizer/year, and ploidy · recommended 1"',
-  "template-grower-id":
+  "default-template":
     'Two-line name, hybridizer/year, and ploidy · recommended 1"',
   "template-sale-tag": 'Name, identity, ploidy, and price · recommended 1"',
   "template-grower-details":

--- a/apps/main/src/app/dashboard/tags/_components/tag-designer-panel.tsx
+++ b/apps/main/src/app/dashboard/tags/_components/tag-designer-panel.tsx
@@ -265,6 +265,7 @@ function TagPreviewCard({
                         widthInches,
                         Boolean(tag.qrCodeUrl),
                         heightInches,
+                        tag.rows,
                       )}px`,
                     }}
                   >

--- a/apps/main/tests/tag-designer-model.test.ts
+++ b/apps/main/tests/tag-designer-model.test.ts
@@ -10,6 +10,7 @@ import {
   getTagTemplateValidationIssues,
   getTagTextTemplateFieldIds,
   getTagPreviewWarnings,
+  resolveCellFontSizePx,
   sanitizeTagDesignerState,
   tagDesignerStateToTemplateText,
 } from "@/app/dashboard/tags/_components/tag-designer-model";
@@ -198,6 +199,34 @@ describe("tag designer model", () => {
     ).toBe(template);
   });
 
+  it("grows a standard title line to use its available width", () => {
+    const rows = buildResolvedRowsForListing(
+      listing,
+      createRowsFromTagTextTemplate("# {{title}}\n{{hybridizerYear}}"),
+    );
+    const title = rows[0]!.cells[0]!;
+    const detail = rows[1]!.cells[0]!;
+
+    expect(resolveCellFontSizePx(title, rows[0]!, 3.5, false)).toBeGreaterThan(
+      title.fontSize,
+    );
+    expect(resolveCellFontSizePx(detail, rows[1]!, 3.5, false)).toBe(
+      detail.fontSize,
+    );
+  });
+
+  it("caps short titles based on tag height", () => {
+    const row = buildResolvedRowsForListing(
+      { ...listing, title: "Clown" },
+      createRowsFromTagTextTemplate("# {{title}}"),
+    )[0]!;
+    const title = row.cells[0]!;
+
+    expect(resolveCellFontSizePx(title, row, 3.5, false, 0.75)).toBe(31.5);
+    expect(resolveCellFontSizePx(title, row, 3.5, false, 1)).toBe(42);
+    expect(resolveCellFontSizePx(title, row, 3.5, false, 2)).toBe(56);
+  });
+
   it("preserves runs of interior blank lines as row spacing", () => {
     const template = "# {{title}}\n\n\n- {{hybridizerYear}}";
     const rows = createRowsFromTagTextTemplate(template);
@@ -261,7 +290,9 @@ describe("tag designer model", () => {
     expect(instructions).toContain("no more than 3 nonblank rows");
     expect(instructions).toContain("no more than two columns per row");
     expect(instructions).toContain("no code fence");
-    expect(instructions).toContain("# for large bold");
+    expect(instructions).toContain(
+      "# for a large bold title that grows to fill the available width",
+    );
     expect(instructions).toContain("| to space columns apart");
     expect(instructions).toContain("{{hybridizerYear}}: Hybridizer, Year");
     expect(instructions).toContain("{{privateNote}}: Private Note");
@@ -322,10 +353,16 @@ describe("tag designer model", () => {
     );
   });
 
-  it("offers four job-based presets with safe template text", () => {
+  it("offers job-based presets with safe template text", () => {
     expect(
       BUILTIN_TAG_LAYOUT_TEMPLATES.map((template) => template.name),
-    ).toEqual(["Simple name", "Garden ID", "Sale tag", "Grower details"]);
+    ).toEqual([
+      "Simple name",
+      "Garden ID",
+      "Grower ID",
+      "Sale tag",
+      "Grower details",
+    ]);
     expect(
       BUILTIN_TAG_LAYOUT_TEMPLATES.map((template) =>
         tagDesignerStateToTemplateText(template.layout),
@@ -333,6 +370,7 @@ describe("tag designer model", () => {
     ).toEqual([
       "# {{title}}",
       "# {{title}}\n{{hybridizerYear}}\n- {{ploidy}}",
+      "# {{title}}\n{{hybridizerYear}} {{ploidy}}",
       "# {{title}}\n{{hybridizerYear}}\n## {{ploidy}} | {{price}}",
       "# {{title}}\n## {{hybridizerYear}}\n{{ploidy}} | {{foliageType}}\nBloom {{bloomSize}} | Scape {{scapeHeight}}\n- Season {{bloomSeason}} | Habit {{bloomHabit}}",
     ]);

--- a/apps/main/tests/tag-designer-model.test.ts
+++ b/apps/main/tests/tag-designer-model.test.ts
@@ -215,6 +215,26 @@ describe("tag designer model", () => {
     );
   });
 
+  it("keeps wide-letter titles inside the printable width while growing", () => {
+    const cases = [
+      { title: "Whammer Jammer", maximumFontSize: 29.3 },
+      { title: "oooooooooooo", maximumFontSize: 35.8 },
+      { title: "COOL COLOR", maximumFontSize: 38.7 },
+    ];
+
+    for (const testCase of cases) {
+      const row = buildResolvedRowsForListing(
+        { ...listing, title: testCase.title },
+        createRowsFromTagTextTemplate("# {{title}}"),
+      )[0]!;
+      const title = row.cells[0]!;
+      const fittedFontSize = resolveCellFontSizePx(title, row, 3.5, true);
+
+      expect(fittedFontSize).toBeGreaterThan(title.fontSize);
+      expect(fittedFontSize).toBeLessThanOrEqual(testCase.maximumFontSize);
+    }
+  });
+
   it("caps short titles based on tag height", () => {
     const row = buildResolvedRowsForListing(
       { ...listing, title: "Clown" },
@@ -225,6 +245,29 @@ describe("tag designer model", () => {
     expect(resolveCellFontSizePx(title, row, 3.5, false, 0.75)).toBe(31.5);
     expect(resolveCellFontSizePx(title, row, 3.5, false, 1)).toBe(42);
     expect(resolveCellFontSizePx(title, row, 3.5, false, 2)).toBe(56);
+  });
+
+  it("reserves enough height for every row in raster exports", () => {
+    const rows = buildResolvedRowsForListing(
+      { ...listing, title: "Clown" },
+      createRowsFromTagTextTemplate(
+        "# {{title}}\n{{hybridizerYear}}\n## {{ploidy}} | {{price}}",
+      ),
+    );
+
+    const fittedRowSizes = rows.map((row) =>
+      Math.max(
+        ...row.cells.map((cell) =>
+          resolveCellFontSizePx(cell, row, 3.5, true, 1, rows),
+        ),
+      ),
+    );
+    const rasterContentHeight =
+      fittedRowSizes.reduce((total, fontSize) => total + fontSize * 1.39, 0) +
+      (rows.length - 1) * 2;
+    const availableHeight = (1 - 0.12) * 96;
+
+    expect(rasterContentHeight).toBeLessThanOrEqual(availableHeight);
   });
 
   it("preserves runs of interior blank lines as row spacing", () => {

--- a/apps/main/tests/tag-designer-model.test.ts
+++ b/apps/main/tests/tag-designer-model.test.ts
@@ -159,6 +159,28 @@ describe("tag designer model", () => {
     });
   });
 
+  it("migrates the previous three-row Garden ID to the consolidated layout", () => {
+    const migrated = sanitizeTagDesignerState({
+      sizePresetId: "brother-tze-1",
+      customWidthInches: 3.5,
+      customHeightInches: 1,
+      showQrCode: true,
+      rows: createRowsFromTagTextTemplate(
+        "# {{title}}\n{{hybridizerYear}}\n- {{ploidy}}",
+      ),
+    });
+    const gardenId = BUILTIN_TAG_LAYOUT_TEMPLATES.find(
+      (template) => template.name === "Garden ID",
+    )!;
+
+    expect(createLayoutSignature(migrated)).toBe(
+      createLayoutSignature(gardenId.layout),
+    );
+    expect(tagDesignerStateToTemplateText(migrated)).toBe(
+      "# {{title}}\n{{hybridizerYear}} {{ploidy}}",
+    );
+  });
+
   it("parses line sizes and space-between columns without wrapping", () => {
     const template =
       "# {{title}}\n## {{hybridizerYear}} | {{ploidy}}\n- {{price}} | {{privateNote}}";
@@ -399,20 +421,13 @@ describe("tag designer model", () => {
   it("offers job-based presets with safe template text", () => {
     expect(
       BUILTIN_TAG_LAYOUT_TEMPLATES.map((template) => template.name),
-    ).toEqual([
-      "Simple name",
-      "Garden ID",
-      "Grower ID",
-      "Sale tag",
-      "Grower details",
-    ]);
+    ).toEqual(["Simple name", "Garden ID", "Sale tag", "Grower details"]);
     expect(
       BUILTIN_TAG_LAYOUT_TEMPLATES.map((template) =>
         tagDesignerStateToTemplateText(template.layout),
       ),
     ).toEqual([
       "# {{title}}",
-      "# {{title}}\n{{hybridizerYear}}\n- {{ploidy}}",
       "# {{title}}\n{{hybridizerYear}} {{ploidy}}",
       "# {{title}}\n{{hybridizerYear}}\n## {{ploidy}} | {{price}}",
       "# {{title}}\n## {{hybridizerYear}}\n{{ploidy}} | {{foliageType}}\nBloom {{bloomSize}} | Scape {{scapeHeight}}\n- Season {{bloomSeason}} | Habit {{bloomHabit}}",

--- a/apps/main/tests/tag-designer-panel.test.tsx
+++ b/apps/main/tests/tag-designer-panel.test.tsx
@@ -329,8 +329,8 @@ describe("TagDesignerPanel", () => {
       screen.getByRole("button", { name: /Garden ID/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^Grower ID/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /^Grower ID/i }),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Sale tag/i }),
     ).toBeInTheDocument();
@@ -353,10 +353,10 @@ describe("TagDesignerPanel", () => {
     expect(screen.getByText("Smith, 2015 · $18.50")).toBeInTheDocument();
   });
 
-  it("applies the two-line Grower ID template with an auto-sized title", () => {
+  it("applies the two-line Garden ID template with an auto-sized title", () => {
     render(<TagDesignerPanel listings={sampleListings} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /^Grower ID/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Garden ID/i }));
 
     expect(screen.getByText("Smith, 2015 tet")).toBeInTheDocument();
     expect(

--- a/apps/main/tests/tag-designer-panel.test.tsx
+++ b/apps/main/tests/tag-designer-panel.test.tsx
@@ -26,6 +26,7 @@ const sampleListings: TagListingData[] = [
       bloomSize: '6"',
       scapeHeight: '32"',
       bloomSeason: "M",
+      ploidy: "Tetraploid",
     },
   },
 ];
@@ -328,6 +329,9 @@ describe("TagDesignerPanel", () => {
       screen.getByRole("button", { name: /Garden ID/i }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("button", { name: /^Grower ID/i }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: /Sale tag/i }),
     ).toBeInTheDocument();
     expect(
@@ -347,6 +351,17 @@ describe("TagDesignerPanel", () => {
     });
 
     expect(screen.getByText("Smith, 2015 · $18.50")).toBeInTheDocument();
+  });
+
+  it("applies the two-line Grower ID template with an auto-sized title", () => {
+    render(<TagDesignerPanel listings={sampleListings} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Grower ID/i }));
+
+    expect(screen.getByText("Smith, 2015 tet")).toBeInTheDocument();
+    expect(
+      Number.parseFloat(screen.getByText("Moonlit Smile").style.fontSize),
+    ).toBeGreaterThan(22);
   });
 
   it("does not erase formatting syntax while the user is typing", () => {


### PR DESCRIPTION
## Summary

Adds the requested two-line Grower ID preset:

```text
# {{title}}
{{hybridizerYear}} {{ploidy}}
```

The standard `#` title format now grows to use the available width as well as shrinking for long names. Its maximum size scales with tag height (31.5px at 0.75", 42px at 1", capped at 56px for taller tags), keeping short cultivar names prominent without becoming oversized.

## Files

- `tag-designer-model.ts`: adds the Grower ID preset and height-aware full-width title sizing.
- `tag-designer-panel.tsx`: uses the selected tag height in previews and documents the auto-size title syntax.
- `tag-designer-html.ts`: applies the same height-aware sizing to individual print output and sheet output.
- `tag-designer-model.test.ts`: covers the new preset, title growth, and height-based caps.
- `tag-designer-panel.test.tsx`: covers selecting the preset and rendering its two-line content.

## Validation

- `pnpm test -- tests/tag-designer-model.test.ts tests/tag-designer-panel.test.tsx` (38 tests)
- `pnpm typecheck`
- focused ESLint on changed source and test files
- authenticated browser verification on `/dashboard/tags` with a real short-title listing (`Cougar`), confirming a 42px title and one-line hybridizer/year/ploidy metadata on the 1" tag