### PR TITLE
Track importer checkout exits

### DIFF
--- a/apps/main/src/app/catalog-importer/checkout/catalog-importer-checkout-start.tsx
+++ b/apps/main/src/app/catalog-importer/checkout/catalog-importer-checkout-start.tsx
@@ -99,6 +99,7 @@ export function CatalogImporterCheckoutStart({
             size="lg"
             className="w-full"
             data-ph-capture-attribute-action="checkout-submit"
+            data-ph-capture-attribute-email={email.trim().toLowerCase()}
             disabled={!isReady || !emailIsValid || createCheckout.isPending}
           >
             {createCheckout.isPending ? (

--- a/apps/main/src/server/catalog-importer/checkout-service.ts
+++ b/apps/main/src/server/catalog-importer/checkout-service.ts
@@ -224,7 +224,9 @@ export async function createCatalogImporterCheckout({
       },
     },
     success_url: `${baseUrl}/catalog-importer/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${baseUrl}${CATALOG_IMPORTER_RETURN_PATH}`,
+    cancel_url: `${baseUrl}${CATALOG_IMPORTER_RETURN_PATH}?checkout=canceled&import_id=${encodeURIComponent(
+      input.importId,
+    )}`,
     metadata: {
       email: input.email,
       ...sourceMetadata,

--- a/apps/main/tests/catalog-importer-checkout-router.test.ts
+++ b/apps/main/tests/catalog-importer-checkout-router.test.ts
@@ -133,7 +133,7 @@ describe("catalog importer checkout", () => {
       },
       success_url:
         "https://daylilycatalog.test/catalog-importer/checkout/success?session_id={CHECKOUT_SESSION_ID}",
-      cancel_url: "https://daylilycatalog.test/catalog-importer",
+      cancel_url: `https://daylilycatalog.test/catalog-importer?checkout=canceled&import_id=${checkoutInput().importId}`,
       metadata: {
         email: "seller@example.com",
         import_id: checkoutInput().importId,
@@ -157,7 +157,8 @@ describe("catalog importer checkout", () => {
       expect.objectContaining({
         success_url:
           "http://localhost:3007/catalog-importer/checkout/success?session_id={CHECKOUT_SESSION_ID}",
-        cancel_url: "http://localhost:3007/catalog-importer",
+        cancel_url:
+          "http://localhost:3007/catalog-importer?checkout=canceled&import_id=123e4567-e89b-42d3-a456-426614174000",
       }),
     );
   });


### PR DESCRIPTION
## Summary

- Add the normalized checkout email to the existing `checkout-submit` autocapture event.
- Add `checkout=canceled` and `import_id` to Stripe's Back-link return URL so the existing PostHog pageview records explicit checkout exits.
- Keep the Stripe webhook unchanged.

## Root cause

Stripe Checkout runs on Stripe's domain, so our existing autocapture could record the submit click but not the email used or an explicit return through Stripe's Back link.

## Files

- `apps/main/src/app/catalog-importer/checkout/catalog-importer-checkout-start.tsx`: adds email metadata to the existing submit autocapture target.
- `apps/main/src/server/catalog-importer/checkout-service.ts`: tags Stripe's cancel return URL for the automatic pageview.
- `apps/main/tests/catalog-importer-checkout-router.test.ts`: verifies the production and localhost cancel URLs.

## Validation

- `pnpm --filter main test -- tests/catalog-importer-checkout-router.test.ts`
- `pnpm --filter main typecheck`
- Focused ESLint and `git diff --check`