### PR TITLE
Link homepage to grower landing pages

### DIFF
--- a/apps/main/src/app/(public)/_components/home-page-client.tsx
+++ b/apps/main/src/app/(public)/_components/home-page-client.tsx
@@ -437,6 +437,22 @@ function FeaturedCatalogsSection({
               Add photos, prices, availability, notes, and contact info in one
               public place. Buyers can contact you directly.
             </p>
+            <div className="mt-6 flex flex-col items-start gap-3 text-sm font-bold text-[#f4c477] sm:flex-row sm:gap-6">
+              <Link
+                href="/daylily-database-software"
+                className="inline-flex items-center hover:underline"
+              >
+                Daylily database software
+                <ArrowRight className="ml-2 size-4" />
+              </Link>
+              <Link
+                href="/sell-daylilies-online"
+                className="inline-flex items-center hover:underline"
+              >
+                Sell daylilies online
+                <ArrowRight className="ml-2 size-4" />
+              </Link>
+            </div>
           </div>
 
           <div className="flex flex-col justify-end gap-4 lg:items-end">

--- a/apps/main/tests/home-page-grower-links.test.tsx
+++ b/apps/main/tests/home-page-grower-links.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import HomePageClient from "@/app/(public)/_components/home-page-client";
+
+describe("homepage grower links", () => {
+  it("links to both grower use-case pages", () => {
+    render(<HomePageClient />);
+
+    expect(
+      screen.getByRole("link", { name: "Daylily database software" }),
+    ).toHaveAttribute("href", "/daylily-database-software");
+    expect(
+      screen.getByRole("link", { name: "Sell daylilies online" }),
+    ).toHaveAttribute("href", "/sell-daylilies-online");
+  });
+});


### PR DESCRIPTION
## Summary

- Add contextual homepage links to both new grower landing pages.
- Keep the existing homepage layout and primary membership calls to action unchanged.
- Use descriptive anchor text for the two target topics.

## Files

- apps/main/src/app/(public)/_components/home-page-client.tsx: Adds Daylily database software and Sell daylilies online links to the existing grower panel.
- apps/main/tests/home-page-grower-links.test.tsx: Verifies both links and destinations through the rendered homepage component.

## Verification

- Focused Vitest test passed.
- pnpm typecheck passed.
- Targeted ESLint passed.
- git diff --check passed.
- Verified the grower panel at desktop and 390 px mobile widths. Both links render, no horizontal overflow occurs, and no browser console errors or framework overlays appear.