### PR TITLE
Track canceled importer checkouts

### DIFF
--- a/apps/main/src/app/(public)/catalog-importer/_components/catalog-importer-client.tsx
+++ b/apps/main/src/app/(public)/catalog-importer/_components/catalog-importer-client.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CatalogImporterWorkbench } from "@/app/(public)/catalog-importer/_components/catalog-importer-workbench";
 import { Spinner } from "@/components/ui/spinner";
+import { capturePosthogEvent } from "@/lib/analytics/posthog";
 import {
   readCatalogImporterDraft,
   type CatalogImporterDraft,
@@ -24,6 +25,30 @@ export function CatalogImporterClient({
   const [initialDraft, setInitialDraft] = useState<
     CatalogImporterDraft | null | undefined
   >(undefined);
+  useEffect(() => {
+    const captureCheckoutCancellation = () => {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get("checkout") !== "canceled") {
+        return;
+      }
+
+      capturePosthogEvent("checkout_canceled", {
+        import_id: url.searchParams.get("import_id") ?? undefined,
+      });
+      url.searchParams.delete("checkout");
+      url.searchParams.delete("import_id");
+      window.history.replaceState(
+        window.history.state,
+        "",
+        `${url.pathname}${url.search}${url.hash}`,
+      );
+    };
+
+    captureCheckoutCancellation();
+    window.addEventListener("pageshow", captureCheckoutCancellation);
+    return () =>
+      window.removeEventListener("pageshow", captureCheckoutCancellation);
+  }, []);
   useEffect(() => {
     const controller = new AbortController();
     void fetch("/api/catalog-importer/viewer-state", {

--- a/apps/main/src/lib/analytics/posthog.ts
+++ b/apps/main/src/lib/analytics/posthog.ts
@@ -15,6 +15,7 @@ export type PosthogEventName =
   | "onboarding_membership_screen_viewed"
   | "onboarding_membership_continue_for_now_clicked"
   | "checkout_started"
+  | "checkout_canceled"
   | "checkout_redirect_ready"
   | "checkout_failed"
   | "trial_started"

--- a/apps/main/src/server/catalog-importer/checkout-service.ts
+++ b/apps/main/src/server/catalog-importer/checkout-service.ts
@@ -259,7 +259,9 @@ export async function createSignedInCatalogImporterCheckout({
   };
 
   return createSubscriptionCheckout({
-    cancelPath: input.returnTo,
+    cancelPath: `${input.returnTo}?checkout=canceled&import_id=${encodeURIComponent(
+      input.importId,
+    )}`,
     db,
     metadata,
     successPath: `/subscribe/success?redirect=${encodeURIComponent(

--- a/apps/main/tests/catalog-importer-checkout-router.test.ts
+++ b/apps/main/tests/catalog-importer-checkout-router.test.ts
@@ -337,7 +337,8 @@ describe("catalog importer checkout", () => {
 
     expect(stripeMocks.checkoutCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        cancel_url: "https://daylilycatalog.test/catalog-importer",
+        cancel_url:
+          "https://daylilycatalog.test/catalog-importer?checkout=canceled&import_id=123e4567-e89b-42d3-a456-426614174000",
         metadata: {
           userId: "user-importer",
           import_id: input.importId,

--- a/apps/main/tests/catalog-importer-client.test.tsx
+++ b/apps/main/tests/catalog-importer-client.test.tsx
@@ -3,9 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CatalogImporterClient } from "@/app/(public)/catalog-importer/_components/catalog-importer-client";
 
 const readCatalogImporterDraftMock = vi.hoisted(() => vi.fn());
+const capturePosthogEventMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/catalog-importer-draft", () => ({
   readCatalogImporterDraft: readCatalogImporterDraftMock,
+}));
+
+vi.mock("@/lib/analytics/posthog", () => ({
+  capturePosthogEvent: capturePosthogEventMock,
 }));
 
 vi.mock(
@@ -34,6 +39,8 @@ vi.mock(
 describe("CatalogImporterClient", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    capturePosthogEventMock.mockClear();
+    window.history.replaceState(null, "", "/catalog-importer");
   });
 
   it("reads the current browser draft on every mount", async () => {
@@ -77,5 +84,32 @@ describe("CatalogImporterClient", () => {
     expect(
       await screen.findByText(/No restored spreadsheet · unavailable/),
     ).toBeVisible();
+  });
+
+  it("records a cached return from Stripe checkout once", async () => {
+    readCatalogImporterDraftMock.mockResolvedValueOnce(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ viewerState: "anonymous" }), {
+          status: 200,
+        }),
+      ),
+    );
+    render(<CatalogImporterClient />);
+    await screen.findByText(/No restored spreadsheet · anonymous/);
+
+    window.history.replaceState(
+      null,
+      "",
+      "/catalog-importer?checkout=canceled&import_id=import-123",
+    );
+    window.dispatchEvent(new PageTransitionEvent("pageshow"));
+
+    expect(capturePosthogEventMock).toHaveBeenCalledOnce();
+    expect(capturePosthogEventMock).toHaveBeenCalledWith("checkout_canceled", {
+      import_id: "import-123",
+    });
+    expect(window.location.href).toBe("http://localhost:3000/catalog-importer");
   });
 });


### PR DESCRIPTION
## Summary

Track customers who leave Stripe Checkout and return to the catalog importer.

The importer can be restored from the browser back-forward cache. In that case, PostHog does not emit a new pageview. The client now captures an explicit `checkout_canceled` event when the Stripe cancel marker appears. It then removes the marker so a refresh does not count the same return again.

## Files

- `catalog-importer-client.tsx`: Capture the cancel event on initial load and `pageshow`, including the import ID.
- `posthog.ts`: Add `checkout_canceled` to the allowed event names.
- `catalog-importer-client.test.tsx`: Cover a cached Stripe return and verify one event plus URL cleanup.

## Checks

- `pnpm --dir apps/main test -- catalog-importer-client.test.tsx`
- `pnpm --dir apps/main typecheck`
- Targeted ESLint for the three changed files
- `git diff --check`