### PR TITLE
Expose canonical links from seller catalog cards

### DIFF
--- a/apps/main/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/page.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/page.tsx
@@ -20,6 +20,7 @@ import { getOptimizedMetaImageUrl } from "@/lib/utils/cloudflareLoader";
 import { IMAGES } from "@/lib/constants/images";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { getSocialCardImageUrl } from "@/lib/social-card";
+import { getPublicListingPath } from "@/lib/public-catalog-url-state";
 import { serializeJsonLd } from "@/lib/utils/json-ld";
 import {
   formatAhsListingSummary,
@@ -126,7 +127,11 @@ function getListingTitle(listing: PublicListingPageData) {
 }
 
 function getCanonicalListingPath(listing: PublicListingPageData) {
-  return `/${listing.userSlug}/${listing.slug || listing.id}`;
+  return getPublicListingPath({
+    listingId: listing.id,
+    listingSlug: listing.slug,
+    sellerSlug: listing.userSlug,
+  });
 }
 
 export async function generateMetadata({

--- a/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings-grid.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings-grid.tsx
@@ -2,6 +2,7 @@
 
 import { ListingCard, ListingCardAction } from "@/components/listing-card";
 import { ViewListingDialog } from "@/components/view-listing-dialog";
+import { getPublicListingPath } from "@/lib/public-catalog-url-state";
 import { type RouterOutputs } from "@/trpc/react";
 
 type Listing = RouterOutputs["public"]["getListings"][number];
@@ -27,7 +28,11 @@ export function CatalogSeoListingsGrid({
             <ListingCard listing={listing}>
               <ListingCardAction asChild>
                 <a
-                  href={`/${canonicalUserSlug}/${listing.slug || listing.id}`}
+                  href={getPublicListingPath({
+                    listingId: listing.id,
+                    listingSlug: listing.slug,
+                    sellerSlug: canonicalUserSlug,
+                  })}
                   aria-label={`View ${listing.title}`}
                 />
               </ListingCardAction>

--- a/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings-grid.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings-grid.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { ListingCard } from "@/components/listing-card";
+import { ListingCard, ListingCardAction } from "@/components/listing-card";
 import { ViewListingDialog } from "@/components/view-listing-dialog";
 import { type RouterOutputs } from "@/trpc/react";
 
 type Listing = RouterOutputs["public"]["getListings"][number];
 
 interface CatalogSeoListingsGridProps {
+  canonicalUserSlug: string;
   listings: Listing[];
 }
 
 export function CatalogSeoListingsGrid({
+  canonicalUserSlug,
   listings,
 }: CatalogSeoListingsGridProps) {
   if (listings.length === 0) {
@@ -22,7 +24,14 @@ export function CatalogSeoListingsGrid({
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3">
         {listings.map((listing) => (
           <div key={listing.id}>
-            <ListingCard listing={listing} />
+            <ListingCard listing={listing}>
+              <ListingCardAction asChild>
+                <a
+                  href={`/${canonicalUserSlug}/${listing.slug || listing.id}`}
+                  aria-label={`View ${listing.title}`}
+                />
+              </ListingCardAction>
+            </ListingCard>
           </div>
         ))}
       </div>

--- a/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings.tsx
@@ -133,7 +133,10 @@ export function CatalogSeoListings({
         </div>
 
         {listings.length > 0 ? (
-          <CatalogSeoListingsGrid listings={listings} />
+          <CatalogSeoListingsGrid
+            canonicalUserSlug={canonicalUserSlug}
+            listings={listings}
+          />
         ) : (
           <div className="rounded-lg border border-dashed p-8 text-center">
             <Muted>No listings available.</Muted>

--- a/apps/main/src/components/listing-card.tsx
+++ b/apps/main/src/components/listing-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import * as React from "react";
+import { type ComponentProps, type ReactNode } from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -30,7 +30,7 @@ type ListingCardProps = {
   listing: RouterOutputs["public"]["getListings"][number];
   className?: string;
   priority?: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 export function ListingCard({
@@ -234,20 +234,20 @@ export function ListingCard({
   );
 }
 
-interface ListingCardActionProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface ListingCardActionProps extends ComponentProps<"button"> {
   asChild?: boolean;
 }
 
-export const ListingCardAction = React.forwardRef<
-  HTMLButtonElement,
-  ListingCardActionProps
->(({ asChild = false, className, type = "button", ...props }, ref) => {
+export function ListingCardAction({
+  asChild = false,
+  className,
+  type = "button",
+  ...props
+}: ListingCardActionProps) {
   const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
-      ref={ref}
       type={asChild ? undefined : type}
       className={cn(
         "focus-visible:ring-ring absolute inset-0 z-10 rounded-xl focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset",
@@ -256,5 +256,4 @@ export const ListingCardAction = React.forwardRef<
       {...props}
     />
   );
-});
-ListingCardAction.displayName = "ListingCardAction";
+}

--- a/apps/main/src/components/listing-card.tsx
+++ b/apps/main/src/components/listing-card.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { TruncatedText } from "@/components/truncated-text";
@@ -18,7 +20,6 @@ import { ImagePlaceholder } from "./image-placeholder";
 import { ImagePopover } from "@/components/image-popover";
 import { AddToCartButton } from "@/components/add-to-cart-button";
 import { useDisplayAhsListing } from "@/hooks/use-display-ahs-listing";
-import { useListingDialogQueryState } from "@/hooks/use-listing-dialog-query-state";
 import {
   formatListingCardTitle,
   getListingCardTitleSizeClass,
@@ -29,10 +30,15 @@ type ListingCardProps = {
   listing: RouterOutputs["public"]["getListings"][number];
   className?: string;
   priority?: boolean;
+  children: React.ReactNode;
 };
 
-export function ListingCard({ listing, priority = false }: ListingCardProps) {
-  const { openListing } = useListingDialogQueryState();
+export function ListingCard({
+  listing,
+  className,
+  priority = false,
+  children,
+}: ListingCardProps) {
   const displayAhsListing = useDisplayAhsListing(listing);
   const displayTitle = formatListingCardTitle(listing.title);
   const titleSizeClass = getListingCardTitleSizeClass(displayTitle.length);
@@ -45,19 +51,12 @@ export function ListingCard({ listing, priority = false }: ListingCardProps) {
 
   return (
     <Card
-      className="group hover:border-primary relative flex h-full cursor-pointer flex-col overflow-hidden transition-all"
-      onClick={() => openListing(listing.id)}
+      className={cn(
+        "group hover:border-primary relative flex h-full cursor-pointer flex-col overflow-hidden transition-all",
+        className,
+      )}
     >
-      {/* Create SEO links for each URL variation */}
-      {/* {urlVariations.map((url, index) => (
-                    <SEOLink
-          key={`seo-link-${index}`}
-          href={url}
-          onCustomClick={() => openListing(listing.id)}
-          ariaLabel={`View details for ${listing.title}`}
-          srText={`View ${listing.title}`}
-        />
-      ))} */}
+      {children}
 
       <div className="relative">
         <div className="aspect-square">
@@ -87,7 +86,7 @@ export function ListingCard({ listing, priority = false }: ListingCardProps) {
 
         {/* Images Preview */}
         {hasMultipleImages && (
-          <div className="absolute bottom-2 left-2">
+          <div className="absolute bottom-2 left-2 z-20">
             <ImagePopover
               images={listing.images}
               size="sm"
@@ -98,7 +97,7 @@ export function ListingCard({ listing, priority = false }: ListingCardProps) {
 
         {/* AHS Link Badge */}
         {displayAhsListing && (
-          <div className="absolute right-2 bottom-2">
+          <div className="absolute right-2 bottom-2 z-20">
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -183,7 +182,7 @@ export function ListingCard({ listing, priority = false }: ListingCardProps) {
           <div className="flex items-center justify-between">
             {/* Lists */}
             {listing.lists.length > 0 && (
-              <div className="flex items-center gap-2">
+              <div className="relative z-20 flex items-center gap-2">
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger>
@@ -217,7 +216,7 @@ export function ListingCard({ listing, priority = false }: ListingCardProps) {
 
             {/* Add to Cart Button - Only show if listing has a price */}
             {listing.price !== null && (
-              <div className="z-10">
+              <div className="relative z-20">
                 <AddToCartButton
                   listing={{
                     id: listing.id,
@@ -234,3 +233,28 @@ export function ListingCard({ listing, priority = false }: ListingCardProps) {
     </Card>
   );
 }
+
+interface ListingCardActionProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export const ListingCardAction = React.forwardRef<
+  HTMLButtonElement,
+  ListingCardActionProps
+>(({ asChild = false, className, type = "button", ...props }, ref) => {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      ref={ref}
+      type={asChild ? undefined : type}
+      className={cn(
+        "focus-visible:ring-ring absolute inset-0 z-10 rounded-xl focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+ListingCardAction.displayName = "ListingCardAction";

--- a/apps/main/src/components/listing-display.tsx
+++ b/apps/main/src/components/listing-display.tsx
@@ -15,6 +15,7 @@ import { AddToCartButton } from "@/components/add-to-cart-button";
 import { useDisplayAhsListing } from "@/hooks/use-display-ahs-listing";
 import { toCultivarRouteSegment } from "@/lib/utils/cultivar-utils";
 import { CopyListingLinkButton } from "@/components/copy-listing-link-button";
+import { getPublicListingPath } from "@/lib/public-catalog-url-state";
 
 type Listing = RouterOutputs["public"]["getListings"][number];
 
@@ -34,7 +35,11 @@ export function ListingDisplay({
   const cultivarHref = cultivarRouteSegment
     ? `/cultivar/${cultivarRouteSegment}`
     : null;
-  const listingHref = `/${listing.userSlug}/${listing.slug || listing.id}`;
+  const listingHref = getPublicListingPath({
+    listingId: listing.id,
+    listingSlug: listing.slug,
+    sellerSlug: listing.userSlug,
+  });
 
   // Determine which heading component to use based on variant
   const HeadingComponent = variant === "page" ? H1 : H2;

--- a/apps/main/src/components/public-catalog-search/public-catalog-search-table.tsx
+++ b/apps/main/src/components/public-catalog-search/public-catalog-search-table.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { type Table } from "@tanstack/react-table";
-import { ListingCard } from "@/components/listing-card";
+import { ListingCard, ListingCardAction } from "@/components/listing-card";
+import { useListingDialogQueryState } from "@/hooks/use-listing-dialog-query-state";
 import { cn } from "@/lib/utils";
 import { type PublicCatalogListing } from "./public-catalog-search-types";
 
@@ -14,6 +15,7 @@ export function PublicCatalogSearchTable({
   table,
   desktopColumns,
 }: PublicCatalogSearchTableProps) {
+  const { openListing } = useListingDialogQueryState();
   const rows = table.getRowModel().rows;
 
   return (
@@ -27,10 +29,12 @@ export function PublicCatalogSearchTable({
     >
       {rows.map((row, index) => (
         <div key={row.original.id}>
-          <ListingCard
-            listing={row.original}
-            priority={index < desktopColumns}
-          />
+          <ListingCard listing={row.original} priority={index < desktopColumns}>
+            <ListingCardAction
+              onClick={() => openListing(row.original.id)}
+              aria-label={`View ${row.original.title}`}
+            />
+          </ListingCard>
         </div>
       ))}
     </div>

--- a/apps/main/src/lib/public-catalog-url-state.ts
+++ b/apps/main/src/lib/public-catalog-url-state.ts
@@ -53,3 +53,18 @@ export function getPublicProfilePagePath(slug: string, page: number) {
 
   return `/${slug}/page/${page}`;
 }
+
+export function getPublicListingPath({
+  listingId,
+  listingSlug,
+  sellerSlug,
+}: {
+  listingId: string;
+  listingSlug: string | null;
+  sellerSlug: string;
+}) {
+  const listingSegment =
+    listingSlug === null || listingSlug.length === 0 ? listingId : listingSlug;
+
+  return `/${sellerSlug}/${listingSegment}`;
+}

--- a/apps/main/tests/catalog-seo-listings.test.tsx
+++ b/apps/main/tests/catalog-seo-listings.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import { type ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { CatalogSeoListings } from "@/app/(public)/[userSlugOrId]/_components/catalog-seo-listings";
+import { type RouterOutputs } from "@/trpc/react";
 
 vi.mock("next/link", () => ({
   default: ({
@@ -13,12 +14,73 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
+  useParams: () => ({
+    userSlugOrId: "rollingoaksdaylilies",
+  }),
   useRouter: () => ({
     push: vi.fn(),
   }),
 }));
 
+vi.mock("@/hooks/use-listing-dialog-query-state", () => ({
+  useListingDialogQueryState: () => ({
+    viewingId: null,
+    closeListing: vi.fn(),
+  }),
+}));
+
+type Listing = RouterOutputs["public"]["getListings"][number];
+
+function createListing(id: string, title: string, slug: string): Listing {
+  return {
+    id,
+    title,
+    slug,
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    description: null,
+    price: null,
+    userId: "user-1",
+    user: {
+      profile: {
+        slug: "rollingoaksdaylilies",
+        title: "Rolling Oaks Daylilies",
+      },
+    },
+    userSlug: "rollingoaksdaylilies",
+    sellerTitle: "Rolling Oaks Daylilies",
+    lists: [],
+    images: [],
+    ahsListing: null,
+    cultivarReference: null,
+    cultivarReferenceImage: null,
+  } as unknown as Listing;
+}
+
 describe("CatalogSeoListings", () => {
+  it("renders canonical listing links with an ID fallback", () => {
+    render(
+      <CatalogSeoListings
+        canonicalUserSlug="rollingoaksdaylilies"
+        listings={[
+          createListing("listing-1", "A Green Desire", "a-green-desire"),
+          createListing("listing-2", "Seedling 24-7", ""),
+        ]}
+        profileLists={[]}
+        page={1}
+        totalPages={1}
+        totalCount={2}
+        forSaleCount={0}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "View A Green Desire" }),
+    ).toHaveAttribute("href", "/rollingoaksdaylilies/a-green-desire");
+    expect(
+      screen.getByRole("link", { name: "View Seedling 24-7" }),
+    ).toHaveAttribute("href", "/rollingoaksdaylilies/listing-2");
+  });
+
   it("renders list cards that link to catalog search with list filter", () => {
     render(
       <CatalogSeoListings

--- a/apps/main/tests/public-catalog-search-table-image-priority.test.tsx
+++ b/apps/main/tests/public-catalog-search-table-image-priority.test.tsx
@@ -1,23 +1,42 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import type { Table } from "@tanstack/react-table";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { PublicCatalogSearchTable } from "@/components/public-catalog-search/public-catalog-search-table";
 import type { PublicCatalogListing } from "@/components/public-catalog-search/public-catalog-search-types";
 
-const mockListingCard = vi.fn();
+const mockListingCard =
+  vi.fn<(props: { id: string; priority?: boolean }) => void>();
+const mockOpenListing = vi.fn();
 
 vi.mock("@/components/listing-card", () => ({
   ListingCard: ({
+    children,
     listing,
     priority,
   }: {
+    children: ReactNode;
     listing: PublicCatalogListing;
     priority?: boolean;
   }) => {
     mockListingCard({ id: listing.id, priority });
-    return <div>{listing.id}</div>;
+    return (
+      <div>
+        {listing.id}
+        {children}
+      </div>
+    );
   },
+  ListingCardAction: (props: React.ComponentProps<"button">) => (
+    <button type="button" {...props} />
+  ),
+}));
+
+vi.mock("@/hooks/use-listing-dialog-query-state", () => ({
+  useListingDialogQueryState: () => ({
+    openListing: mockOpenListing,
+  }),
 }));
 
 describe("PublicCatalogSearchTable image priority", () => {
@@ -52,4 +71,26 @@ describe("PublicCatalogSearchTable image priority", () => {
       ).toEqual(priorities);
     },
   );
+
+  it("opens a listing dialog from a search result card", () => {
+    const listings = [
+      {
+        id: "listing-1",
+        title: "A Green Desire",
+      },
+    ] as PublicCatalogListing[];
+    const table = {
+      getRowModel: () => ({
+        rows: listings.map((original) => ({ original })),
+      }),
+    } as unknown as Table<PublicCatalogListing>;
+
+    render(<PublicCatalogSearchTable table={table} desktopColumns={2} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "View A Green Desire" }),
+    );
+
+    expect(mockOpenListing).toHaveBeenCalledWith("listing-1");
+  });
 });

--- a/apps/main/tests/public-catalog-url-state.test.ts
+++ b/apps/main/tests/public-catalog-url-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getPublicListingPath,
   getPublicProfilePagePath,
   hasNonPageProfileParams,
   parsePositiveInteger,
@@ -7,6 +8,30 @@ import {
 } from "@/lib/public-catalog-url-state";
 
 describe("public catalog url state", () => {
+  it("builds canonical listing paths with an ID fallback", () => {
+    expect(
+      getPublicListingPath({
+        listingId: "listing-1",
+        listingSlug: "a-green-desire",
+        sellerSlug: "grower",
+      }),
+    ).toBe("/grower/a-green-desire");
+    expect(
+      getPublicListingPath({
+        listingId: "listing-1",
+        listingSlug: null,
+        sellerSlug: "grower",
+      }),
+    ).toBe("/grower/listing-1");
+    expect(
+      getPublicListingPath({
+        listingId: "listing-1",
+        listingSlug: "",
+        sellerSlug: "grower",
+      }),
+    ).toBe("/grower/listing-1");
+  });
+
   it("parses positive integer and falls back for invalid values", () => {
     expect(parsePositiveInteger("5", 1)).toBe(5);
     expect(parsePositiveInteger("0", 1)).toBe(1);


### PR DESCRIPTION
## Summary

Public seller catalog cards now expose canonical listing-page links on the normal and paginated catalog routes. Ordinary clicks navigate to the dedicated listing page, and native link behavior supports Back restoration, modifier-clicks, middle-clicks, context menus, and new tabs.

Search-result cards keep the existing listing-details dialog. Search terms, filters, result state, and scroll position stay on the search page.

## File changes

- `apps/main/src/components/listing-card.tsx`
  - Adds a composable `ListingCardAction` slot.
  - Uses a direct action component without an inaccurate polymorphic ref contract.
  - Keeps card controls above the full-card action without nested interactive elements.
  - Removes dialog-state ownership from the shared card.
- `apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings-grid.tsx`
  - Composes catalog cards with server-rendered canonical anchors.
  - Uses the listing ID when a listing slug is unavailable.
  - Keeps the dialog mounted for compatible existing `?viewing=` deep links.
- `apps/main/src/app/(public)/[userSlugOrId]/_components/catalog-seo-listings.tsx`
  - Passes the canonical seller slug to the listings grid.
- `apps/main/src/components/public-catalog-search/public-catalog-search-table.tsx`
  - Composes search cards with a button that opens the existing dialog.
- `apps/main/src/lib/public-catalog-url-state.ts`
  - Defines the shared canonical public listing-path builder and listing-ID fallback.
- `apps/main/src/components/listing-display.tsx`
  - Uses the shared public listing-path builder.
- `apps/main/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/page.tsx`
  - Uses the shared path builder for listing metadata and page URLs.
- `apps/main/tests/catalog-seo-listings.test.tsx`
  - Covers canonical seller/listing links and the listing-ID fallback.
- `apps/main/tests/public-catalog-search-table-image-priority.test.tsx`
  - Covers the search-card dialog action.
- `apps/main/tests/public-catalog-url-state.test.ts`
  - Covers canonical listing slugs and null or empty slug fallbacks.

## SEO reason

The normal catalog HTML now contains ordinary links to each canonical dedicated listing page. Crawlers can discover these listing pages without running the listing dialog client code.

## Browser evidence

Checked in Chrome against the local app with seeded catalog data:

- Raw server HTML for the normal catalog and page 2 contained canonical listing anchors.
- An ordinary catalog-card click opened the dedicated listing page.
- Back returned to page 2 at the exact prior scroll position.
- Modifier-click opened the dedicated listing in a new tab and kept the catalog tab in place.
- Enter on a catalog-card link opened the dedicated listing page.
- A search-result card opened the listing dialog without leaving the search route.
- Closing the dialog preserved the search term, For Sale filter, result set, and exact scroll position.
- Cultivar links, cart controls, and image previews kept their existing behavior without unwanted card navigation.
- An existing catalog `?viewing=` deep link still opened the listing dialog.

## Test evidence

- Focused Vitest run: 7 files and 28 tests passed.
- Final change-focused Vitest run: 3 files and 14 tests passed.
- `pnpm typecheck` passed.
- Targeted ESLint for the changed source and tests passed.
- Full lint passed with one unrelated existing warning in `dashboard-db-provider.tsx`.
- `git diff --check` passed.
- Two automated review findings were fixed: the card focus ring is inset, and existing catalog dialog deep links remain compatible.
- The final automated review found no actionable defects.
- The thermo-nuclear maintainability findings were fixed by removing the false ref contract and centralizing canonical listing paths.

## Pending

- GitHub CI remains pending.
- Production verification is not part of this local change.
