### PR TITLE
Finish Ahrefs crawl fixes

### DIFF
--- a/apps/main/src/app/(public)/[userSlugOrId]/_seo/json-ld.ts
+++ b/apps/main/src/app/(public)/[userSlugOrId]/_seo/json-ld.ts
@@ -79,7 +79,6 @@ async function createProfilePageJsonLd(
               url: `${metadata.pageUrl}/lists/${list.id}`,
               // Include collection items if we have valid listings for this list
               ...(listListings.length > 0 && {
-                collectionSize: listListings.length,
                 itemListElement: listListings.map((listing, index) => ({
                   "@type": "ListItem",
                   position: index + 1,

--- a/apps/main/src/app/(public)/_components/home-seo.tsx
+++ b/apps/main/src/app/(public)/_components/home-seo.tsx
@@ -1,5 +1,5 @@
 // eslint-disable react/no-danger -- intentional static JSON-LD, style, or compatibility script injection.
-import { generateSoftwareApplicationJsonLd } from "../_seo/json-ld";
+import { generateHomePageJsonLd } from "../_seo/json-ld";
 import type { PublicPageMetadata } from "../_seo/public-seo";
 import { serializeJsonLd } from "@/lib/utils/json-ld";
 
@@ -8,7 +8,7 @@ interface HomePageSEOProps {
 }
 
 export async function HomePageSEO({ metadata }: HomePageSEOProps) {
-  const jsonLd = await generateSoftwareApplicationJsonLd(metadata);
+  const jsonLd = await generateHomePageJsonLd(metadata);
 
   return (
     <>

--- a/apps/main/src/app/(public)/_seo/json-ld.ts
+++ b/apps/main/src/app/(public)/_seo/json-ld.ts
@@ -23,9 +23,9 @@ const HOME_PAGE_FAQ = [
   },
 ] as const;
 
-// Function to generate JSON-LD for SoftwareApplication schema
-async function createSoftwareApplicationJsonLd(metadata: MetadataInput) {
+async function createHomePageJsonLd(metadata: MetadataInput) {
   try {
+    // Add SoftwareApplication only when verified review data is available.
     // Create a schema set that covers both classic SEO and GEO use-cases.
     const schemas = [
       {
@@ -46,22 +46,6 @@ async function createSoftwareApplicationJsonLd(metadata: MetadataInput) {
           "@type": "WebSite",
           name: METADATA_CONFIG.SITE_NAME,
           url: metadata.url,
-        },
-      },
-      // SoftwareApplication schema (primary schema for the platform)
-      {
-        "@context": "https://schema.org",
-        "@type": "SoftwareApplication",
-        name: METADATA_CONFIG.SITE_NAME,
-        description: metadata.description,
-        url: metadata.url,
-        applicationCategory: "BusinessApplication",
-        operatingSystem: "Web",
-        offers: {
-          "@type": "Offer",
-          price: "0",
-          priceCurrency: "USD",
-          availability: "https://schema.org/InStock",
         },
       },
       // Organization schema for the company
@@ -96,11 +80,10 @@ async function createSoftwareApplicationJsonLd(metadata: MetadataInput) {
           : new Error("Unknown error in JSON-LD generation"),
       level: "error",
       context: {
-        function: "createSoftwareApplicationJsonLd",
+        function: "createHomePageJsonLd",
       },
     });
 
-    // Minimal valid SoftwareApplication JSON-LD as fallback
     return [
       {
         "@context": "https://schema.org",
@@ -108,21 +91,10 @@ async function createSoftwareApplicationJsonLd(metadata: MetadataInput) {
         name: METADATA_CONFIG.SITE_NAME,
         url: metadata.url,
       },
-      {
-        "@context": "https://schema.org",
-        "@type": "SoftwareApplication",
-        name: METADATA_CONFIG.SITE_NAME,
-        description:
-          metadata.description ||
-          "Discover beautiful daylilies from growers across the country.",
-        applicationCategory: "BusinessApplication",
-      },
     ];
   }
 }
 
-export async function generateSoftwareApplicationJsonLd(
-  metadata: MetadataInput,
-) {
-  return createSoftwareApplicationJsonLd(metadata);
+export async function generateHomePageJsonLd(metadata: MetadataInput) {
+  return createHomePageJsonLd(metadata);
 }

--- a/apps/main/src/app/(public)/cultivars/page.tsx
+++ b/apps/main/src/app/(public)/cultivars/page.tsx
@@ -60,12 +60,6 @@ export async function generateMetadata({
           },
         }
       : {}),
-    openGraph: {
-      title,
-      description,
-      type: "website",
-      url: `${baseUrl}/cultivars`,
-    },
   };
 }
 

--- a/apps/main/src/app/(public)/cultivars/page.tsx
+++ b/apps/main/src/app/(public)/cultivars/page.tsx
@@ -2,8 +2,10 @@
 import { type Metadata } from "next";
 import { notFound } from "next/navigation";
 import { MainContent } from "@/app/(public)/_components/main-content";
+import { buildPublicPageMetadata } from "@/app/(public)/_seo/public-seo";
 import { METADATA_CONFIG } from "@/config/constants";
 import { isPublicCultivarSearchEnabled } from "@/config/feature-flags";
+import { IMAGES } from "@/lib/constants/images";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { serializeJsonLd } from "@/lib/utils/json-ld";
 import { CultivarSearchPageClient } from "./_components/cultivar-search-page-client";
@@ -37,14 +39,19 @@ export async function generateMetadata({
 
   const baseUrl = getCanonicalBaseUrl();
   const hasSearchState = Object.keys((await searchParams) ?? {}).length > 0;
-  const title = `Daylily Cultivar Search – Over 100,000 Registered Daylilies | ${METADATA_CONFIG.SITE_NAME}`;
+  const title = `Search 100,000+ Daylily Cultivars | ${METADATA_CONFIG.SITE_NAME}`;
   const description =
     "Search over 100,000 registered daylilies by cultivar, hybridizer, color, bloom traits, photos, and current public catalog availability.";
 
   return {
-    title,
-    description,
-    alternates: { canonical: `${baseUrl}/cultivars` },
+    ...buildPublicPageMetadata({
+      canonicalPath: "/cultivars",
+      description,
+      imageAlt: "Daylily cultivar search",
+      imageUrl: `${baseUrl}${IMAGES.DEFAULT_LISTING}`,
+      pageUrl: `${baseUrl}/cultivars`,
+      title,
+    }),
     ...(hasSearchState
       ? {
           robots: {

--- a/apps/main/src/app/(public)/daylily-database-software/page.tsx
+++ b/apps/main/src/app/(public)/daylily-database-software/page.tsx
@@ -92,6 +92,7 @@ export const metadata = buildPublicPageMetadata({
 function createPageJsonLd() {
   const pageUrl = `${BASE_URL}${PAGE_PATH}`;
 
+  // Add SoftwareApplication only when verified review data is available.
   return [
     {
       "@context": "https://schema.org",
@@ -104,16 +105,6 @@ function createPageJsonLd() {
         name: METADATA_CONFIG.SITE_NAME,
         url: BASE_URL,
       },
-    },
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      name: METADATA_CONFIG.SITE_NAME,
-      applicationCategory: "BusinessApplication",
-      operatingSystem: "Web",
-      description: PAGE_DESCRIPTION,
-      url: pageUrl,
-      featureList: HERO_POINTS,
     },
     {
       "@context": "https://schema.org",

--- a/apps/main/src/app/(public)/sell-daylilies-online/page.tsx
+++ b/apps/main/src/app/(public)/sell-daylilies-online/page.tsx
@@ -20,7 +20,7 @@ import { buildPublicPageMetadata } from "../_seo/public-seo";
 const PAGE_PATH = "/sell-daylilies-online";
 const PAGE_TITLE = "Sell Daylilies Online With a Public Catalog";
 const PAGE_DESCRIPTION =
-  "Publish daylily listings with photos, prices, and availability. Buyers build a cart and send an inquiry while you control payment, shipping, pickup, and fulfillment.";
+  "Publish daylily listings with photos, prices, and availability. Buyers build a cart and send an inquiry while you control payment, shipping, and fulfillment.";
 const BASE_URL = getCanonicalBaseUrl();
 
 const HERO_POINTS = [
@@ -92,6 +92,7 @@ export const metadata = buildPublicPageMetadata({
 function createPageJsonLd() {
   const pageUrl = `${BASE_URL}${PAGE_PATH}`;
 
+  // Add SoftwareApplication only when verified review data is available.
   return [
     {
       "@context": "https://schema.org",
@@ -104,16 +105,6 @@ function createPageJsonLd() {
         name: METADATA_CONFIG.SITE_NAME,
         url: BASE_URL,
       },
-    },
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      name: METADATA_CONFIG.SITE_NAME,
-      applicationCategory: "BusinessApplication",
-      operatingSystem: "Web",
-      description: PAGE_DESCRIPTION,
-      url: pageUrl,
-      featureList: HERO_POINTS,
     },
     {
       "@context": "https://schema.org",

--- a/apps/main/src/app/sitemaps/main.xml/route.ts
+++ b/apps/main/src/app/sitemaps/main.xml/route.ts
@@ -2,7 +2,7 @@ import { serializeSitemapUrls, sitemapXmlResponse } from "@/lib/sitemap-xml";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { getMainSitemapEntries } from "@/server/sitemap-data";
 
-export const revalidate = 86400;
+export const dynamic = "force-dynamic";
 
 export async function GET() {
   const entries = await getMainSitemapEntries(getCanonicalBaseUrl());

--- a/apps/main/src/server/security/editor-js-content.ts
+++ b/apps/main/src/server/security/editor-js-content.ts
@@ -41,17 +41,36 @@ function escapeAttribute(value: string) {
   return escapeHtml(value).replace(/"/g, "&quot;");
 }
 
-function isSafeHref(href: string) {
+const CANONICAL_PUBLIC_HOST = "daylilycatalog.com";
+
+function normalizeSafeHref(href: string) {
   const trimmed = href.trim();
   if (trimmed.startsWith("/")) {
-    return !trimmed.startsWith("//");
+    return trimmed.startsWith("//")
+      ? null
+      : { href: trimmed, isInternal: true };
   }
 
   try {
     const parsed = new URL(trimmed);
-    return ["http:", "https:", "mailto:", "tel:"].includes(parsed.protocol);
+    if (!["http:", "https:", "mailto:", "tel:"].includes(parsed.protocol)) {
+      return null;
+    }
+
+    if (
+      [CANONICAL_PUBLIC_HOST, `www.${CANONICAL_PUBLIC_HOST}`].includes(
+        parsed.hostname.toLowerCase(),
+      )
+    ) {
+      return {
+        href: `${parsed.pathname}${parsed.search}${parsed.hash}`,
+        isInternal: true,
+      };
+    }
+
+    return { href: parsed.toString(), isInternal: false };
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -80,11 +99,15 @@ function serializeSanitizedNode(node: Node): string {
 
   if (tagName === "a") {
     const href = node.getAttribute("href");
-    if (!href || !isSafeHref(href)) {
+    const safeHref = href ? normalizeSafeHref(href) : null;
+    if (!safeHref) {
       return `<a>${children}</a>`;
     }
 
-    return `<a href="${escapeAttribute(href)}" rel="noopener noreferrer nofollow" target="_blank">${children}</a>`;
+    const externalAttributes = safeHref.isInternal
+      ? ""
+      : ' rel="noopener noreferrer nofollow" target="_blank"';
+    return `<a href="${escapeAttribute(safeHref.href)}"${externalAttributes}>${children}</a>`;
   }
 
   return `<${tagName}>${children}</${tagName}>`;

--- a/apps/main/tests/editor-js-content-sanitizer.test.ts
+++ b/apps/main/tests/editor-js-content-sanitizer.test.ts
@@ -61,6 +61,14 @@ describe("EditorJS content sanitizer", () => {
     );
   });
 
+  it("normalizes public-site links to internal paths", () => {
+    const sanitized = sanitizeEditorJsHtml(
+      `<a href="http://www.daylilycatalog.com/catalogs">Catalogs</a>`,
+    );
+
+    expect(sanitized).toBe(`<a href="/catalogs">Catalogs</a>`);
+  });
+
   it("converts legacy plain text into escaped EditorJS content", () => {
     const parsed = parseAndSanitizeEditorJsContent(
       `Legacy <img src=x onerror="alert(1)"> text`,

--- a/apps/main/tests/profile-json-ld.test.ts
+++ b/apps/main/tests/profile-json-ld.test.ts
@@ -46,6 +46,7 @@ describe("profile page json-ld", () => {
         };
       }>;
       hasOfferCatalog?: Array<{
+        collectionSize?: number;
         itemListElement?: Array<{
           item?: {
             offers?: { availability?: string };
@@ -64,6 +65,7 @@ describe("profile page json-ld", () => {
       mainEntity.hasOfferCatalog?.[0]?.itemListElement?.[0]?.item?.offers
         ?.availability,
     ).toBe("https://schema.org/InStock");
+    expect(mainEntity.hasOfferCatalog?.[0]?.collectionSize).toBeUndefined();
     expect(jsonLd.interactionStatistic).toBeUndefined();
   });
 

--- a/apps/main/tests/sitemap-host-selection.test.ts
+++ b/apps/main/tests/sitemap-host-selection.test.ts
@@ -260,7 +260,10 @@ describe("sitemap and robots host selection", () => {
     delete process.env.VERCEL_URL;
     delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
     process.env.PORT = "4123";
-    const { GET: mainSitemap } = await import("@/app/sitemaps/main.xml/route");
+    const { GET: mainSitemap, dynamic } = await import(
+      "@/app/sitemaps/main.xml/route"
+    );
+    expect(dynamic).toBe("force-dynamic");
     const sitemapText = await (await mainSitemap()).text();
 
     expect(sitemapText).toContain(

--- a/apps/main/tests/social-sharing-metadata.test.ts
+++ b/apps/main/tests/social-sharing-metadata.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 
 import type { Metadata } from "next";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { generateMetadata as generateCultivarSearchMetadata } from "@/app/(public)/cultivars/page";
 import { buildPublicPageMetadata } from "@/app/(public)/_seo/public-seo";
 import { generateHomePageJsonLd } from "@/app/(public)/_seo/json-ld";
 import {
@@ -9,6 +10,10 @@ import {
   generateProfileMetadata,
 } from "@/app/(public)/[userSlugOrId]/_seo/metadata";
 import { getSocialCardImageUrl } from "@/lib/social-card";
+
+vi.mock("@/config/feature-flags", () => ({
+  isPublicCultivarSearchEnabled: () => true,
+}));
 
 function getOpenGraphImageUrl(metadata: Metadata) {
   const images = metadata.openGraph?.images;
@@ -60,6 +65,15 @@ describe("social sharing metadata", () => {
         kind: "catalog",
       }),
     ).toBe("https://daylilycatalog.com/api/og/catalog/seller-1?v=2");
+  });
+
+  it("keeps the complete cultivar search Open Graph metadata", async () => {
+    const metadata = await generateCultivarSearchMetadata({
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(metadata.openGraph?.description).toBe(metadata.description);
+    expect(getOpenGraphImageUrl(metadata)).not.toBeNull();
   });
 
   it("uses a catalog card without replacing the structured-data image", async () => {

--- a/apps/main/tests/social-sharing-metadata.test.ts
+++ b/apps/main/tests/social-sharing-metadata.test.ts
@@ -3,6 +3,7 @@
 import type { Metadata } from "next";
 import { describe, expect, it } from "vitest";
 import { buildPublicPageMetadata } from "@/app/(public)/_seo/public-seo";
+import { generateHomePageJsonLd } from "@/app/(public)/_seo/json-ld";
 import {
   generateCollectionMetadata,
   generateProfileMetadata,
@@ -40,6 +41,17 @@ const profile = {
 };
 
 describe("social sharing metadata", () => {
+  it("omits app rich results without verified reviews", async () => {
+    const jsonLd = await generateHomePageJsonLd({
+      description: "Daylily catalog software for growers.",
+      url: "https://daylilycatalog.com",
+    });
+
+    expect(jsonLd.map((schema) => schema["@type"])).not.toContain(
+      "SoftwareApplication",
+    );
+  });
+
   it("uses stable renderer-versioned image URLs", () => {
     expect(
       getSocialCardImageUrl({


### PR DESCRIPTION
## Summary

- Remove every reproducible application error from the completed Ahrefs crawl.
- Keep valid WebSite, WebPage, Organization, and FAQ structured data without inventing SoftwareApplication reviews or ratings.
- Normalize Daylily Catalog links in member content to canonical internal paths.
- Complete the cultivar search page metadata and make the main sitemap use runtime feature flags.

## File changes

- `apps/main/src/app/(public)/[userSlugOrId]/_seo/json-ld.ts`: remove the unsupported `collectionSize` property from `OfferCatalog` markup.
- `apps/main/src/app/(public)/_components/home-seo.tsx`: use the renamed home-page JSON-LD generator.
- `apps/main/src/app/(public)/_seo/json-ld.ts`: omit SoftwareApplication markup until verified review data is available and keep the remaining home schemas.
- `apps/main/src/app/(public)/cultivars/page.tsx`: use the complete shared Open Graph and Twitter metadata without overwriting its image, and shorten the search title.
- `apps/main/src/app/(public)/daylily-database-software/page.tsx`: remove SoftwareApplication rich-result markup that cannot be valid without review data.
- `apps/main/src/app/(public)/sell-daylilies-online/page.tsx`: remove the same invalid rich-result markup and shorten the meta description to 157 characters.
- `apps/main/src/app/sitemaps/main.xml/route.ts`: render the main sitemap dynamically so production runtime flags include `/cultivars` and `/catalog-importer`.
- `apps/main/src/server/security/editor-js-content.ts`: convert absolute Daylily Catalog links, including HTTP and `www` variants, to canonical internal paths while preserving defensive attributes on external links.
- `apps/main/tests/editor-js-content-sanitizer.test.ts`: cover canonical internal-link normalization.
- `apps/main/tests/profile-json-ld.test.ts`: prevent `collectionSize` from returning on OfferCatalog markup.
- `apps/main/tests/sitemap-host-selection.test.ts`: require the main sitemap to read runtime flags dynamically.
- `apps/main/tests/social-sharing-metadata.test.ts`: prevent unverified SoftwareApplication markup and incomplete cultivar-search social metadata from returning.

## Why the previous crawl proof missed these errors

PR #375 checked HTTP responses, redirects, canonical URLs, `og:url`, robots, JSON-LD parsing, and hand-written Product and Offer rules. It did not run a complete Schema.org or Google rich-result rule set. Therefore, its zero-findings result only applied to those custom rules. It also did not verify sitemap membership or the full Open Graph field set.

## Exact validation crawl

A rebuilt production-shaped Docker image was checked against all 198 URLs saved in the Ahrefs crawl:

- 198 of 198 returned HTTP 200.
- 198 of 198 were present across the six generated sitemap files.
- Zero incomplete Open Graph records.
- Zero internal HTTP links.
- Zero missing image `alt` attributes.
- Zero JSON-LD parse failures.
- Zero `OfferCatalog.collectionSize` errors.
- Zero Software Application review errors.
- Zero Product or Offer required-field errors.

The local smoke build uses `dev.daylilycatalog.com` for two statically built marketing pages by design. Production host selection is covered separately and is not counted as a product failure.

## Ahrefs score acceptance rule

The next Ahrefs crawl keeps the 198-URL representative custom list because the site has more than 100,000 pages and this plan is limited to 250 internal pages per crawl. It also uses the Website and auto-detected sitemap sources, follows links to a maximum seed depth of 16, and keeps all 173 issue checks enabled. The existing crawl still reports results from its old depth-zero configuration and does not prove the new score. After deployment, run the new representative link-following crawl. The acceptance rule is a score of 100 with zero health-score errors. If the new crawl reports real orphan, sitemap, or other issues, fix those issues instead of suppressing their checks.

## Validation

- `pnpm --filter main test -- social-sharing-metadata.test.ts sitemap-host-selection.test.ts` — 14 tests passed.
- `pnpm --filter main typecheck` — passed.
- Focused ESLint — passed.
- Production Docker build — passed.
- Exact production-shaped crawl — passed except for the documented local build-host difference.
- `git diff --check` — passed.
