### PR TITLE
Add dashboard state atlas

### DIFF
--- a/apps/main/playwright.atlas.config.ts
+++ b/apps/main/playwright.atlas.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
     {
       name: "member",
       testMatch: [
+        "dashboard-home.atlas.ts",
         "listing-management.atlas.ts",
         "listing-media.atlas.ts",
         "list-management.atlas.ts",

--- a/apps/main/scripts/atlas-flows.mjs
+++ b/apps/main/scripts/atlas-flows.mjs
@@ -2,20 +2,26 @@
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 const stateFor =
-  (captureSpec) =>
+  (captureSpec, atlasFlowId) =>
   (id, title, description, url, urlReproducible = true) => ({
     id,
     title,
     description,
     capture: `${id}.png`,
     captureSpec,
-    reproductionCommand: `ATLAS_OUTPUT_DIR=local/atlas/reproduce ATLAS_CAPTURE_DIR=local/atlas/reproduce/screenshots pnpm main exec playwright test -c playwright.atlas.config.ts ${captureSpec} --grep "${title}"`,
+    reproductionCommand: atlasFlowId
+      ? `node apps/main/scripts/run-atlas-flow.mjs ${atlasFlowId} --output=local/atlas/reproduce`
+      : `ATLAS_OUTPUT_DIR=local/atlas/reproduce ATLAS_CAPTURE_DIR=local/atlas/reproduce/screenshots pnpm main exec playwright test -c playwright.atlas.config.ts ${captureSpec} --grep "${title}"`,
     url,
     urlReproducible,
   });
 const publicState = stateFor("tests/atlas/public-catalog.atlas.ts");
 const cultivarState = stateFor("tests/atlas/cultivar-search.atlas.ts");
 const onboardingState = stateFor("tests/atlas/onboarding-membership.atlas.ts");
+const dashboardHomeState = stateFor(
+  "tests/atlas/dashboard-home.atlas.ts",
+  "dashboard-home",
+);
 const listingState = stateFor("tests/atlas/listing-management.atlas.ts");
 const listingMediaState = stateFor("tests/atlas/listing-media.atlas.ts");
 const listState = stateFor("tests/atlas/list-management.atlas.ts");
@@ -401,6 +407,102 @@ export const ATLAS_FLOWS = [
             "Checkout review",
             "The account email and membership terms immediately before Stripe.",
             "/onboarding?step=checkout",
+            false,
+          ),
+        ],
+      },
+    ],
+  },
+  {
+    id: "dashboard-home",
+    audience: "member",
+    title: "Choose the next catalog action",
+    description:
+      "Orient on the dashboard across setup, membership, billing, and established Pro states without multiplying partial-state permutations.",
+    tests: {
+      unit: [testRef("unit", "tests/build-dashboard-stats.test.ts")],
+      integration: [
+        testRef("integration", "tests/pro-membership-card.test.tsx"),
+        testRef("integration", "tests/persisted-subscription-query.test.ts"),
+      ],
+      e2e: [
+        testRef("e2e", "tests/e2e/new-user-journey.e2e.ts"),
+        testRef("e2e", "tests/e2e/onboarding-full-flow.e2e.ts"),
+      ],
+    },
+    steps: [
+      {
+        title: "Finish setup",
+        states: [
+          dashboardHomeState(
+            "dashboard-home-desktop-setup",
+            "Desktop setup guidance",
+            "Combined incomplete profile and catalog guidance with the membership offer at the supported iPad width.",
+            "/dashboard",
+            false,
+          ),
+          dashboardHomeState(
+            "dashboard-home-mobile-setup",
+            "Mobile setup guidance",
+            "The same combined setup guidance and membership offer at the supported phone width.",
+            "/dashboard",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Start membership",
+        states: [
+          dashboardHomeState(
+            "dashboard-home-desktop-upgrade",
+            "Desktop membership upgrade",
+            "A complete free catalog with the remaining Pro membership decision at the supported iPad width.",
+            "/dashboard",
+            false,
+          ),
+          dashboardHomeState(
+            "dashboard-home-mobile-upgrade",
+            "Mobile membership upgrade",
+            "The same complete free catalog and Pro decision at the supported phone width.",
+            "/dashboard",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Resolve billing",
+        states: [
+          dashboardHomeState(
+            "dashboard-home-desktop-billing",
+            "Desktop billing attention",
+            "A complete catalog with past-due billing guidance and recovery actions at the supported iPad width.",
+            "/dashboard",
+            false,
+          ),
+          dashboardHomeState(
+            "dashboard-home-mobile-billing",
+            "Mobile billing attention",
+            "The same past-due billing recovery state at the supported phone width.",
+            "/dashboard",
+            false,
+          ),
+        ],
+      },
+      {
+        title: "Return as an established Pro",
+        states: [
+          dashboardHomeState(
+            "dashboard-home-desktop-active-pro",
+            "Desktop active Pro",
+            "A complete active-Pro catalog after all conditional guidance disappears at the supported iPad width.",
+            "/dashboard",
+            false,
+          ),
+          dashboardHomeState(
+            "dashboard-home-mobile-active-pro",
+            "Mobile active Pro",
+            "The same established-Pro dashboard at the supported phone width.",
+            "/dashboard",
             false,
           ),
         ],

--- a/apps/main/scripts/run-atlas-flow.mjs
+++ b/apps/main/scripts/run-atlas-flow.mjs
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import * as dotenv from "dotenv";
 import {
   generateAtlasGallery,
@@ -53,8 +54,14 @@ const baseURL =
   process.env.BASE_URL ??
   `http://localhost:${process.env.ATLAS_PORT ?? "3210"}`;
 const explicitDatabaseUrl = process.env.DATABASE_URL;
+const normalizeDatabaseUrl = (databaseUrl) =>
+  databaseUrl?.startsWith("file:")
+    ? new URL(databaseUrl, pathToFileURL(`${appRoot}${path.sep}`)).href
+    : databaseUrl;
 let disposableDatabase;
-let atlasDatabaseUrl = explicitDatabaseUrl;
+let atlasDatabaseUrl = normalizeDatabaseUrl(
+  process.env.ATLAS_DATABASE_URL ?? explicitDatabaseUrl,
+);
 const runtimeFlagsPath = path.join(
   tmpdir(),
   `daylily-atlas-feature-flags-${process.pid}.json`,
@@ -124,7 +131,7 @@ async function startServer() {
   ]) {
     if (existsSync(envPath)) dotenv.config({ path: envPath, quiet: true });
   }
-  let databaseUrl = explicitDatabaseUrl;
+  let databaseUrl = normalizeDatabaseUrl(explicitDatabaseUrl);
   if (!databaseUrl) {
     const manifest = assertRealisticDataSeedFresh({
       manifestPath: path.join(appRoot, "local/realistic-data/personas.json"),
@@ -176,6 +183,11 @@ async function startServer() {
 try {
   mkdirSync(path.dirname(outputDirectory), { recursive: true });
   await startServer();
+  if (flows.some((flow) => flow.id === "dashboard-home") && !atlasDatabaseUrl) {
+    throw new Error(
+      "Dashboard home Atlas states need ATLAS_DATABASE_URL when BASE_URL reuses an existing server.",
+    );
+  }
   rmSync(outputDirectory, { recursive: true, force: true });
   mkdirSync(outputDirectory, { recursive: true });
   if (serverLogFd !== undefined) {

--- a/apps/main/scripts/run-atlas-flow.mjs
+++ b/apps/main/scripts/run-atlas-flow.mjs
@@ -54,6 +54,7 @@ const baseURL =
   `http://localhost:${process.env.ATLAS_PORT ?? "3210"}`;
 const explicitDatabaseUrl = process.env.DATABASE_URL;
 let disposableDatabase;
+let atlasDatabaseUrl = explicitDatabaseUrl;
 const runtimeFlagsPath = path.join(
   tmpdir(),
   `daylily-atlas-feature-flags-${process.pid}.json`,
@@ -142,6 +143,7 @@ async function startServer() {
     });
     databaseUrl = `file:${disposableDatabase.databasePath}`;
   }
+  atlasDatabaseUrl = databaseUrl;
   serverLogFd = openSync(serverLogPath, "w");
   writeFileSync(runtimeFlagsPath, '{"publicCultivarSearch":true}');
   server = spawn("pnpm", ["dev", "--", "--port", new URL(baseURL).port], {
@@ -204,6 +206,7 @@ try {
         env: {
           ...process.env,
           BASE_URL: baseURL,
+          ATLAS_DATABASE_URL: atlasDatabaseUrl,
           ATLAS_OUTPUT_DIR: flowOutputDirectory,
           ATLAS_CAPTURE_DIR: captureDirectory,
           ATLAS_AUTH_STATE: path.join(flowOutputDirectory, ".auth/member.json"),

--- a/apps/main/tests/atlas/dashboard-home.atlas.ts
+++ b/apps/main/tests/atlas/dashboard-home.atlas.ts
@@ -216,6 +216,13 @@ function restoreRealisticPersona() {
         originalSubscriptionValue,
         now,
       );
+      database
+        .prepare("DELETE FROM KeyValue WHERE key = ?")
+        .run(fixtureStripeKey);
+      database
+        .prepare("DELETE FROM UserProfile WHERE id = ?")
+        .run(fixtureProfileId);
+      database.prepare("DELETE FROM User WHERE id = ?").run(fixtureUserId);
     }),
   );
 }

--- a/apps/main/tests/atlas/dashboard-home.atlas.ts
+++ b/apps/main/tests/atlas/dashboard-home.atlas.ts
@@ -1,0 +1,346 @@
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import { DashboardHome } from "../e2e/pages/dashboard-home";
+import { DashboardShell } from "../e2e/pages/dashboard-shell";
+import { captureAtlasState, expect, test } from "./atlas-test";
+
+const desktop = { height: 768, width: 1024 };
+const mobile = { height: 874, width: 402 };
+const fixtureUserId = "atlas-dashboard-home-user";
+const fixtureProfileId = "atlas-dashboard-home-profile";
+const fixtureStripeCustomerId = "atlas_dashboard_home";
+const fixtureStripeKey = `stripe:customer:${fixtureStripeCustomerId}`;
+let originalUserId: string;
+let realisticClerkUserId: string;
+let originalStripeKey: string;
+let originalSubscriptionValue: string;
+let originalListingCount: number;
+
+type DashboardState = "setup" | "upgrade" | "billing" | "active-pro";
+type AtlasDatabaseRow = Record<string, unknown>;
+
+function withAtlasDatabase<T>(run: (database: DatabaseSync) => T) {
+  const databaseUrl = process.env.ATLAS_DATABASE_URL;
+  if (!databaseUrl?.startsWith("file:")) {
+    throw new Error(
+      "Dashboard home Atlas states require a managed file-backed ATLAS_DATABASE_URL.",
+    );
+  }
+
+  const database = new DatabaseSync(fileURLToPath(new URL(databaseUrl)));
+  database.exec("PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 15000;");
+  try {
+    return run(database);
+  } finally {
+    database.close();
+  }
+}
+
+function inTransaction<T>(database: DatabaseSync, run: () => T) {
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    const result = run();
+    database.exec("COMMIT;");
+    return result;
+  } catch (error) {
+    database.exec("ROLLBACK;");
+    throw error;
+  }
+}
+
+function initializeFixture() {
+  withAtlasDatabase((database) =>
+    inTransaction(database, () => {
+      const originalUser = database
+        .prepare(
+          `
+            SELECT
+              User.id,
+              User.clerkUserId,
+              User.stripeCustomerId,
+              KeyValue.value AS subscriptionValue
+            FROM User
+            INNER JOIN UserProfile ON UserProfile.userId = User.id
+            INNER JOIN KeyValue
+              ON KeyValue.key = 'stripe:customer:' || User.stripeCustomerId
+            WHERE UserProfile.slug = 'rollingoaksdaylilies'
+          `,
+        )
+        .get() as AtlasDatabaseRow | undefined;
+      if (
+        typeof originalUser?.id !== "string" ||
+        typeof originalUser.clerkUserId !== "string" ||
+        typeof originalUser.stripeCustomerId !== "string" ||
+        typeof originalUser.subscriptionValue !== "string"
+      ) {
+        throw new Error("The realistic Rolling Oaks Atlas persona is missing.");
+      }
+      originalUserId = originalUser.id;
+      realisticClerkUserId = originalUser.clerkUserId;
+      originalStripeKey = `stripe:customer:${originalUser.stripeCustomerId}`;
+      originalSubscriptionValue = originalUser.subscriptionValue;
+      const listingCount = database
+        .prepare("SELECT COUNT(*) AS count FROM Listing WHERE userId = ?")
+        .get(originalUserId) as AtlasDatabaseRow | undefined;
+      if (typeof listingCount?.count !== "number") {
+        throw new Error("The realistic Rolling Oaks listing count is missing.");
+      }
+      originalListingCount = listingCount.count;
+
+      const now = Date.now();
+      database
+        .prepare(
+          `
+            INSERT INTO User (
+              id, clerkUserId, stripeCustomerId, role, createdAt, updatedAt
+            )
+            VALUES (?, NULL, ?, 'USER', ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+              stripeCustomerId = excluded.stripeCustomerId,
+              updatedAt = excluded.updatedAt
+          `,
+        )
+        .run(fixtureUserId, fixtureStripeCustomerId, now, now);
+      database
+        .prepare(
+          `
+            INSERT INTO UserProfile (
+              id, userId, title, slug, description, content, location,
+              createdAt, updatedAt
+            )
+            VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+              title = excluded.title,
+              slug = excluded.slug,
+              updatedAt = excluded.updatedAt
+          `,
+        )
+        .run(
+          fixtureProfileId,
+          fixtureUserId,
+          "Atlas Daylilies",
+          "atlas-dashboard-home",
+          now,
+          now,
+        );
+    }),
+  );
+}
+
+function upsertSubscription(
+  database: DatabaseSync,
+  key: string,
+  value: string,
+  now: number,
+) {
+  database
+    .prepare(
+      `
+        INSERT INTO KeyValue (key, value, createdAt, updatedAt)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(key) DO UPDATE SET
+          value = excluded.value,
+          updatedAt = excluded.updatedAt
+      `,
+    )
+    .run(key, value, now, now);
+}
+
+function seedDashboardState(state: DashboardState) {
+  const subscriptionStatus =
+    state === "billing"
+      ? "past_due"
+      : state === "active-pro"
+        ? "active"
+        : "none";
+
+  withAtlasDatabase((database) =>
+    inTransaction(database, () => {
+      const now = Date.now();
+      if (state === "setup") {
+        database
+          .prepare(
+            "UPDATE User SET clerkUserId = NULL, updatedAt = ? WHERE id = ?",
+          )
+          .run(now, originalUserId);
+        database
+          .prepare(
+            "UPDATE User SET clerkUserId = ?, updatedAt = ? WHERE id = ?",
+          )
+          .run(realisticClerkUserId, now, fixtureUserId);
+        upsertSubscription(
+          database,
+          fixtureStripeKey,
+          JSON.stringify({ status: "none" }),
+          now,
+        );
+      } else {
+        database
+          .prepare(
+            "UPDATE User SET clerkUserId = NULL, updatedAt = ? WHERE id = ?",
+          )
+          .run(now, fixtureUserId);
+        database
+          .prepare(
+            "UPDATE User SET clerkUserId = ?, updatedAt = ? WHERE id = ?",
+          )
+          .run(realisticClerkUserId, now, originalUserId);
+        upsertSubscription(
+          database,
+          originalStripeKey,
+          JSON.stringify({ status: subscriptionStatus }),
+          now,
+        );
+      }
+    }),
+  );
+}
+
+function restoreRealisticPersona() {
+  if (!originalUserId) return;
+  withAtlasDatabase((database) =>
+    inTransaction(database, () => {
+      const now = Date.now();
+      database
+        .prepare(
+          "UPDATE User SET clerkUserId = NULL, updatedAt = ? WHERE id = ?",
+        )
+        .run(now, fixtureUserId);
+      database
+        .prepare("UPDATE User SET clerkUserId = ?, updatedAt = ? WHERE id = ?")
+        .run(realisticClerkUserId, now, originalUserId);
+      upsertSubscription(
+        database,
+        originalStripeKey,
+        originalSubscriptionValue,
+        now,
+      );
+    }),
+  );
+}
+
+async function openDashboard(
+  page: Page,
+  state: DashboardState,
+  viewport: typeof desktop,
+) {
+  seedDashboardState(state);
+  await page.addInitScript(() => {
+    for (const key of Object.keys(window.localStorage)) {
+      if (key.startsWith("stripe-subscription:")) {
+        window.localStorage.removeItem(key);
+      }
+    }
+  });
+  await page.setViewportSize(viewport);
+  await page.goto("/dashboard");
+
+  const dashboard = new DashboardHome(page);
+  await dashboard.waitForLoaded();
+  await new DashboardShell(page).refreshDashboardData();
+  await expect(
+    page.getByText("Dashboard refreshed", { exact: true }),
+  ).toBeHidden();
+  // The dev-only auth failure trigger is not part of the production dashboard.
+  await page
+    .getByRole("button", { name: "Test Auth Error" })
+    .evaluate((button) => {
+      button.parentElement?.style.setProperty("display", "none");
+    });
+
+  const totalListingsCard = page
+    .getByText("Total Listings", { exact: true })
+    .locator("../..");
+  await expect(totalListingsCard).toContainText(
+    state === "setup" ? "0" : String(originalListingCount),
+  );
+  return dashboard;
+}
+
+async function captureSetup(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const dashboard = await openDashboard(page, "setup", viewport);
+  await expect(dashboard.profileCompletionPercentage).toHaveText("0%");
+  await expect(dashboard.catalogProgressPercentage).toHaveText("0%");
+  await expect(dashboard.upgradeToProButton).toBeVisible();
+  await captureAtlasState(page, stateId);
+}
+
+async function captureUpgrade(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const dashboard = await openDashboard(page, "upgrade", viewport);
+  await expect(dashboard.completeProfileCard).toHaveCount(0);
+  await expect(dashboard.catalogProgressCard).toHaveCount(0);
+  await expect(dashboard.upgradeToProButton).toBeVisible();
+  await expect(page.getByTestId("dashboard-billing-alert")).toHaveCount(0);
+  await captureAtlasState(page, stateId);
+}
+
+async function captureBilling(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const dashboard = await openDashboard(page, "billing", viewport);
+  await expect(dashboard.completeProfileCard).toHaveCount(0);
+  await expect(dashboard.catalogProgressCard).toHaveCount(0);
+  await expect(page.getByTestId("dashboard-billing-alert")).toBeVisible();
+  await expect(page.getByTestId("dashboard-update-billing")).toBeVisible();
+  await captureAtlasState(page, stateId);
+}
+
+async function captureActivePro(
+  page: Page,
+  viewport: typeof desktop,
+  stateId: string,
+) {
+  const dashboard = await openDashboard(page, "active-pro", viewport);
+  await expect(dashboard.completeProfileCard).toHaveCount(0);
+  await expect(dashboard.catalogProgressCard).toHaveCount(0);
+  await expect(dashboard.proMembershipCard).toHaveCount(0);
+  await expect(page.getByTestId("dashboard-billing-alert")).toHaveCount(0);
+  await captureAtlasState(page, stateId);
+}
+
+test.describe.configure({ mode: "serial" });
+test.beforeAll(initializeFixture);
+test.afterAll(restoreRealisticPersona);
+
+test("Desktop setup guidance", async ({ page }) => {
+  await captureSetup(page, desktop, "dashboard-home-desktop-setup");
+});
+
+test("Mobile setup guidance", async ({ page }) => {
+  await captureSetup(page, mobile, "dashboard-home-mobile-setup");
+});
+
+test("Desktop membership upgrade", async ({ page }) => {
+  await captureUpgrade(page, desktop, "dashboard-home-desktop-upgrade");
+});
+
+test("Mobile membership upgrade", async ({ page }) => {
+  await captureUpgrade(page, mobile, "dashboard-home-mobile-upgrade");
+});
+
+test("Desktop billing attention", async ({ page }) => {
+  await captureBilling(page, desktop, "dashboard-home-desktop-billing");
+});
+
+test("Mobile billing attention", async ({ page }) => {
+  await captureBilling(page, mobile, "dashboard-home-mobile-billing");
+});
+
+test("Desktop active Pro", async ({ page }) => {
+  await captureActivePro(page, desktop, "dashboard-home-desktop-active-pro");
+});
+
+test("Mobile active Pro", async ({ page }) => {
+  await captureActivePro(page, mobile, "dashboard-home-mobile-active-pro");
+});


### PR DESCRIPTION
## Description

Adds a production-shaped dashboard Atlas flow so agents can review every meaningful dashboard decision state before proposing product changes. The flow captures full-page mobile and iPad-width views for setup, free-member upgrade, past-due billing, and established active-Pro accounts. It changes no production dashboard behavior.

## Files

- `apps/main/tests/atlas/dashboard-home.atlas.ts`: creates reversible disposable-database personas and captures eight dashboard states, using the real Rolling Oaks catalog for completed-account states.
- `apps/main/scripts/atlas-flows.mjs`: registers the dashboard flow, state descriptions, reproduction command, and existing unit/integration/E2E confidence links.
- `apps/main/scripts/run-atlas-flow.mjs`: exposes the runner-managed disposable database URL to Atlas tests.
- `apps/main/playwright.atlas.config.ts`: includes the dashboard spec in the authenticated member Atlas project.

## Verification

- Dashboard Atlas: 9/9 passed
- TypeScript typecheck passed
- Focused manifest/unit confidence: 23/23 passed
- All eight full-page captures inspected
- Browser diagnostics and Next issue checks clean
- `git diff --check` clean