### PR TITLE
Keep last-known-good search index available

### DIFF
--- a/apps/main/src/server/search/public-search-index.ts
+++ b/apps/main/src/server/search/public-search-index.ts
@@ -10,7 +10,6 @@ import { env, isLibsqlDatabaseUrl } from "@/env";
 const execFileAsync = promisify(execFile);
 
 const DEFAULT_SEARCH_INDEX_REFRESH_INTERVAL_SECONDS = 60 * 60;
-const SEARCH_INDEX_MAX_STALE_SECONDS = 24 * 60 * 60;
 const SEARCH_INDEX_REFRESH_LOCK_STALE_MS = 10 * 60 * 1000;
 const EXPECTED_SEARCH_INDEX_SCHEMA_VERSION = "13";
 const PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH =
@@ -178,11 +177,7 @@ function getStatusFromAge(
     return "fresh" satisfies PublicSearchIndexStatus["status"];
   }
 
-  if (ageSeconds < SEARCH_INDEX_MAX_STALE_SECONDS) {
-    return "stale" satisfies PublicSearchIndexStatus["status"];
-  }
-
-  return "expired" satisfies PublicSearchIndexStatus["status"];
+  return "stale" satisfies PublicSearchIndexStatus["status"];
 }
 
 function toStringOrNull(value: unknown) {
@@ -349,8 +344,10 @@ async function refreshPublicSearchIndex(): Promise<PublicSearchIndexStatus> {
       return getPublicSearchIndexStatus();
     }
 
+    let stage = "source_sync";
     try {
       const sourcePath = await preparePublicSearchBuildSource();
+      stage = "index_build";
       const buildArgs = [getBuildScriptPath()];
 
       if (sourcePath) {
@@ -397,6 +394,7 @@ async function refreshPublicSearchIndex(): Promise<PublicSearchIndexStatus> {
     } catch (error) {
       logSearchIndex("public_search_index_build_failed", {
         error: error instanceof Error ? error.message : String(error),
+        stage,
       });
       throw error;
     } finally {

--- a/apps/main/tests/public-search-index-refresh.test.ts
+++ b/apps/main/tests/public-search-index-refresh.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => {
     closeStatusClient: vi.fn(),
     createClient: vi.fn(),
     createClientConfigs: [] as LibSqlClientConfigSnapshot[],
+    indexBuiltAt: new Date().toISOString(),
     execFile,
     execFilePromisified,
     indexExists: false,
@@ -97,6 +98,7 @@ describe("public search index refresh", () => {
     mocks.createClient.mockReset();
     mocks.createClientConfigs.length = 0;
     mocks.execFilePromisified.mockReset();
+    mocks.indexBuiltAt = new Date().toISOString();
     mocks.indexExists = false;
     mocks.lockClose.mockReset();
     mocks.lockWriteFile.mockReset();
@@ -145,7 +147,7 @@ describe("public search index refresh", () => {
       if (sql.includes("SearchIndexMeta")) {
         return {
           rows: [
-            { key: "builtAt", value: new Date().toISOString() },
+            { key: "builtAt", value: mocks.indexBuiltAt },
             {
               key: "sourcePath",
               value: "/data/search/public-search-source-replica.sqlite",
@@ -183,6 +185,7 @@ describe("public search index refresh", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllEnvs();
     vi.resetModules();
   });
@@ -238,6 +241,28 @@ describe("public search index refresh", () => {
     );
     expect(mocks.sourceSync).not.toHaveBeenCalled();
     expect(mocks.execFilePromisified).not.toHaveBeenCalled();
+  });
+
+  it("keeps an old index usable when its background refresh fails", async () => {
+    mocks.indexBuiltAt = new Date(0).toISOString();
+    mocks.indexExists = true;
+    mocks.sourceSync.mockRejectedValue(
+      new Error("database disk image is malformed"),
+    );
+    const log = vi.spyOn(console, "log");
+
+    const { ensurePublicSearchIndex, isPublicSearchIndexUsable } = await import(
+      "@/server/search/public-search-index"
+    );
+
+    const status = await ensurePublicSearchIndex();
+
+    expect(status.status).toBe("stale");
+    expect(isPublicSearchIndexUsable(status)).toBe(true);
+    await vi.waitFor(() => expect(mocks.sourceSync).toHaveBeenCalledOnce());
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('"stage":"source_sync"'),
+    );
   });
 
   it("prepares a search source replica without requiring the live app replica env", async () => {


### PR DESCRIPTION
## Summary

- Keep a schema-compatible public search index usable regardless of age.
- Continue to refresh stale indexes in the background, so a failed refresh does not fail search or cultivar matching.
- Identify failed refreshes as `source_sync` or `index_build` in the existing structured failure event.
- Add one regression test for an old serving index and a malformed source replica.

## Files

- `apps/main/src/server/search/public-search-index.ts`: remove the 24-hour hard expiration cutoff and add the failure stage to the existing JSON event.
- `apps/main/tests/public-search-index-refresh.test.ts`: prove the old index remains stale and usable when source sync fails, and prove the event identifies `source_sync`.

## Verification

- `pnpm --filter @daylily-catalog/main test -- public-search-index-refresh.test.ts`
- `pnpm --filter @daylily-catalog/main typecheck`
- Prettier check for both changed files
- `git diff --check`