### PR TITLE
Self-heal corrupted search source replicas

### DIFF
--- a/apps/main/scripts/build-public-search-index.mjs
+++ b/apps/main/scripts/build-public-search-index.mjs
@@ -724,6 +724,27 @@ SELECT 'quickCheck', quick_check FROM pragma_quick_check;
   return output.trim();
 }
 
+function validateSource(sourcePath) {
+  let output;
+  try {
+    output = execFileSync("sqlite3", [sourcePath, "PRAGMA quick_check;"], {
+      encoding: "utf8",
+    }).trim();
+  } catch (error) {
+    throw new Error(
+      `Source replica post_build quick_check failed:\n${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (output !== "ok") {
+    throw new Error(`Source replica post_build quick_check failed:\n${output}`);
+  }
+
+  return output;
+}
+
 function main() {
   const startedAt = performance.now();
   const args = parseArgs();
@@ -752,7 +773,9 @@ function main() {
   });
 
   const validation = validateIndex(nextPath);
+  const sourceValidation = validateSource(sourcePath);
 
+  console.log(`Source quick_check: ${sourceValidation}`);
   replaceSqliteDatabase({ nextPath, previousPath, targetPath });
 
   const elapsedMs = Math.round(performance.now() - startedAt);

--- a/apps/main/src/server/search/public-search-index.ts
+++ b/apps/main/src/server/search/public-search-index.ts
@@ -119,10 +119,20 @@ async function checkPublicSearchBuildSource(
     );
     result = stdout.trim();
   } catch (error) {
-    throw new SourceReplicaIntegrityError(
-      phase,
-      error instanceof Error ? error.message : String(error),
-    );
+    const detail =
+      error instanceof Error && "stderr" in error
+        ? `${error.message}\n${String(error.stderr)}`
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    if (
+      !/database disk image is malformed|file is not a database|malformed database schema/i.test(
+        detail,
+      )
+    ) {
+      throw error;
+    }
+    throw new SourceReplicaIntegrityError(phase, detail);
   }
 
   logSearchIndex("public_search_source_integrity_checked", { phase, result });

--- a/apps/main/src/server/search/public-search-index.ts
+++ b/apps/main/src/server/search/public-search-index.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { execFile } from "node:child_process";
-import { mkdir, open, stat, unlink } from "node:fs/promises";
+import { mkdir, open, rename, stat, unlink } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { createClient } from "@libsql/client";
@@ -14,6 +14,13 @@ const SEARCH_INDEX_REFRESH_LOCK_STALE_MS = 10 * 60 * 1000;
 const EXPECTED_SEARCH_INDEX_SCHEMA_VERSION = "13";
 const PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH =
   "/data/search/public-search-source-replica.sqlite";
+const PUBLIC_SEARCH_BUILD_SOURCE_SUFFIXES = [
+  "",
+  "-info",
+  "-wal",
+  "-shm",
+  "-journal",
+];
 
 interface SearchIndexMeta {
   builtAt: string | null;
@@ -50,6 +57,15 @@ const globalForPublicSearchIndex = globalThis as unknown as {
   publicSearchIndexRefreshPromise: Promise<PublicSearchIndexStatus> | undefined;
 };
 
+class SourceReplicaIntegrityError extends Error {
+  constructor(
+    readonly phase: string,
+    detail: string,
+  ) {
+    super(`Source replica ${phase} quick_check failed: ${detail}`);
+  }
+}
+
 function getAppRoot() {
   const cwd = process.cwd();
 
@@ -76,6 +92,45 @@ function getRefreshLockPath() {
   return `${getPublicSearchIndexPath()}.refresh.lock`;
 }
 
+async function checkPublicSearchBuildSource(
+  phase: "pre_sync" | "post_sync",
+  allowMissing = false,
+) {
+  try {
+    await stat(PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH);
+  } catch (error) {
+    if (allowMissing && isMissingFileError(error)) {
+      logSearchIndex("public_search_source_integrity_checked", {
+        phase,
+        result: "missing",
+      });
+      return;
+    }
+
+    throw error;
+  }
+
+  let result: string;
+  try {
+    const { stdout } = await execFileAsync(
+      "sqlite3",
+      [PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH, "PRAGMA quick_check;"],
+      { maxBuffer: 1024 * 1024 },
+    );
+    result = stdout.trim();
+  } catch (error) {
+    throw new SourceReplicaIntegrityError(
+      phase,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  logSearchIndex("public_search_source_integrity_checked", { phase, result });
+  if (result !== "ok") {
+    throw new SourceReplicaIntegrityError(phase, result);
+  }
+}
+
 async function preparePublicSearchBuildSource() {
   const databaseUrl = env.DATABASE_URL;
 
@@ -91,6 +146,7 @@ async function preparePublicSearchBuildSource() {
   await mkdir(path.dirname(PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH), {
     recursive: true,
   });
+  await checkPublicSearchBuildSource("pre_sync", true);
 
   const client = createClient({
     authToken: env.TURSO_DATABASE_AUTH_TOKEN,
@@ -104,6 +160,7 @@ async function preparePublicSearchBuildSource() {
     client.close();
   }
 
+  await checkPublicSearchBuildSource("post_sync");
   return PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH;
 }
 
@@ -335,6 +392,105 @@ function logSearchIndex(event: string, payload: Record<string, unknown> = {}) {
   );
 }
 
+function getRecoverableSourcePhase(error: unknown, stage: string) {
+  if (error instanceof SourceReplicaIntegrityError) {
+    return error.phase;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  if (/post_build/i.test(message)) {
+    return "post_build";
+  }
+
+  return /InvalidLocalState|database disk image is malformed/i.test(message)
+    ? stage
+    : null;
+}
+
+async function quarantinePublicSearchBuildSource(
+  phase: string,
+  sourceError: unknown,
+) {
+  const quarantineDirectory = `${PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH}.quarantine-${Date.now()}`;
+  await mkdir(quarantineDirectory, { recursive: true });
+  const files: string[] = [];
+
+  for (const suffix of PUBLIC_SEARCH_BUILD_SOURCE_SUFFIXES) {
+    const sourcePath = `${PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH}${suffix}`;
+    try {
+      await rename(
+        sourcePath,
+        path.join(quarantineDirectory, path.basename(sourcePath)),
+      );
+      files.push(path.basename(sourcePath));
+    } catch (error) {
+      if (!isMissingFileError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  logSearchIndex("public_search_source_quarantined", {
+    error:
+      sourceError instanceof Error ? sourceError.message : String(sourceError),
+    files,
+    phase,
+    quarantineDirectory,
+  });
+}
+
+async function runPublicSearchIndexRefreshAttempt(state: { stage: string }) {
+  state.stage = "source_sync";
+  const sourcePath = await preparePublicSearchBuildSource();
+  state.stage = "index_build";
+  const buildArgs = [getBuildScriptPath()];
+
+  if (sourcePath) {
+    buildArgs.push("--source", sourcePath);
+  }
+
+  buildArgs.push("--target", getPublicSearchIndexPath());
+
+  logSearchIndex("public_search_index_build_started", {
+    path: getPublicSearchIndexPath(),
+    sourcePath,
+  });
+
+  const { stdout, stderr } = await execFileAsync(process.execPath, buildArgs, {
+    cwd: getAppRoot(),
+    env: process.env,
+    maxBuffer: 1024 * 1024,
+  });
+
+  if (sourcePath) {
+    logSearchIndex("public_search_source_integrity_checked", {
+      phase: "post_build",
+      result: "ok",
+    });
+  }
+
+  if (stdout.trim().length > 0) {
+    logSearchIndex("public_search_index_build_stdout", {
+      output: stdout.trim(),
+    });
+  }
+
+  if (stderr.trim().length > 0) {
+    logSearchIndex("public_search_index_build_stderr", {
+      output: stderr.trim(),
+    });
+  }
+
+  const status = await getPublicSearchIndexStatus();
+  logSearchIndex("public_search_index_build_succeeded", {
+    ageSeconds: status.ageSeconds,
+    counts: status.counts,
+    path: status.path,
+  });
+
+  return status;
+}
+
 async function refreshPublicSearchIndex(): Promise<PublicSearchIndexStatus> {
   globalForPublicSearchIndex.publicSearchIndexRefreshPromise ??= (async () => {
     const releaseLock = await acquireRefreshLock();
@@ -344,57 +500,36 @@ async function refreshPublicSearchIndex(): Promise<PublicSearchIndexStatus> {
       return getPublicSearchIndexStatus();
     }
 
-    let stage = "source_sync";
+    const state = { stage: "source_sync" };
+    let recoveryPhase: string | null = null;
     try {
-      const sourcePath = await preparePublicSearchBuildSource();
-      stage = "index_build";
-      const buildArgs = [getBuildScriptPath()];
-
-      if (sourcePath) {
-        buildArgs.push("--source", sourcePath);
+      try {
+        return await runPublicSearchIndexRefreshAttempt(state);
+      } catch (error) {
+        recoveryPhase = getRecoverableSourcePhase(error, state.stage);
+        if (!recoveryPhase) {
+          throw error;
+        }
+        await quarantinePublicSearchBuildSource(recoveryPhase, error);
       }
 
-      buildArgs.push("--target", getPublicSearchIndexPath());
-
-      logSearchIndex("public_search_index_build_started", {
-        path: getPublicSearchIndexPath(),
-        sourcePath,
-      });
-
-      const { stdout, stderr } = await execFileAsync(
-        process.execPath,
-        buildArgs,
-        {
-          cwd: getAppRoot(),
-          env: process.env,
-          maxBuffer: 1024 * 1024,
-        },
-      );
-
-      if (stdout.trim().length > 0) {
-        logSearchIndex("public_search_index_build_stdout", {
-          output: stdout.trim(),
+      try {
+        const status = await runPublicSearchIndexRefreshAttempt(state);
+        logSearchIndex("public_search_source_recovery_succeeded", {
+          phase: recoveryPhase,
         });
-      }
-
-      if (stderr.trim().length > 0) {
-        logSearchIndex("public_search_index_build_stderr", {
-          output: stderr.trim(),
+        return status;
+      } catch (error) {
+        logSearchIndex("public_search_source_recovery_failed", {
+          error: error instanceof Error ? error.message : String(error),
+          phase: recoveryPhase,
         });
+        throw error;
       }
-
-      const status = await getPublicSearchIndexStatus();
-      logSearchIndex("public_search_index_build_succeeded", {
-        ageSeconds: status.ageSeconds,
-        counts: status.counts,
-        path: status.path,
-      });
-
-      return status;
     } catch (error) {
       logSearchIndex("public_search_index_build_failed", {
         error: error instanceof Error ? error.message : String(error),
-        stage,
+        stage: state.stage,
       });
       throw error;
     } finally {

--- a/apps/main/src/server/search/public-search-index.ts
+++ b/apps/main/src/server/search/public-search-index.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { execFile } from "node:child_process";
-import { mkdir, open, rename, stat, unlink } from "node:fs/promises";
+import { mkdir, open, rename, rm, stat, unlink } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { createClient } from "@libsql/client";
@@ -411,7 +411,8 @@ async function quarantinePublicSearchBuildSource(
   phase: string,
   sourceError: unknown,
 ) {
-  const quarantineDirectory = `${PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH}.quarantine-${Date.now()}`;
+  const quarantineDirectory = `${PUBLIC_SEARCH_BUILD_SOURCE_REPLICA_PATH}.quarantine`;
+  await rm(quarantineDirectory, { force: true, recursive: true });
   await mkdir(quarantineDirectory, { recursive: true });
   const files: string[] = [];
 

--- a/apps/main/tests/build-public-search-index.test.ts
+++ b/apps/main/tests/build-public-search-index.test.ts
@@ -172,11 +172,12 @@ describe("build-public-search-index source selection", () => {
 
     try {
       createAuthoritativeFlowerShowSource(sourcePath);
-      await execFileAsync(
+      const { stdout } = await execFileAsync(
         process.execPath,
         [buildScriptPath, "--source", sourcePath, "--target", targetPath],
         { env: process.env },
       );
+      expect(stdout).toContain("Source quick_check: ok");
 
       const targetDb = new DatabaseSync(targetPath, { readOnly: true });
       const rows = targetDb

--- a/apps/main/tests/build-public-search-index.test.ts
+++ b/apps/main/tests/build-public-search-index.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
-import { execFile } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { execFile, execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -137,6 +137,27 @@ function createAuthoritativeFlowerShowSource(sourcePath: string) {
   db.close();
 }
 
+function createFailingSourceCheckSqlite(binDirectory: string) {
+  const sqlitePath = execFileSync("which", ["sqlite3"], {
+    encoding: "utf8",
+  }).trim();
+  const wrapperPath = path.join(binDirectory, "sqlite3");
+
+  writeFileSync(
+    wrapperPath,
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "$FAIL_SOURCE_PATH" ] && [ "$2" = "PRAGMA quick_check;" ]; then',
+      '  echo "database disk image is malformed" >&2',
+      "  exit 11",
+      "fi",
+      `exec "${sqlitePath}" "$@"`,
+      "",
+    ].join("\n"),
+  );
+  chmodSync(wrapperPath, 0o755);
+}
+
 describe("build-public-search-index source selection", () => {
   it("requires an explicit source in production", async () => {
     const error = await runBuildScript([], {
@@ -213,6 +234,47 @@ describe("build-public-search-index source selection", () => {
         { value: "Pleated", count: 1 },
       ]);
       targetDb.close();
+    } finally {
+      rmSync(tempDirectory, { force: true, recursive: true });
+    }
+  });
+
+  it("does not promote an index when the final source check fails", async () => {
+    const tempDirectory = mkdtempSync(
+      path.join(tmpdir(), "public-search-source-check-"),
+    );
+    const sourcePath = path.join(tempDirectory, "source.sqlite");
+    const targetPath = path.join(tempDirectory, "target.sqlite");
+
+    try {
+      createAuthoritativeFlowerShowSource(sourcePath);
+      const targetDb = new DatabaseSync(targetPath);
+      targetDb.exec(
+        "CREATE TABLE Marker (value TEXT); INSERT INTO Marker VALUES ('old');",
+      );
+      targetDb.close();
+      createFailingSourceCheckSqlite(tempDirectory);
+
+      const error = await runBuildScript(
+        ["--source", sourcePath, "--target", targetPath],
+        {
+          FAIL_SOURCE_PATH: sourcePath,
+          PATH: `${tempDirectory}:${process.env.PATH}`,
+        },
+      );
+
+      expect(error).toMatchObject({
+        stderr: expect.stringContaining(
+          "Source replica post_build quick_check failed",
+        ),
+      });
+      const preservedTarget = new DatabaseSync(targetPath, { readOnly: true });
+      expect(preservedTarget.prepare("SELECT value FROM Marker").get()).toEqual(
+        {
+          value: "old",
+        },
+      );
+      preservedTarget.close();
     } finally {
       rmSync(tempDirectory, { force: true, recursive: true });
     }

--- a/apps/main/tests/public-search-index-refresh.test.ts
+++ b/apps/main/tests/public-search-index-refresh.test.ts
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
     lockWriteFile: vi.fn(),
     mkdir: vi.fn(),
     open: vi.fn(),
+    rename: vi.fn(),
     sourceSync: vi.fn(),
     stat: vi.fn(),
     statusExecute: vi.fn(),
@@ -78,6 +79,7 @@ vi.mock("node:child_process", () => ({
 vi.mock("node:fs/promises", () => ({
   mkdir: mocks.mkdir,
   open: mocks.open,
+  rename: mocks.rename,
   stat: mocks.stat,
   unlink: mocks.unlink,
 }));
@@ -104,6 +106,7 @@ describe("public search index refresh", () => {
     mocks.lockWriteFile.mockReset();
     mocks.mkdir.mockReset();
     mocks.open.mockReset();
+    mocks.rename.mockReset();
     mocks.sourceSync.mockReset();
     mocks.stat.mockReset();
     mocks.statusExecute.mockReset();
@@ -116,6 +119,7 @@ describe("public search index refresh", () => {
     } satisfies MockFileHandle);
     mocks.lockClose.mockResolvedValue(undefined);
     mocks.lockWriteFile.mockResolvedValue(undefined);
+    mocks.rename.mockResolvedValue(undefined);
     mocks.unlink.mockResolvedValue(undefined);
 
     mocks.stat.mockImplementation(async (filePath: string) => {
@@ -134,7 +138,11 @@ describe("public search index refresh", () => {
       return { mtimeMs: Date.now() };
     });
 
-    mocks.execFilePromisified.mockImplementation(async () => {
+    mocks.execFilePromisified.mockImplementation(async (file: string) => {
+      if (file === "sqlite3") {
+        return { stderr: "", stdout: "ok\n" };
+      }
+
       mocks.indexExists = true;
 
       return {
@@ -204,7 +212,9 @@ describe("public search index refresh", () => {
     });
     expect(mocks.sourceSync).toHaveBeenCalledTimes(1);
     expect(mocks.closeSourceClient).toHaveBeenCalledTimes(1);
-    const execArgs = mocks.execFilePromisified.mock.calls[0]?.[1];
+    const execArgs = mocks.execFilePromisified.mock.calls.find(
+      ([file]) => file === process.execPath,
+    )?.[1];
 
     expect(execArgs).not.toContain("/data/turso-replica.db");
     expect(execArgs).toContain(
@@ -243,12 +253,10 @@ describe("public search index refresh", () => {
     expect(mocks.execFilePromisified).not.toHaveBeenCalled();
   });
 
-  it("keeps an old index usable when its background refresh fails", async () => {
+  it("keeps an old index usable while repairing its source replica", async () => {
     mocks.indexBuiltAt = new Date(0).toISOString();
     mocks.indexExists = true;
-    mocks.sourceSync.mockRejectedValue(
-      new Error("database disk image is malformed"),
-    );
+    mocks.sourceSync.mockRejectedValueOnce(new Error("InvalidLocalState"));
     const log = vi.spyOn(console, "log");
 
     const { ensurePublicSearchIndex, isPublicSearchIndexUsable } = await import(
@@ -259,10 +267,27 @@ describe("public search index refresh", () => {
 
     expect(status.status).toBe("stale");
     expect(isPublicSearchIndexUsable(status)).toBe(true);
-    await vi.waitFor(() => expect(mocks.sourceSync).toHaveBeenCalledOnce());
-    expect(log).toHaveBeenCalledWith(
-      expect.stringContaining('"stage":"source_sync"'),
+    await vi.waitFor(() =>
+      expect(mocks.execFilePromisified).toHaveBeenCalledWith(
+        process.execPath,
+        expect.anything(),
+        expect.anything(),
+      ),
     );
+    expect(mocks.sourceSync).toHaveBeenCalledTimes(2);
+    expect(mocks.rename.mock.calls.map(([source]) => source)).toEqual(
+      ["", "-info", "-wal", "-shm", "-journal"].map(
+        (suffix) => `/data/search/public-search-source-replica.sqlite${suffix}`,
+      ),
+    );
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("public_search_source_recovery_succeeded"),
+    );
+    for (const phase of ["pre_sync", "post_sync", "post_build"]) {
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining(`"phase":"${phase}"`),
+      );
+    }
   });
 
   it("prepares a search source replica without requiring the live app replica env", async () => {

--- a/apps/main/tests/public-search-index-refresh.test.ts
+++ b/apps/main/tests/public-search-index-refresh.test.ts
@@ -298,6 +298,54 @@ describe("public search index refresh", () => {
     }
   });
 
+  it("repairs a source replica that fails its post-sync integrity check", async () => {
+    mocks.execFilePromisified
+      .mockResolvedValueOnce({ stderr: "", stdout: "ok\n" })
+      .mockRejectedValueOnce(
+        Object.assign(new Error("sqlite3 quick_check failed"), {
+          code: 11,
+          stderr: "database disk image is malformed",
+        }),
+      );
+    const log = vi.spyOn(console, "log");
+
+    const { ensurePublicSearchIndex } = await import(
+      "@/server/search/public-search-index"
+    );
+
+    await ensurePublicSearchIndex();
+
+    expect(mocks.sourceSync).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.execFilePromisified.mock.calls.filter(
+        ([file]) => file === process.execPath,
+      ),
+    ).toHaveLength(1);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('"phase":"post_sync"'),
+    );
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("public_search_source_recovery_succeeded"),
+    );
+  });
+
+  it("does not quarantine the source when sqlite3 cannot start", async () => {
+    mocks.execFilePromisified.mockRejectedValueOnce(
+      Object.assign(new Error("spawn sqlite3 ENOENT"), { code: "ENOENT" }),
+    );
+
+    const { ensurePublicSearchIndex } = await import(
+      "@/server/search/public-search-index"
+    );
+
+    await expect(ensurePublicSearchIndex()).rejects.toThrow(
+      "spawn sqlite3 ENOENT",
+    );
+    expect(mocks.sourceSync).not.toHaveBeenCalled();
+    expect(mocks.rm).not.toHaveBeenCalled();
+    expect(mocks.rename).not.toHaveBeenCalled();
+  });
+
   it("prepares a search source replica without requiring the live app replica env", async () => {
     mockEnv.TURSO_EMBEDDED_REPLICA_URL = undefined;
 

--- a/apps/main/tests/public-search-index-refresh.test.ts
+++ b/apps/main/tests/public-search-index-refresh.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => {
     mkdir: vi.fn(),
     open: vi.fn(),
     rename: vi.fn(),
+    rm: vi.fn(),
     sourceSync: vi.fn(),
     stat: vi.fn(),
     statusExecute: vi.fn(),
@@ -80,6 +81,7 @@ vi.mock("node:fs/promises", () => ({
   mkdir: mocks.mkdir,
   open: mocks.open,
   rename: mocks.rename,
+  rm: mocks.rm,
   stat: mocks.stat,
   unlink: mocks.unlink,
 }));
@@ -107,6 +109,7 @@ describe("public search index refresh", () => {
     mocks.mkdir.mockReset();
     mocks.open.mockReset();
     mocks.rename.mockReset();
+    mocks.rm.mockReset();
     mocks.sourceSync.mockReset();
     mocks.stat.mockReset();
     mocks.statusExecute.mockReset();
@@ -120,6 +123,7 @@ describe("public search index refresh", () => {
     mocks.lockClose.mockResolvedValue(undefined);
     mocks.lockWriteFile.mockResolvedValue(undefined);
     mocks.rename.mockResolvedValue(undefined);
+    mocks.rm.mockResolvedValue(undefined);
     mocks.unlink.mockResolvedValue(undefined);
 
     mocks.stat.mockImplementation(async (filePath: string) => {
@@ -279,6 +283,10 @@ describe("public search index refresh", () => {
       ["", "-info", "-wal", "-shm", "-journal"].map(
         (suffix) => `/data/search/public-search-source-replica.sqlite${suffix}`,
       ),
+    );
+    expect(mocks.rm).toHaveBeenCalledWith(
+      "/data/search/public-search-source-replica.sqlite.quarantine",
+      { force: true, recursive: true },
     );
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining("public_search_source_recovery_succeeded"),


### PR DESCRIPTION
## Summary

- Run source replica `quick_check` before sync, after sync, and after the index build.
- If the source is corrupt, retain its latest full file bundle and retry once with a fresh replica.
- Keep the last-known-good serving index until the replacement and source pass validation.
- Quarantine only when SQLite reports corruption; process launch and permission failures do not move the replica.
- Add structured phase, quarantine, and recovery logs without changing the builder architecture.
- Bound quarantine storage to one source bundle for the production VPS.

## Files

- `apps/main/src/server/search/public-search-index.ts`: Add phased checks, narrow corruption detection, bounded full-bundle quarantine, structured recovery logs, and one retry.
- `apps/main/scripts/build-public-search-index.mjs`: Check the source after the build and before index promotion.
- `apps/main/tests/public-search-index-refresh.test.ts`: Cover post-sync corruption, process launch failure, full-bundle quarantine, bounded retention, one retry, and the three log phases.
- `apps/main/tests/build-public-search-index.test.ts`: Prove the real builder runs the final source check and does not promote a replacement after that check fails.

## Tests

- `pnpm --filter @daylily-catalog/main test -- public-search-index-refresh.test.ts build-public-search-index.test.ts`
- `pnpm --filter @daylily-catalog/main typecheck`
- `pnpm --filter @daylily-catalog/main exec eslint src/server/search/public-search-index.ts`
- Prettier check for all changed files
- `git diff --check`