### PR TITLE
Improve cultivar image generation workflow

### DIFF
--- a/apps/main/docs/generated-cultivar-image-catchup.md
+++ b/apps/main/docs/generated-cultivar-image-catchup.md
@@ -105,10 +105,6 @@ require formal approval. Only change rows manually when something is wrong:
 requeue obvious bad generations, reject known-bad outputs, and leave
 `source_invalid` rows out of blind retries.
 
-Source downloads use delayed retries. Exhausted downloads are recorded as
-`source_invalid` so one unavailable URL cannot block later alphabetical backlog
-work.
-
 Queue sync marks rows `imported` when the local prod copy already has a ready
 generated cultivar `ImageAsset`. Older pre-`CultivarReference.id` review rows
 that are not safely importable by the current workflow are marked `legacy`.
@@ -235,10 +231,14 @@ Run a bounded generation batch:
 pnpm main exec node scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs --limit 20 --concurrency 10
 ```
 
-The worker drains the existing queue, performs one linked-listing catch-up check,
-drains newly queued catch-up rows, then selects alphabetical non-linked rows
-until it reaches `--limit`. The SQLite queue remains the durable recovery and
-review layer; it no longer requires separate catch-up or backlog queue commands.
+The worker attempts at most `--limit` retryable, linked catch-up, and
+alphabetical backlog rows per invocation. Already generated `review`,
+`approved`, and `imported` rows do not count against that run limit, so each run
+adds its successful results to the existing approval queue. New source rows are
+queued only as needed and backlog downloads happen in rolling chunks so
+generation resumes without waiting for the entire run's source set. The SQLite
+queue remains the durable recovery and review layer; it no longer requires
+separate catch-up or backlog queue commands.
 
 ## Related V2 Data Refresh
 

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -20,6 +20,7 @@
     "db:seed:prepare": "node scripts/generate-realistic-data-snapshot.mjs",
     "db:seed:sync": "bash scripts/sync-seeded-daylily-catalog-from-local.sh",
     "images:generate": "node --disable-warning=ExperimentalWarning scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs",
+    "images:control": "node --disable-warning=ExperimentalWarning scripts/image-processing/v2-ahs-image-review/control-codex-native-worker.mjs",
     "search:index:build": "node scripts/build-public-search-index.mjs",
     "search:parentage:build": "node scripts/build-public-parentage-index.mjs",
     "migrate:generate": "npx prisma migrate dev",

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/README.md
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/README.md
@@ -25,6 +25,9 @@ create worktree-local artifacts.
 
 - review server: `pnpm main exec node scripts/image-processing/v2-ahs-image-review/server.mjs`
 - Codex-native generation: `pnpm images:generate --limit 20 --concurrency 10`
+- Worker status: `pnpm images:control status`
+- Live concurrency: `pnpm images:control concurrency 20`
+- Graceful stop: `pnpm images:control drain`
 - Legacy ChatGPT worker fallback: `pnpm main exec node scripts/image-processing/v2-ahs-image-review/chatgpt-worker-agent-browser.mjs --limit 50`
 
 ## Generation Flow
@@ -52,8 +55,6 @@ Run:
 pnpm env:dev bash scripts/db-backup.sh
 pnpm images:generate --limit 20 --concurrency 10
 ```
-
-From a linked worktree, perform the [exceptional full-snapshot copy](../../../docs/db-backup-readme.md#linked-worktrees) before running generation.
 
 Spot-check generated images in the local UI, then run the generated cultivar
 ImageAsset/R2 backfill. Rows marked `review` are generated and importable; use

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/app.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/app.mjs
@@ -1,6 +1,5 @@
 const countsEl = document.getElementById("counts");
 const itemsGridEl = document.getElementById("items-grid");
-const pathsEl = document.getElementById("paths");
 const syncButtonEl = document.getElementById("sync-button");
 const refreshButtonEl = document.getElementById("refresh-button");
 const approveAllButtonEl = document.getElementById("approve-all-button");
@@ -8,12 +7,24 @@ const approveAllDialogEl = document.getElementById("approve-all-dialog");
 const approveAllCountEl = document.getElementById("approve-all-count");
 const approveAllCancelEl = document.getElementById("approve-all-cancel");
 const approveAllConfirmEl = document.getElementById("approve-all-confirm");
+const detailDialogEl = document.getElementById("detail-dialog");
+const detailTitleEl = document.getElementById("detail-title");
+const detailIdEl = document.getElementById("detail-id");
+const detailOriginalEl = document.getElementById("detail-original");
+const detailEditedEl = document.getElementById("detail-edited");
+const detailCloseEl = document.getElementById("detail-close");
+const detailRejectEl = document.getElementById("detail-reject");
 const pageLabelEl = document.getElementById("page-label");
 const actionMessageEl = document.getElementById("action-message");
 
 let approvingAll = false;
-let approveAllIds = [];
-let reviewCount = 0;
+let approvingPage = false;
+let totalReviewCount = 0;
+let allReviewItems = [];
+let currentPage = 0;
+let pageSize = 1;
+let activeItemId = null;
+let reviewItemsById = new Map();
 
 function escapeHtml(value) {
   return String(value)
@@ -25,14 +36,10 @@ function escapeHtml(value) {
 
 function renderCounts(counts) {
   const entries = [
-    ["Total", counts.total],
-    ["Pending", counts.pending],
-    ["Processing", counts.processing],
     ["Review", counts.review],
-    ["Approved", counts.approved],
-    ["Imported", counts.imported],
-    ["Legacy", counts.legacy],
+    ["Processing", counts.processing],
     ["Failed", counts.failed],
+    ["Approved", counts.approved],
   ];
 
   if (!countsEl) {
@@ -46,9 +53,13 @@ function renderCounts(counts) {
     )
     .join("");
 
-  reviewCount = Number(counts.review ?? 0);
+  totalReviewCount = Number(counts.review ?? 0);
+  updateApproveAllButton();
+}
+
+function updateApproveAllButton() {
   if (approveAllButtonEl instanceof HTMLButtonElement) {
-    approveAllButtonEl.disabled = approvingAll || reviewCount === 0;
+    approveAllButtonEl.disabled = approvingAll || totalReviewCount === 0;
   }
 }
 
@@ -62,30 +73,10 @@ function setActionMessage(message, kind = "") {
   actionMessageEl.classList.toggle("error", kind === "error");
 }
 
-function updatePageLabel(totalReviewCount) {
-  if (!pageLabelEl || !itemsGridEl) {
-    return;
-  }
-
-  const visibleCount = itemsGridEl.querySelectorAll(".queue-item").length;
-  pageLabelEl.textContent = visibleCount
-    ? `${visibleCount} of ${totalReviewCount}`
-    : "No items";
-}
-
-function removeQueueItem(button, counts) {
-  const queueItem = button.closest(".queue-item");
-
-  if (queueItem) {
-    queueItem.remove();
-  }
-
-  updatePageLabel(counts?.review ?? 0);
-
-  if (itemsGridEl && !itemsGridEl.querySelector(".queue-item")) {
-    itemsGridEl.innerHTML =
-      '<div class="empty">No images available for review.</div>';
-  }
+function removeQueueItem(id) {
+  reviewItemsById.delete(id);
+  allReviewItems = allReviewItems.filter((item) => item.id !== id);
+  renderPage();
 }
 
 function renderQueueItem(item) {
@@ -95,71 +86,104 @@ function renderQueueItem(item) {
   const editedSrc = `/image?id=${encodeURIComponent(item.id)}&variant=edited&v=${imageVersion}`;
 
   return `
-    <section class="queue-item">
-      <div class="queue-header">
-        <div class="meta">
-          <div class="queue-title">${escapeHtml(item.id)} · ${escapeHtml(title)}</div>
-          <div class="queue-meta">
-            <span>status <code>${escapeHtml(item.status)}</code></span>
-          </div>
-        </div>
-        <div class="actions">
-          <button class="approve" data-id="${escapeHtml(item.id)}" data-status="approved" type="button">Approve</button>
-          <button class="neutral" data-id="${escapeHtml(item.id)}" data-status="requeue" type="button">Requeue</button>
-        </div>
-      </div>
+    <button class="queue-item" data-open-id="${escapeHtml(item.id)}" type="button" aria-label="Inspect ${escapeHtml(title)}">
       <div class="compare-strip">
         <img alt="Original ${escapeHtml(title)}" src="${originalSrc}" loading="lazy" decoding="async" />
         <img alt="Edited ${escapeHtml(title)}" src="${editedSrc}" loading="lazy" decoding="async" />
       </div>
-    </section>
+    </button>
   `;
 }
 
-function renderItems(items, total) {
+function getPageSize() {
+  const barHeight =
+    document.querySelector(".utility-bar")?.getBoundingClientRect().height ??
+    41;
+  const columns = Math.max(1, Math.floor(window.innerWidth / 281));
+  const rows = Math.max(1, Math.floor((window.innerHeight - barHeight) / 161));
+
+  return columns * rows;
+}
+
+function getPageCount() {
+  return Math.max(1, Math.ceil(allReviewItems.length / pageSize));
+}
+
+function getCurrentPageItems() {
+  const start = currentPage * pageSize;
+  return allReviewItems.slice(start, start + pageSize);
+}
+
+function renderPage() {
   if (!itemsGridEl) {
     return;
   }
 
-  if (!items.length) {
+  pageSize = getPageSize();
+  currentPage = Math.min(currentPage, getPageCount() - 1);
+  const pageItems = getCurrentPageItems();
+
+  if (!pageItems.length) {
     itemsGridEl.innerHTML =
       '<div class="empty">Queue is empty. Run the sync command, then start the worker.</div>';
-
     if (pageLabelEl) {
-      pageLabelEl.textContent = "No items";
+      pageLabelEl.textContent = "";
     }
-
     return;
   }
 
-  itemsGridEl.innerHTML = items.map((item) => renderQueueItem(item)).join("");
+  itemsGridEl.innerHTML = pageItems
+    .map((item) => renderQueueItem(item))
+    .join("");
 
   if (pageLabelEl) {
-    pageLabelEl.textContent = `${items.length} of ${total}`;
+    pageLabelEl.textContent = `${currentPage + 1}/${getPageCount()} · ${pageItems.length} items · A approve page`;
   }
 }
 
-itemsGridEl?.addEventListener("click", async (event) => {
-  const target = event.target;
+function renderItems(items) {
+  allReviewItems = items;
+  reviewItemsById = new Map(items.map((item) => [item.id, item]));
+  renderPage();
+}
 
-  if (!(target instanceof Element)) {
+function navigatePage(offset) {
+  const pageCount = getPageCount();
+  currentPage = (currentPage + offset + pageCount) % pageCount;
+  renderPage();
+}
+
+function openDetail(id) {
+  const item = reviewItemsById.get(id);
+
+  if (
+    !item ||
+    !(detailDialogEl instanceof HTMLDialogElement) ||
+    !(detailOriginalEl instanceof HTMLImageElement) ||
+    !(detailEditedEl instanceof HTMLImageElement)
+  ) {
     return;
   }
 
-  const button = target.closest("[data-status][data-id]");
-
-  if (!(button instanceof HTMLButtonElement)) {
-    return;
+  const title = item.postTitle ?? item.id;
+  const imageVersion = encodeURIComponent(item.updatedAt ?? "");
+  activeItemId = item.id;
+  detailTitleEl.textContent = title;
+  detailIdEl.textContent = item.id;
+  detailOriginalEl.src = `/image?id=${encodeURIComponent(item.id)}&variant=original&v=${imageVersion}`;
+  detailEditedEl.src = `/image?id=${encodeURIComponent(item.id)}&variant=edited&v=${imageVersion}`;
+  if (detailRejectEl instanceof HTMLButtonElement) {
+    detailRejectEl.disabled = false;
   }
-
-  const id = button.getAttribute("data-id");
-  const status = button.getAttribute("data-status");
-
-  if (!id || !status) {
-    return;
+  if (!detailDialogEl.open) {
+    detailDialogEl.showModal();
   }
+}
 
-  button.disabled = true;
+async function updateItemStatus(id, status, button) {
+  if (button instanceof HTMLButtonElement) {
+    button.disabled = true;
+  }
   setActionMessage(`${status} ${id}...`);
 
   try {
@@ -185,15 +209,36 @@ itemsGridEl?.addEventListener("click", async (event) => {
       renderCounts(payload.counts);
     }
 
-    if (status === "approved" || status === "requeue") {
-      removeQueueItem(button, payload.counts);
-    } else {
-      button.disabled = false;
+    removeQueueItem(id);
+    if (detailDialogEl instanceof HTMLDialogElement) {
+      detailDialogEl.close();
     }
+    activeItemId = null;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     setActionMessage(`${id}: ${message}`, "error");
-    button.disabled = false;
+    if (button instanceof HTMLButtonElement) {
+      button.disabled = false;
+    }
+  }
+}
+
+itemsGridEl?.addEventListener("click", (event) => {
+  const target = event.target;
+
+  if (!(target instanceof Element)) {
+    return;
+  }
+
+  const button = target.closest("[data-open-id]");
+
+  if (!(button instanceof HTMLButtonElement)) {
+    return;
+  }
+
+  const id = button.getAttribute("data-open-id");
+  if (id) {
+    openDetail(id);
   }
 });
 
@@ -202,11 +247,7 @@ async function loadState() {
   const state = await response.json();
   renderCounts(state.counts);
 
-  if (pathsEl) {
-    pathsEl.innerHTML = `Originals: <code>${escapeHtml(state.paths.originals)}</code><br />Edited: <code>${escapeHtml(state.paths.edited)}</code><br />Queue DB: <code>${escapeHtml(state.paths.db)}</code>`;
-  }
-
-  renderItems(state.items ?? [], state.counts.review);
+  renderItems(state.items ?? []);
 }
 
 syncButtonEl?.addEventListener("click", async () => {
@@ -228,23 +269,56 @@ refreshButtonEl?.addEventListener("click", async () => {
   await loadState();
 });
 
-approveAllButtonEl?.addEventListener("click", () => {
-  if (!(approveAllDialogEl instanceof HTMLDialogElement) || reviewCount === 0) {
+async function approveCurrentPage() {
+  if (approvingPage) {
     return;
   }
 
-  approveAllIds = Array.from(
-    itemsGridEl?.querySelectorAll(".queue-item [data-id]") ?? [],
-  )
-    .map((element) => element.getAttribute("data-id"))
-    .filter((id, index, ids) => id && ids.indexOf(id) === index);
+  const ids = getCurrentPageItems().map((item) => item.id);
+  if (ids.length === 0) {
+    return;
+  }
 
-  if (approveAllIds.length === 0) {
+  approvingPage = true;
+  setActionMessage(`Approving page ${currentPage + 1}...`);
+
+  try {
+    const response = await fetch("/api/approve-page", {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ ids }),
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    const payload = await response.json().catch(() => ({}));
+
+    if (!response.ok || payload.ok !== true) {
+      throw new Error(payload.error || `HTTP ${response.status}`);
+    }
+
+    await loadState();
+    setActionMessage(`Approved ${payload.updated} images`, "ok");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    setActionMessage(`Approve page failed: ${message}`, "error");
+  } finally {
+    approvingPage = false;
+  }
+}
+
+approveAllButtonEl?.addEventListener("click", () => {
+  if (
+    !(approveAllDialogEl instanceof HTMLDialogElement) ||
+    totalReviewCount === 0
+  ) {
     return;
   }
 
   if (approveAllCountEl) {
-    approveAllCountEl.textContent = String(approveAllIds.length);
+    approveAllCountEl.textContent = String(totalReviewCount);
   }
   approveAllDialogEl.showModal();
 });
@@ -265,16 +339,12 @@ approveAllConfirmEl?.addEventListener("click", async () => {
   if (approveAllButtonEl instanceof HTMLButtonElement) {
     approveAllButtonEl.disabled = true;
   }
-  setActionMessage(`Approving ${approveAllIds.length} images...`);
+  setActionMessage(`Approving all ${totalReviewCount} images...`);
 
   try {
     const response = await fetch("/api/approve-all", {
       method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ ids: approveAllIds }),
+      headers: { accept: "application/json" },
       cache: "no-store",
       credentials: "same-origin",
     });
@@ -290,12 +360,62 @@ approveAllConfirmEl?.addEventListener("click", async () => {
     const message = error instanceof Error ? error.message : String(error);
     setActionMessage(`Approve all failed: ${message}`, "error");
   } finally {
-    approveAllIds = [];
     approvingAll = false;
-    if (approveAllButtonEl instanceof HTMLButtonElement) {
-      approveAllButtonEl.disabled = reviewCount === 0;
-    }
+    updateApproveAllButton();
   }
+});
+
+detailCloseEl?.addEventListener("click", () => {
+  if (detailDialogEl instanceof HTMLDialogElement) {
+    detailDialogEl.close();
+  }
+  activeItemId = null;
+});
+
+detailDialogEl?.addEventListener("close", () => {
+  activeItemId = null;
+});
+
+detailRejectEl?.addEventListener("click", () => {
+  if (activeItemId) {
+    void updateItemStatus(activeItemId, "rejected", detailRejectEl);
+  }
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.metaKey || event.ctrlKey || event.altKey || event.repeat) {
+    return;
+  }
+
+  if (
+    approveAllDialogEl instanceof HTMLDialogElement &&
+    approveAllDialogEl.open
+  ) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      approveAllConfirmEl?.click();
+    }
+    return;
+  }
+
+  if (detailDialogEl instanceof HTMLDialogElement && detailDialogEl.open) {
+    return;
+  }
+
+  if (event.key === "ArrowLeft") {
+    event.preventDefault();
+    navigatePage(-1);
+  } else if (event.key === "ArrowRight") {
+    event.preventDefault();
+    navigatePage(1);
+  } else if (!event.shiftKey && event.key.toLowerCase() === "a") {
+    event.preventDefault();
+    void approveCurrentPage();
+  }
+});
+
+window.addEventListener("resize", () => {
+  renderPage();
 });
 
 window.setInterval(() => {

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/codex-native-image-generation.md
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/codex-native-image-generation.md
@@ -68,11 +68,29 @@ pnpm images:generate \
   --concurrency 10
 ```
 
+The worker keeps the requested concurrency full while work remains. It
+prefetches source images before the pending queue empties. Control a running
+worker from another terminal:
+
+```bash
+pnpm images:control status
+pnpm images:control concurrency 20
+pnpm images:control drain
+```
+
+Increasing concurrency fills the additional slots immediately. Decreasing it
+lets the current work finish and stops replacements until the active count
+reaches the new target. `drain` stops source refills and replacements, lets all
+active generations finish and promote, then exits. The first `Ctrl-C` also
+drains; a second `Ctrl-C` force-stops active generations.
+
 Each bounded run drains the existing queue first, performs one linked-listing
 catch-up check against the local prod copy, drains newly queued catch-up rows,
 then adds alphabetical non-linked work until it reaches `--limit`.
 The startup log reports the local prod copy's path, modification time, and
 human-readable age so stale snapshots are visible before generation proceeds.
+Normal runs skip rows already marked `failed` or `rejected`. Retry one of those
+rows explicitly with `--id` after fixing or replacing its source image.
 
 For one specific row:
 
@@ -127,8 +145,14 @@ image generation. The isolated home links only the existing Codex
 authentication file; personal configuration, MCP servers, skills, memory,
 napkin, and repo instructions are not loaded.
 
-`--limit` bounds the total attempted rows. `--concurrency` defaults to 10 and
-`--timeout-minutes` defaults to 15. Generation agents default to
+`--limit` bounds generation attempts for the current invocation. Existing
+`review`, `approved`, and `imported` rows do not count; retryable `pending` and
+`failed` rows do because they still require generation. Source selection adds
+only enough linked catch-up and alphabetical backlog rows to reach that run
+limit. Backlog sources are selected in rolling chunks of twice the worker
+concurrency by default; override that with `--backlog-refill-size`.
+`--concurrency` defaults to 10 and `--timeout-minutes` defaults to 15.
+Generation agents default to
 `gpt-5.6-luna` with high reasoning; override them with `--model` and `--effort`
 or `CODEX_IMAGE_AGENT_MODEL` and `CODEX_IMAGE_AGENT_EFFORT`. Interrupting the
 worker returns active rows to `pending`; other failures are recorded as
@@ -160,7 +184,7 @@ The generation request should look like this in structured form:
   "items": [
     {
       "type": "local_image",
-      "path": "/Users/makon/daylily-catalog-image-processing/v2-ahs-images/{id}.jpg"
+      "path": "/absolute/path/to/daylily-catalog-image-processing/v2-ahs-images/{id}.jpg"
     },
     {
       "type": "text",
@@ -477,7 +501,7 @@ There should be no `pending` or `processing` rows for the drained batch.
 Use this exact final audit when draining the whole queue:
 
 ```bash
-sqlite3 /Users/makon/daylily-catalog-image-processing/v2-ahs-image-review/review.sqlite \
+sqlite3 ~/daylily-catalog-image-processing/v2-ahs-image-review/review.sqlite \
   "select status,count(*) from v2_image_review_queue group by status order by status;
    select '---remaining';
    select id,status,attempts,lastError

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/control-codex-native-worker.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/control-codex-native-worker.mjs
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { REVIEW_ROOT } from "./review-db.mjs";
+
+const LOCK_PATH = path.join(REVIEW_ROOT, "codex-native-worker.lock");
+const COMMAND_PATH = path.join(REVIEW_ROOT, "codex-native-worker-command.json");
+const STATE_PATH = path.join(REVIEW_ROOT, "codex-native-worker-state.json");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function readWorker() {
+  if (!fs.existsSync(LOCK_PATH)) {
+    throw new Error("No Codex-native image worker is running.");
+  }
+
+  const lock = readJson(LOCK_PATH);
+  try {
+    process.kill(lock.pid, 0);
+  } catch {
+    throw new Error(`Worker lock is stale: ${LOCK_PATH}`);
+  }
+  return lock;
+}
+
+function writeCommand(command) {
+  const worker = readWorker();
+  const temporaryPath = `${COMMAND_PATH}.${process.pid}.tmp`;
+  fs.writeFileSync(
+    temporaryPath,
+    `${JSON.stringify({ ...command, runId: worker.runId }, null, 2)}\n`,
+  );
+  fs.renameSync(temporaryPath, COMMAND_PATH);
+}
+
+const [command, value] = process.argv.slice(2).filter((arg) => arg !== "--");
+
+if (command === "status") {
+  const worker = readWorker();
+  const state = fs.existsSync(STATE_PATH) ? readJson(STATE_PATH) : null;
+  console.log(JSON.stringify({ state, worker }, null, 2));
+} else if (command === "drain") {
+  writeCommand({ command: "drain" });
+  console.log("Drain requested. Active generations will finish before exit.");
+} else if (command === "concurrency") {
+  const concurrency = Number(value);
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error("Pass a positive integer: images:control concurrency <n>");
+  }
+  writeCommand({ command: "concurrency", value: concurrency });
+  console.log(`Concurrency change requested: ${concurrency}`);
+} else {
+  throw new Error("Use: images:control status | concurrency <n> | drain");
+}

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/index.html
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/index.html
@@ -35,31 +35,18 @@
         display: grid;
         gap: 0;
       }
-      .masthead {
-        display: grid;
-        gap: 8px;
-        padding: 10px 12px;
-        border-bottom: 1px solid var(--line);
-      }
-      .topbar {
+      .utility-bar {
+        position: sticky;
+        top: 0;
+        z-index: 2;
         display: flex;
+        align-items: center;
         justify-content: space-between;
-        align-items: flex-end;
-        gap: 20px;
-        flex-wrap: wrap;
-      }
-      .eyebrow {
-        font-family: "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
-        font-size: 11px;
-        letter-spacing: 0.22em;
-        text-transform: uppercase;
-        color: var(--muted);
-      }
-      h1 {
-        margin: 2px 0 0;
-        font-size: 20px;
-        font-weight: 700;
-        letter-spacing: 0;
+        gap: 8px;
+        min-height: 40px;
+        padding: 4px 6px;
+        border-bottom: 1px solid var(--line);
+        background: rgba(255, 255, 255, 0.96);
       }
       p {
         margin: 0;
@@ -75,40 +62,35 @@
         font-size: 12px;
       }
       .status-strip {
-        display: grid;
-        gap: 4px;
-        grid-template-columns: repeat(6, minmax(0, 1fr));
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        min-width: 0;
+        white-space: nowrap;
       }
       .status-cell {
-        display: grid;
-        gap: 2px;
-        padding: 10px 0;
-        border-top: 1px solid var(--line);
-      }
-      .toolbar {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 12px;
-        flex-wrap: wrap;
-        padding: 0;
-      }
-      .toolbar-group {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        flex-wrap: wrap;
+        display: inline-flex;
+        align-items: baseline;
+        gap: 4px;
       }
       .count-label {
         font-family: "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
         font-size: 11px;
         color: var(--muted);
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
       }
       .count-value {
-        font-size: 22px;
+        font-size: 13px;
         font-weight: 700;
+      }
+      .page-label {
+        font:
+          600 11px/1 "SFMono-Regular",
+          Menlo,
+          Monaco,
+          Consolas,
+          monospace;
+        color: var(--muted);
+        white-space: nowrap;
       }
       .actions {
         display: flex;
@@ -117,15 +99,17 @@
       }
       .stream {
         display: grid;
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr));
+        gap: 1px;
+        background: var(--line);
       }
       button {
         border: 1px solid var(--line-strong);
         border-radius: 0;
-        min-height: 44px;
-        padding: 0 14px;
+        min-height: 32px;
+        padding: 0 10px;
         font:
-          600 13px/1 "SFMono-Regular",
+          600 11px/1 "SFMono-Regular",
           Menlo,
           Monaco,
           Consolas,
@@ -183,34 +167,20 @@
         display: grid;
         gap: 0;
         padding: 0;
+        min-height: 0;
+        border: 0;
+        background: var(--bg);
+        text-align: left;
+        font: inherit;
       }
-      .queue-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: 8px;
-        flex-wrap: wrap;
-        padding: 8px 12px;
+      .queue-item:hover {
+        background: #f4f2ed;
       }
-      .queue-title {
-        font:
-          600 13px/1.2 "SFMono-Regular",
-          Menlo,
-          Monaco,
-          Consolas,
-          monospace;
-        letter-spacing: 0;
-      }
-      .queue-meta {
-        display: flex;
-        gap: 8px;
-        flex-wrap: wrap;
-        align-items: center;
-        color: var(--muted);
-      }
-      .queue-meta code,
-      .page-meta code {
-        font-size: 13px;
+      .queue-item:focus-visible {
+        position: relative;
+        z-index: 1;
+        outline: 3px solid var(--accent);
+        outline-offset: -3px;
       }
       .compare-strip {
         display: grid;
@@ -221,23 +191,41 @@
       .compare-strip img {
         width: 100%;
         min-width: 0;
-        aspect-ratio: 1 / 1;
-        height: auto;
-        object-fit: cover;
+        height: 160px;
+        object-fit: contain;
         display: block;
+      }
+      .detail-dialog {
+        width: min(1100px, calc(100vw - 32px));
+      }
+      .detail-dialog .dialog-body {
+        gap: 12px;
+      }
+      .detail-compare img {
+        width: 100%;
+        min-width: 0;
+        height: min(70vh, 720px);
+        object-fit: contain;
+        display: block;
+        background: #f4f2ed;
+      }
+      .shortcut-hint {
+        font:
+          600 11px/1.4 "SFMono-Regular",
+          Menlo,
+          Monaco,
+          Consolas,
+          monospace;
+        color: var(--muted);
       }
       .empty {
         width: 100%;
-        min-height: 280px;
+        min-height: 160px;
         display: grid;
         place-items: center;
         border: 1px dashed var(--line-strong);
         color: var(--muted);
         background: rgba(255, 255, 255, 0.4);
-      }
-      .meta {
-        display: grid;
-        gap: 4px;
       }
       .error {
         color: var(--danger-ink);
@@ -245,52 +233,17 @@
       .footer {
         display: none;
       }
-      .pill {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 4px 8px;
-        border-radius: 999px;
-        background: rgba(255, 255, 255, 0.5);
-        border: 1px solid var(--line);
-        font:
-          600 12px/1 "SFMono-Regular",
-          Menlo,
-          Monaco,
-          Consolas,
-          monospace;
-        color: var(--muted);
-      }
-      label,
-      select {
-        font:
-          600 12px/1 "SFMono-Regular",
-          Menlo,
-          Monaco,
-          Consolas,
-          monospace;
-        color: var(--muted);
-      }
-      select {
-        height: 36px;
-        border-radius: 0;
-        border: 1px solid var(--line-strong);
-        background: rgba(255, 255, 255, 0.6);
-        padding: 0 10px;
-      }
-      .page-meta {
-        display: grid;
-        gap: 4px;
-      }
       .action-message {
-        min-height: 18px;
         font:
-          600 12px/1.4 "SFMono-Regular",
+          600 11px/1.4 "SFMono-Regular",
           Menlo,
           Monaco,
           Consolas,
           monospace;
         color: var(--muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .action-message.error {
         color: var(--danger-ink);
@@ -298,52 +251,31 @@
       .action-message.ok {
         color: var(--accent);
       }
-      @media (max-width: 900px) {
-        .status-strip {
-          grid-template-columns: repeat(3, minmax(0, 1fr));
-        }
-      }
     </style>
   </head>
   <body>
     <div class="page">
-      <div class="masthead">
-        <div class="topbar">
-          <div>
-            <div class="eyebrow">Local Tool</div>
-            <h1>V2 Image Review</h1>
-            <p id="paths"></p>
-          </div>
-          <div class="actions">
-            <button class="approve" id="approve-all-button" type="button">
-              Approve All
-            </button>
-            <button
-              class="neutral"
-              type="button"
-              onclick="location.href='/gallery'"
-            >
-              Gallery
-            </button>
-            <button class="primary" id="sync-button" type="button">
-              Sync Queue
-            </button>
-            <button class="neutral" id="refresh-button" type="button">
-              Refresh
-            </button>
-          </div>
-        </div>
-
+      <header class="utility-bar">
         <div class="status-strip" id="counts"></div>
-
-        <div class="toolbar">
-          <div class="page-meta">
-            <span class="eyebrow">Visible For Review</span>
-            <span class="pill" id="page-label">Loading…</span>
-            <span class="action-message" id="action-message"></span>
-          </div>
+        <span class="page-label" id="page-label"></span>
+        <span class="action-message" id="action-message"></span>
+        <div class="actions">
+          <button class="approve" id="approve-all-button" type="button">
+            Approve All
+          </button>
+          <button
+            class="neutral"
+            type="button"
+            onclick="location.href='/gallery'"
+          >
+            Gallery
+          </button>
+          <button class="primary" id="sync-button" type="button">Sync</button>
+          <button class="neutral" id="refresh-button" type="button">
+            Refresh
+          </button>
         </div>
-      </div>
+      </header>
 
       <div class="stream" id="items-grid">
         <div class="empty">Loading…</div>
@@ -372,7 +304,7 @@
         <p>
           Approve all
           <strong id="approve-all-count">0</strong>
-          images currently awaiting review?
+          images awaiting review?
         </p>
         <div class="dialog-actions">
           <button class="neutral" id="approve-all-cancel" type="button">
@@ -380,6 +312,30 @@
           </button>
           <button class="approve" id="approve-all-confirm" type="button">
             Confirm
+          </button>
+        </div>
+      </div>
+    </dialog>
+
+    <dialog
+      class="detail-dialog"
+      id="detail-dialog"
+      aria-labelledby="detail-title"
+    >
+      <div class="dialog-body">
+        <div>
+          <h2 id="detail-title">Image comparison</h2>
+          <p id="detail-id"></p>
+        </div>
+        <div class="compare-strip detail-compare">
+          <img id="detail-original" alt="Original image" />
+          <img id="detail-edited" alt="Edited image" />
+        </div>
+        <div class="dialog-actions">
+          <span class="shortcut-hint">Esc close</span>
+          <button class="neutral" id="detail-close" type="button">Close</button>
+          <button class="neutral" id="detail-reject" type="button">
+            Reject
           </button>
         </div>
       </div>

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/promote-codex-native-batch.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/promote-codex-native-batch.mjs
@@ -58,12 +58,13 @@ function findNewestPng(agentId) {
     .readdirSync(agentDir, { withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith(".png"))
     .map((entry) => path.join(agentDir, entry.name))
+    .filter((filePath) => fs.statSync(filePath).size > 0)
     .sort(
       (left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs,
     );
 
   if (!pngPaths[0]) {
-    return { error: `No generated PNG found in: ${agentDir}` };
+    return { error: `No non-empty generated PNG found in: ${agentDir}` };
   }
 
   return { path: pngPaths[0] };

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/promote-codex-native-result.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/promote-codex-native-result.mjs
@@ -50,6 +50,7 @@ function findNewestPng(agentId) {
     .readdirSync(agentDir, { withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith(".png"))
     .map((entry) => path.join(agentDir, entry.name))
+    .filter((filePath) => fs.statSync(filePath).size > 0)
     .sort((left, right) => {
       const leftStat = fs.statSync(left);
       const rightStat = fs.statSync(right);
@@ -57,7 +58,7 @@ function findNewestPng(agentId) {
     });
 
   if (!pngPaths[0]) {
-    throw new Error(`No generated PNG found in: ${agentDir}`);
+    throw new Error(`No non-empty generated PNG found in: ${agentDir}`);
   }
 
   return pngPaths[0];
@@ -115,6 +116,9 @@ const sourcePath = explicitSource ?? findNewestPng(agentId);
 
 if (!fs.existsSync(sourcePath)) {
   throw new Error(`Generated PNG does not exist: ${sourcePath}`);
+}
+if (fs.statSync(sourcePath).size === 0) {
+  throw new Error(`Generated PNG is empty: ${sourcePath}`);
 }
 
 const currentRow = readRow(id);

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/queue-backlog-source-images.ts
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/queue-backlog-source-images.ts
@@ -30,23 +30,6 @@ interface ParsedArgs {
 const CLAIMABLE_STATUSES = ["pending", "processing", "failed", "rejected"];
 const RETRIES = 3;
 const REQUEST_TIMEOUT_MS = 30_000;
-const RETRY_DELAY_MS = Number(
-  process.env.V2_AHS_IMAGE_RETRY_DELAY_MS ?? "2000",
-);
-const RATE_LIMIT_DELAY_MS = Number(
-  process.env.V2_AHS_IMAGE_RATE_LIMIT_DELAY_MS ?? "10000",
-);
-
-class HttpError extends Error {
-  readonly status: number;
-  readonly retryAfterMs: number | null;
-
-  constructor(status: number, retryAfterMs: number | null) {
-    super(`HTTP ${status}`);
-    this.status = status;
-    this.retryAfterMs = retryAfterMs;
-  }
-}
 
 function parseArgs(): ParsedArgs {
   const args = process.argv.slice(2).filter((arg) => arg !== "--");
@@ -319,25 +302,6 @@ function mapOriginalsById(): Map<string, string> {
   return originals;
 }
 
-function sleep(milliseconds: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
-function retryAfterMs(response: Response): number | null {
-  const value = response.headers.get("retry-after");
-  if (!value) return null;
-
-  const seconds = Number(value);
-  if (Number.isFinite(seconds)) {
-    return Math.min(60_000, Math.max(0, seconds * 1_000));
-  }
-
-  const date = Date.parse(value);
-  return Number.isNaN(date)
-    ? null
-    : Math.min(60_000, Math.max(0, date - Date.now()));
-}
-
 async function downloadImage(url: string, outputPath: string): Promise<void> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -353,12 +317,8 @@ async function downloadImage(url: string, outputPath: string): Promise<void> {
       },
     });
 
-    if (!response.ok) {
-      throw new HttpError(response.status, retryAfterMs(response));
-    }
-
-    if (!response.body) {
-      throw new Error("Empty response body");
+    if (!response.ok || !response.body) {
+      throw new Error(`HTTP ${response.status}`);
     }
 
     await pipeline(
@@ -385,16 +345,9 @@ async function downloadWithRetries(
 
       if (attempt === RETRIES) return message;
 
-      const delayMs =
-        error instanceof HttpError && error.retryAfterMs !== null
-          ? error.retryAfterMs
-          : error instanceof HttpError && error.status === 429
-            ? RATE_LIMIT_DELAY_MS * attempt
-            : RETRY_DELAY_MS * attempt;
       console.warn(
-        `[v2-image-queue] retry=${attempt}/${RETRIES} delay=${delayMs}ms id=${row.id} error=${message}`,
+        `[v2-image-queue] retry=${attempt}/${RETRIES} id=${row.id} error=${message}`,
       );
-      await sleep(delayMs);
     }
   }
 
@@ -425,39 +378,6 @@ function insertQueueRow(row: BacklogRow, originalPath: string): void {
         `,
       )
       .run(row.id, row.postTitle, originalPath, now, now);
-  } finally {
-    database.close();
-  }
-}
-
-function insertSourceInvalidRow(
-  row: BacklogRow,
-  originalPath: string,
-  error: string,
-): void {
-  const database = openQueueDb();
-  const now = new Date().toISOString();
-
-  try {
-    ensureSchema(database);
-    database
-      .prepare(
-        `
-          INSERT OR IGNORE INTO "v2_image_review_queue" (
-            "id",
-            "postTitle",
-            "originalPath",
-            "editedPath",
-            "status",
-            "attempts",
-            "lastError",
-            "promptVersion",
-            "createdAt",
-            "updatedAt"
-          ) VALUES (?, ?, ?, NULL, 'source_invalid', 0, ?, NULL, ?, ?)
-        `,
-      )
-      .run(row.id, row.postTitle, originalPath, error, now, now);
   } finally {
     database.close();
   }
@@ -521,9 +441,8 @@ async function main() {
 
     if (error) {
       failed += 1;
-      insertSourceInvalidRow(row, outputPath, error);
       console.warn(
-        `[v2-image-queue] source_invalid id=${row.id} title=${row.postTitle ?? ""} error=${error}`,
+        `[v2-image-queue] failed id=${row.id} title=${row.postTitle ?? ""} error=${error}`,
       );
       continue;
     }

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/queue-backlog-source-images.ts
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/queue-backlog-source-images.ts
@@ -383,6 +383,39 @@ function insertQueueRow(row: BacklogRow, originalPath: string): void {
   }
 }
 
+function insertSourceInvalidRow(
+  row: BacklogRow,
+  originalPath: string,
+  error: string,
+): void {
+  const database = openQueueDb();
+  const now = new Date().toISOString();
+
+  try {
+    ensureSchema(database);
+    database
+      .prepare(
+        `
+          INSERT OR IGNORE INTO "v2_image_review_queue" (
+            "id",
+            "postTitle",
+            "originalPath",
+            "editedPath",
+            "status",
+            "attempts",
+            "lastError",
+            "promptVersion",
+            "createdAt",
+            "updatedAt"
+          ) VALUES (?, ?, ?, NULL, 'source_invalid', 0, ?, NULL, ?, ?)
+        `,
+      )
+      .run(row.id, row.postTitle, originalPath, error, now, now);
+  } finally {
+    database.close();
+  }
+}
+
 async function main() {
   const args = parseArgs();
   const { claimableIds, existingIds } = readQueueState();
@@ -441,8 +474,9 @@ async function main() {
 
     if (error) {
       failed += 1;
+      insertSourceInvalidRow(row, outputPath, error);
       console.warn(
-        `[v2-image-queue] failed id=${row.id} title=${row.postTitle ?? ""} error=${error}`,
+        `[v2-image-queue] source_invalid id=${row.id} title=${row.postTitle ?? ""} error=${error}`,
       );
       continue;
     }

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/review-db.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/review-db.mjs
@@ -97,7 +97,6 @@ export function ensureSchema(database) {
       ON "v2_image_review_queue"("status", "updatedAt");
   `);
 
-  /** @type {Array<{ name: string }>} */
   const columns = database
     .prepare(`PRAGMA table_info("v2_image_review_queue")`)
     .all();
@@ -435,6 +434,7 @@ export function getCounts() {
   }
 }
 
+/** @param {string | null} [preferredId] */
 export function getItem(preferredId = null) {
   const database = openQueueDb();
 
@@ -565,7 +565,7 @@ export function getEditedItems() {
 /**
  * @param {string} id
  * @param {string} status
- * @param {{ lastError?: unknown, editedPath?: unknown, promptVersion?: unknown, incrementAttempts?: boolean }} [options]
+ * @param {{ lastError?: string | null, editedPath?: string | null, promptVersion?: string | null, incrementAttempts?: boolean }} [options]
  */
 export function updateStatus(id, status, options = {}) {
   const database = openQueueDb();
@@ -596,13 +596,13 @@ export function updateStatus(id, status, options = {}) {
       .run(
         status,
         Object.hasOwn(options, "lastError")
-          ? options.lastError
+          ? (options.lastError ?? null)
           : item.lastError,
         Object.hasOwn(options, "editedPath")
-          ? options.editedPath
+          ? (options.editedPath ?? null)
           : item.editedPath,
         Object.hasOwn(options, "promptVersion")
-          ? options.promptVersion
+          ? (options.promptVersion ?? null)
           : item.promptVersion,
         ["pending", "failed", "rejected"].includes(status)
           ? null
@@ -677,6 +677,10 @@ export function approveAllReviewItems() {
   }
 }
 
+/**
+ * @param {string} id
+ * @param {string} agentId
+ */
 export function assignCodexNativeAgent(id, agentId) {
   const database = openQueueDb();
 
@@ -822,6 +826,10 @@ export function claimNextPendingItem(preferredId = null) {
   }
 }
 
+/**
+ * @param {string} id
+ * @param {string} variant
+ */
 export function getFilePath(id, variant) {
   const item = getItem(id);
 

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/review-db.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/review-db.mjs
@@ -28,6 +28,10 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+/**
+ * @param {string} dirPath
+ * @returns {Map<string, string>}
+ */
 function mapFilesByStem(dirPath) {
   const fileMap = new Map();
 
@@ -73,6 +77,7 @@ export function prepareQueueDbForConcurrentWrites() {
   }
 }
 
+/** @param {DatabaseSync} database */
 export function ensureSchema(database) {
   database.exec(`
     CREATE TABLE IF NOT EXISTS "v2_image_review_queue" (
@@ -92,6 +97,7 @@ export function ensureSchema(database) {
       ON "v2_image_review_queue"("status", "updatedAt");
   `);
 
+  /** @type {Array<{ name: string }>} */
   const columns = database
     .prepare(`PRAGMA table_info("v2_image_review_queue")`)
     .all();
@@ -103,7 +109,12 @@ export function ensureSchema(database) {
   }
 }
 
+/**
+ * @param {DatabaseSync} database
+ * @param {string} id
+ */
 function readQueueItem(database, id) {
+  /** @type {Record<string, unknown> | undefined} */
   const row = database
     .prepare(
       `
@@ -551,6 +562,11 @@ export function getEditedItems() {
   }
 }
 
+/**
+ * @param {string} id
+ * @param {string} status
+ * @param {{ lastError?: unknown, editedPath?: unknown, promptVersion?: unknown, incrementAttempts?: boolean }} [options]
+ */
 export function updateStatus(id, status, options = {}) {
   const database = openQueueDb();
 
@@ -602,6 +618,7 @@ export function updateStatus(id, status, options = {}) {
   }
 }
 
+/** @param {string[]} ids */
 export function approveReviewItems(ids) {
   const uniqueIds = [
     ...new Set(ids.filter((id) => typeof id === "string" && id.length > 0)),

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/review-db.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/review-db.mjs
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -590,11 +588,9 @@ export function updateStatus(id, status, options = {}) {
         Object.hasOwn(options, "promptVersion")
           ? options.promptVersion
           : item.promptVersion,
-        Object.hasOwn(options, "codexNativeAgentId")
-          ? options.codexNativeAgentId
-          : ["pending", "failed", "rejected"].includes(status)
-            ? null
-            : item.codexNativeAgentId,
+        ["pending", "failed", "rejected"].includes(status)
+          ? null
+          : item.codexNativeAgentId,
         options.incrementAttempts ? item.attempts + 1 : item.attempts,
         nowIso(),
         id,
@@ -607,41 +603,58 @@ export function updateStatus(id, status, options = {}) {
 }
 
 export function approveReviewItems(ids) {
-  const uniqueIds = [...new Set(ids)];
-  if (uniqueIds.length === 0) return 0;
+  const uniqueIds = [
+    ...new Set(ids.filter((id) => typeof id === "string" && id.length > 0)),
+  ];
+
+  if (uniqueIds.length === 0) {
+    return 0;
+  }
 
   const database = openQueueDb();
 
   try {
     ensureSchema(database);
-    database.exec("BEGIN IMMEDIATE TRANSACTION");
-    let approved = 0;
-
-    for (let offset = 0; offset < uniqueIds.length; offset += 1_000) {
-      const chunk = uniqueIds.slice(offset, offset + 1_000);
-      const placeholders = chunk.map(() => "?").join(", ");
-      const result = database
-        .prepare(
-          `
+    const result = database
+      .prepare(
+        `
           UPDATE "v2_image_review_queue"
           SET
             "status" = 'approved',
             "updatedAt" = ?
           WHERE "status" = 'review'
-            AND "id" IN (${placeholders})
+            AND "id" IN (
+              SELECT CAST("value" AS TEXT)
+              FROM json_each(?)
+            )
         `,
-        )
-        .run(nowIso(), ...chunk);
-      approved += Number(result.changes);
-    }
+      )
+      .run(nowIso(), JSON.stringify(uniqueIds));
 
-    database.exec("COMMIT");
-    return approved;
-  } catch (error) {
-    try {
-      database.exec("ROLLBACK");
-    } catch {}
-    throw error;
+    return Number(result.changes);
+  } finally {
+    database.close();
+  }
+}
+
+export function approveAllReviewItems() {
+  const database = openQueueDb();
+
+  try {
+    ensureSchema(database);
+    const result = database
+      .prepare(
+        `
+          UPDATE "v2_image_review_queue"
+          SET
+            "status" = 'approved',
+            "updatedAt" = ?
+          WHERE "status" = 'review'
+        `,
+      )
+      .run(nowIso());
+
+    return Number(result.changes);
   } finally {
     database.close();
   }

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/rolling-worker-pool.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/rolling-worker-pool.mjs
@@ -1,0 +1,239 @@
+export async function runRollingWorkerPool({
+  backlogRefillSize,
+  claimItem,
+  getClaimableIds,
+  getPendingCount,
+  initialConcurrency,
+  limit,
+  log,
+  onStateChange,
+  processItem,
+  queueSourceRows,
+  specificId,
+  takeControlCommand,
+  terminateChild,
+  terminateRunningChildren,
+}) {
+  const activeTasks = new Set();
+  const attemptedIds = new Set();
+  let desiredConcurrency = initialConcurrency;
+  let draining = false;
+  let forceStopping = false;
+  let stopSignal = null;
+  let stopReason = null;
+  let catchupStarted = Boolean(specificId);
+  let catchupComplete = Boolean(specificId);
+  let backlogExhausted = false;
+  let refillChild = null;
+  let refillMode = null;
+  let refillPromise = null;
+  let refillCheckNeeded = true;
+  let fatalError = null;
+
+  const getState = () => ({
+    active: activeTasks.size,
+    attempted: attemptedIds.size,
+    desiredConcurrency,
+    draining,
+    forceStopping,
+    refillMode,
+    stopReason,
+    stopSignal,
+  });
+  const publishState = () => onStateChange(getState());
+
+  const requestDrain = (reason) => {
+    if (draining) return;
+    draining = true;
+    stopReason = reason;
+    log(`draining reason=${reason} active=${activeTasks.size}`);
+    if (refillChild) terminateChild(refillChild);
+    publishState();
+  };
+
+  const forceStop = (signal) => {
+    if (forceStopping) return;
+    forceStopping = true;
+    draining = true;
+    stopSignal = signal;
+    stopReason ??= signal;
+    log(`force stopping signal=${signal} active=${activeTasks.size}`);
+    if (refillChild) terminateChild(refillChild);
+    terminateRunningChildren(signal);
+    publishState();
+  };
+
+  const handleSignal = (signal) => {
+    if (draining) {
+      forceStop(signal);
+      return;
+    }
+    requestDrain(signal);
+  };
+  const handleSigint = () => handleSignal("SIGINT");
+  const handleSigterm = () => handleSignal("SIGTERM");
+  process.on("SIGINT", handleSigint);
+  process.on("SIGTERM", handleSigterm);
+
+  const startAvailable = () => {
+    if (draining || attemptedIds.size >= limit) return;
+
+    const slots = Math.min(
+      desiredConcurrency - activeTasks.size,
+      limit - attemptedIds.size,
+    );
+    if (slots <= 0) return;
+
+    const ids = getClaimableIds(slots);
+    let claimed = 0;
+    for (const id of ids) {
+      const item = claimItem(id);
+      if (!item) {
+        log(`skipped id=${id} reason=not-claimable`);
+        continue;
+      }
+
+      attemptedIds.add(id);
+      claimed += 1;
+      let task;
+      task = processItem(item, getState).finally(() => {
+        activeTasks.delete(task);
+        refillCheckNeeded = true;
+        publishState();
+      });
+      activeTasks.add(task);
+    }
+
+    if (claimed > 0) refillCheckNeeded = true;
+    publishState();
+  };
+
+  const beginRefill = (mode, refillLimit) => {
+    if (refillPromise || draining || refillLimit < 1) return;
+    refillMode = mode;
+    if (mode === "catchup") catchupStarted = true;
+    publishState();
+
+    refillPromise = queueSourceRows(mode, refillLimit, (child) => {
+      refillChild = child;
+    })
+      .then((output) => {
+        if (mode === "catchup") catchupComplete = true;
+        if (mode === "backlog" && /\bselected=0\b/.test(output)) {
+          backlogExhausted = true;
+        }
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        if (draining) {
+          log(`queue refill interrupted mode=${mode}`);
+          return;
+        }
+
+        fatalError = error;
+        process.exitCode = 1;
+        log(`${mode} refill stopped error=${message}`);
+        requestDrain(`${mode} refill failed`);
+      })
+      .finally(() => {
+        refillChild = null;
+        refillMode = null;
+        refillPromise = null;
+        refillCheckNeeded = true;
+        publishState();
+      });
+  };
+
+  const maybeRefill = () => {
+    if (specificId || draining || refillPromise || !refillCheckNeeded) return;
+    refillCheckNeeded = false;
+
+    const remaining = limit - attemptedIds.size;
+    if (remaining <= 0) return;
+    if (!catchupStarted) {
+      beginRefill("catchup", remaining);
+      return;
+    }
+    if (!catchupComplete || backlogExhausted) return;
+
+    const pending = getPendingCount();
+    const lowWater = Math.min(remaining, desiredConcurrency * 2);
+    if (pending >= lowWater) return;
+    const refillSize = Math.min(
+      remaining - pending,
+      Math.max(backlogRefillSize, desiredConcurrency * 3),
+    );
+    beginRefill("backlog", refillSize);
+  };
+
+  const applyControlCommand = () => {
+    const command = takeControlCommand();
+    if (!command) return;
+
+    if (command.command === "drain") {
+      requestDrain("control command");
+      return;
+    }
+    if (
+      command.command === "concurrency" &&
+      Number.isInteger(command.value) &&
+      command.value > 0
+    ) {
+      const previous = desiredConcurrency;
+      desiredConcurrency = command.value;
+      refillCheckNeeded = true;
+      log(
+        `concurrency changed previous=${previous} desired=${desiredConcurrency} active=${activeTasks.size}`,
+      );
+      publishState();
+      return;
+    }
+    log(`control command ignored reason=invalid command=${command.command}`);
+  };
+
+  const waitForActivity = async () => {
+    const waits = [new Promise((resolve) => setTimeout(resolve, 250))];
+    waits.push(...activeTasks);
+    if (refillPromise) waits.push(refillPromise);
+    await Promise.race(waits);
+  };
+
+  publishState();
+  try {
+    while (true) {
+      applyControlCommand();
+      startAvailable();
+      maybeRefill();
+
+      if (!draining && attemptedIds.size >= limit) {
+        requestDrain("limit reached");
+      }
+      if (
+        !draining &&
+        specificId &&
+        attemptedIds.size === 0 &&
+        activeTasks.size === 0
+      ) {
+        requestDrain("queue item is not claimable");
+      }
+      if (
+        !draining &&
+        backlogExhausted &&
+        !refillPromise &&
+        activeTasks.size === 0 &&
+        getClaimableIds(1).length === 0
+      ) {
+        requestDrain("source backlog exhausted");
+      }
+      if (draining && activeTasks.size === 0 && !refillPromise) break;
+      if (fatalError && activeTasks.size === 0 && !refillPromise) break;
+
+      await waitForActivity();
+    }
+  } finally {
+    process.removeListener("SIGINT", handleSigint);
+    process.removeListener("SIGTERM", handleSigterm);
+  }
+
+  return getState();
+}

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs
@@ -15,6 +15,7 @@ import {
   prepareQueueDbForConcurrentWrites,
   updateStatus,
 } from "./review-db.mjs";
+import { runRollingWorkerPool } from "./rolling-worker-pool.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const PROMOTE_SCRIPT = path.join(SCRIPT_DIR, "promote-codex-native-result.mjs");
@@ -576,7 +577,7 @@ function logProdCopyAge() {
   }
 }
 
-function getClaimableIds({ id, limit }, excludedIds = new Set()) {
+function getClaimableIds({ id, limit }) {
   const database = openQueueDb();
 
   try {
@@ -594,24 +595,39 @@ function getClaimableIds({ id, limit }, excludedIds = new Set()) {
         )
         .get(id);
 
-      return row && !excludedIds.has(String(row.id)) ? [String(row.id)] : [];
+      return row ? [String(row.id)] : [];
     }
 
     const rows = database
       .prepare(
         `
-          SELECT "id", "status", "updatedAt"
+          SELECT "id"
           FROM "v2_image_review_queue"
           WHERE "status" = 'pending'
           ORDER BY "updatedAt" ASC, "id" ASC
+          LIMIT ?
         `,
       )
-      .all();
+      .all(limit);
 
-    return rows
-      .filter((row) => !excludedIds.has(String(row.id)))
-      .slice(0, limit)
-      .map((row) => String(row.id));
+    return rows.map((row) => String(row.id));
+  } finally {
+    database.close();
+  }
+}
+
+function getPendingCount() {
+  const database = openQueueDb();
+
+  try {
+    ensureSchema(database);
+    return Number(
+      database
+        .prepare(
+          `SELECT COUNT(*) AS "count" FROM "v2_image_review_queue" WHERE "status" = 'pending'`,
+        )
+        .get().count,
+    );
   } finally {
     database.close();
   }
@@ -1011,8 +1027,6 @@ async function main() {
   const recovery = recoverMappedOutputs();
   log(`queue afterRecovery ${getQueueStatusSummary()}`);
   const activeChildren = new Map();
-  const activeTasks = new Set();
-  const attemptedIds = new Set();
   const runStartedAt = Date.now();
   const durationsMs = [];
   const usageTotals = {
@@ -1022,37 +1036,25 @@ async function main() {
     reasoningOutputTokens: 0,
   };
   let usageSamples = 0;
-  let desiredConcurrency = args.concurrency;
-  let draining = false;
-  let forceStopping = false;
-  let stopSignal = null;
-  let stopReason = null;
   let completed = 0;
   let promoted = 0;
   let failed = 0;
   let interrupted = 0;
-  let catchupStarted = Boolean(args.id);
-  let catchupComplete = Boolean(args.id);
-  let backlogExhausted = false;
-  let refillChild = null;
-  let refillMode = null;
-  let refillPromise = null;
-  let fatalError = null;
 
-  const writeWorkerState = () => {
+  const writeWorkerState = (schedulerState) => {
     writeJsonAtomic(WORKER_STATE_PATH, {
-      active: activeChildren.size,
-      attempted: attemptedIds.size,
+      active: schedulerState.active,
+      attempted: schedulerState.attempted,
       completed,
-      desiredConcurrency,
-      draining,
+      desiredConcurrency: schedulerState.desiredConcurrency,
+      draining: schedulerState.draining,
       failed,
       limit: args.limit,
       pid: process.pid,
       promoted,
-      refillMode,
+      refillMode: schedulerState.refillMode,
       runId: RUN_ID,
-      status: draining ? "draining" : "running",
+      status: schedulerState.draining ? "draining" : "running",
       updatedAt: new Date().toISOString(),
     });
   };
@@ -1075,59 +1077,23 @@ async function main() {
     }
   };
 
-  const logProgress = () => {
+  const logProgress = (schedulerState) => {
     const completionPercent = ((completed / args.limit) * 100).toFixed(1);
     const successPercent =
       completed === 0 ? "0.0" : ((promoted / completed) * 100).toFixed(1);
     log(
-      `progress completed=${completed}/${args.limit} (${completionPercent}%) success=${promoted}/${completed} (${successPercent}%) failed=${failed} active=${activeChildren.size} target=${desiredConcurrency}`,
+      `progress completed=${completed}/${args.limit} (${completionPercent}%) success=${promoted}/${completed} (${successPercent}%) failed=${failed} active=${schedulerState.active} target=${schedulerState.desiredConcurrency}`,
     );
-    writeWorkerState();
   };
-
-  const requestDrain = (reason) => {
-    if (draining) return;
-    draining = true;
-    stopReason = reason;
-    log(`draining reason=${reason} active=${activeChildren.size}`);
-    if (refillChild) terminate(refillChild);
-    writeWorkerState();
-  };
-
-  const forceStop = (signal) => {
-    if (forceStopping) return;
-    forceStopping = true;
-    draining = true;
-    stopSignal = signal;
-    stopReason ??= signal;
-    log(`force stopping signal=${signal} active=${activeChildren.size}`);
-    if (refillChild) terminate(refillChild);
-    for (const child of activeChildren.values()) terminate(child);
-    writeWorkerState();
-  };
-
-  const handleSignal = (signal) => {
-    if (draining) {
-      forceStop(signal);
-      return;
-    }
-    requestDrain(signal);
-  };
-
-  const handleSigint = () => handleSignal("SIGINT");
-  const handleSigterm = () => handleSignal("SIGTERM");
-  process.on("SIGINT", handleSigint);
-  process.on("SIGTERM", handleSigterm);
 
   log(
     `worker started limit=${args.limit} backlogRefillSize=${args.backlogRefillSize} concurrency=${args.concurrency} model=${args.model} effort=${args.effort} timeoutMinutes=${Math.round(args.timeoutMs / 60_000)} usageIntervalMinutes=${args.usageIntervalMs / 60_000} scheduler=rolling sessionMode=isolated-image-only`,
   );
-  writeWorkerState();
   const usageMonitor = createUsageMonitor(args.usageIntervalMs);
   await usageMonitor.sample("start");
   usageMonitor.start();
 
-  const processItem = async (item) => {
+  const processItem = async (item, getSchedulerState) => {
     try {
       const result = await generate(item, args, activeChildren);
       promoted += 1;
@@ -1136,13 +1102,14 @@ async function main() {
       log(
         `thread finished id=${item.id} session=${result.sessionId} image=yes promoted=yes status=review durationSeconds=${(result.durationMs / 1_000).toFixed(1)} ${formatUsage(result.usage)} output=${result.imagePath}`,
       );
-      logProgress();
+      logProgress(getSchedulerState());
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      const schedulerState = getSchedulerState();
 
-      if (forceStopping) {
+      if (schedulerState.forceStopping) {
         interrupted += 1;
-        const interruption = `Worker interrupted by ${stopSignal ?? "signal"}`;
+        const interruption = `Worker interrupted by ${schedulerState.stopSignal ?? "signal"}`;
         try {
           updateStatus(item.id, "pending", { lastError: interruption });
         } catch (databaseError) {
@@ -1155,7 +1122,7 @@ async function main() {
           );
         }
         log(
-          `thread interrupted id=${item.id} session=${error?.sessionId ?? "unknown"} signal=${stopSignal ?? "unknown"} status=pending`,
+          `thread interrupted id=${item.id} session=${error?.sessionId ?? "unknown"} signal=${schedulerState.stopSignal ?? "unknown"} status=pending`,
         );
         return;
       }
@@ -1188,174 +1155,51 @@ async function main() {
           logLines(`no-image diagnostic id=${item.id}`, error.codexDiagnostics);
         }
       }
-      logProgress();
+      logProgress(schedulerState);
     }
   };
 
-  const startAvailable = () => {
-    if (draining || attemptedIds.size >= args.limit) return;
-
-    const slots = Math.min(
-      desiredConcurrency - activeTasks.size,
-      args.limit - attemptedIds.size,
-    );
-    if (slots <= 0) return;
-
-    const ids = getClaimableIds({ ...args, limit: slots }, attemptedIds);
-    for (const id of ids) {
-      const item = claimNextPendingItem(id);
-      if (!item) {
-        log(`skipped id=${id} reason=not-claimable`);
-        continue;
-      }
-
-      attemptedIds.add(id);
-      let task;
-      task = processItem(item).finally(() => {
-        activeTasks.delete(task);
-        writeWorkerState();
-      });
-      activeTasks.add(task);
-    }
-    writeWorkerState();
-  };
-
-  const beginRefill = (mode, limit) => {
-    if (refillPromise || draining || limit < 1) return;
-    refillMode = mode;
-    if (mode === "catchup") catchupStarted = true;
-    writeWorkerState();
-
-    refillPromise = queueSourceRows(mode, limit, (child) => {
-      refillChild = child;
-    })
-      .then((output) => {
-        if (mode === "catchup") catchupComplete = true;
-        if (mode === "backlog" && /\bselected=0\b/.test(output)) {
-          backlogExhausted = true;
-        }
-      })
-      .catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        if (draining) {
-          log(`queue refill interrupted mode=${mode}`);
-          return;
-        }
-
-        fatalError = error;
-        process.exitCode = 1;
-        log(`${mode} refill stopped error=${message}`);
-        requestDrain(`${mode} refill failed`);
-      })
-      .finally(() => {
-        refillChild = null;
-        refillMode = null;
-        refillPromise = null;
-        writeWorkerState();
-      });
-  };
-
-  const maybeRefill = () => {
-    if (args.id || draining || refillPromise) return;
-    const remaining = args.limit - attemptedIds.size;
-    if (remaining <= 0) return;
-
-    const pending = getClaimableIds(
-      { ...args, id: null, limit: remaining },
-      attemptedIds,
-    ).length;
-    if (!catchupStarted) {
-      beginRefill("catchup", remaining);
-      return;
-    }
-    if (!catchupComplete || backlogExhausted) return;
-
-    const lowWater = Math.min(remaining, desiredConcurrency * 2);
-    if (pending >= lowWater) return;
-    const refillSize = Math.min(
-      remaining - pending,
-      Math.max(args.backlogRefillSize, desiredConcurrency * 3),
-    );
-    beginRefill("backlog", refillSize);
-  };
-
-  const applyControlCommand = () => {
-    if (!fs.existsSync(WORKER_COMMAND_PATH)) return;
+  const takeControlCommand = () => {
+    if (!fs.existsSync(WORKER_COMMAND_PATH)) return null;
 
     let command;
     try {
       command = JSON.parse(fs.readFileSync(WORKER_COMMAND_PATH, "utf8"));
-      fs.rmSync(WORKER_COMMAND_PATH, { force: true });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       log(`control command ignored error=${message}`);
-      return;
+      return null;
+    } finally {
+      fs.rmSync(WORKER_COMMAND_PATH, { force: true });
     }
 
     if (command.runId !== RUN_ID) {
       log(
         `control command ignored reason=run-mismatch command=${command.runId}`,
       );
-      return;
+      return null;
     }
-    if (command.command === "drain") {
-      requestDrain("control command");
-      return;
-    }
-    if (
-      command.command === "concurrency" &&
-      Number.isInteger(command.value) &&
-      command.value > 0
-    ) {
-      const previous = desiredConcurrency;
-      desiredConcurrency = command.value;
-      log(
-        `concurrency changed previous=${previous} desired=${desiredConcurrency} active=${activeChildren.size}`,
-      );
-      writeWorkerState();
-      return;
-    }
-    log(`control command ignored reason=invalid command=${command.command}`);
+    return command;
   };
 
-  const waitForActivity = async () => {
-    const waits = [new Promise((resolve) => setTimeout(resolve, 250))];
-    waits.push(...activeTasks);
-    if (refillPromise) waits.push(refillPromise);
-    await Promise.race(waits);
-  };
-
-  while (true) {
-    applyControlCommand();
-    startAvailable();
-    maybeRefill();
-
-    if (!draining && attemptedIds.size >= args.limit) {
-      requestDrain("limit reached");
-    }
-    if (
-      !draining &&
-      args.id &&
-      attemptedIds.size === 0 &&
-      activeTasks.size === 0
-    ) {
-      requestDrain("queue item is not claimable");
-    }
-    if (
-      !draining &&
-      backlogExhausted &&
-      !refillPromise &&
-      activeTasks.size === 0 &&
-      getClaimableIds({ ...args, id: null, limit: 1 }, attemptedIds).length ===
-        0
-    ) {
-      requestDrain("source backlog exhausted");
-    }
-    if (draining && activeTasks.size === 0 && !refillPromise) break;
-    if (fatalError && activeTasks.size === 0 && !refillPromise) break;
-
-    await waitForActivity();
-  }
+  const schedulerResult = await runRollingWorkerPool({
+    backlogRefillSize: args.backlogRefillSize,
+    claimItem: claimNextPendingItem,
+    getClaimableIds: (limit) => getClaimableIds({ ...args, limit }),
+    getPendingCount,
+    initialConcurrency: args.concurrency,
+    limit: args.limit,
+    log,
+    onStateChange: writeWorkerState,
+    processItem,
+    queueSourceRows,
+    specificId: args.id,
+    takeControlCommand,
+    terminateChild: terminate,
+    terminateRunningChildren: () => {
+      for (const child of activeChildren.values()) terminate(child);
+    },
+  });
 
   await usageMonitor.finish();
   const wallSeconds = (Date.now() - runStartedAt) / 1_000;
@@ -1381,10 +1225,8 @@ async function main() {
   }
   log(`queue finish ${getQueueStatusSummary()}`);
   log(
-    `worker finished attempted=${attemptedIds.size} completed=${completed} promoted=${promoted} recovered=${recovery.recovered} recoveryReset=${recovery.reset} failed=${failed} interrupted=${interrupted} stopReason=${stopReason ?? "complete"} successRate=${completed === 0 ? "0.0" : ((promoted / completed) * 100).toFixed(1)}% runLog=${RUN_LOG_PATH} eventsLog=${RUN_EVENTS_PATH}`,
+    `worker finished attempted=${schedulerResult.attempted} completed=${completed} promoted=${promoted} recovered=${recovery.recovered} recoveryReset=${recovery.reset} failed=${failed} interrupted=${interrupted} stopReason=${schedulerResult.stopReason ?? "complete"} successRate=${completed === 0 ? "0.0" : ((promoted / completed) * 100).toFixed(1)}% runLog=${RUN_LOG_PATH} eventsLog=${RUN_EVENTS_PATH}`,
   );
-  process.removeListener("SIGINT", handleSigint);
-  process.removeListener("SIGTERM", handleSigterm);
   removeWorkerState();
   process.removeListener("exit", removeWorkerState);
   releaseWorkerLock();

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs
@@ -44,7 +44,9 @@ const GENERATED_IMAGES_ROOT = path.resolve(
   process.env.CODEX_GENERATED_IMAGES_ROOT ||
     path.join(CODEX_IMAGE_HOME, "generated_images"),
 );
-const CODEX_AUTH_PATH = path.join(os.homedir(), ".codex", "auth.json");
+const CODEX_AUTH_PATH = path.resolve(
+  process.env.CODEX_AUTH_PATH || path.join(os.homedir(), ".codex", "auth.json"),
+);
 const CODEX_BIN = process.env.CODEX_BIN || "codex";
 const DEFAULT_MODEL = process.env.CODEX_IMAGE_AGENT_MODEL || "gpt-5.6-luna";
 const DEFAULT_EFFORT = process.env.CODEX_IMAGE_AGENT_EFFORT || "high";

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs
@@ -707,7 +707,7 @@ function getQueueStatusSummary() {
   }
 }
 
-function recoverMappedOutputs() {
+function recoverMappedOutputs(staleAfterMs) {
   const database = openQueueDb();
   let rows;
 
@@ -716,7 +716,7 @@ function recoverMappedOutputs() {
     rows = database
       .prepare(
         `
-          SELECT "id", "codexNativeAgentId"
+          SELECT "id", "codexNativeAgentId", "updatedAt"
           FROM "v2_image_review_queue"
           WHERE "status" = 'processing'
         `,
@@ -727,6 +727,7 @@ function recoverMappedOutputs() {
   }
 
   let recovered = 0;
+  let preserved = 0;
   let reset = 0;
 
   for (const row of rows) {
@@ -755,8 +756,20 @@ function recoverMappedOutputs() {
           log(
             `recovery promotion failed id=${id} session=${sessionId} error=${message}`,
           );
+          preserved += 1;
+          continue;
         }
       }
+    }
+
+    const updatedAtMs = Date.parse(String(row.updatedAt));
+    const ageMs = Date.now() - updatedAtMs;
+    if (Number.isFinite(updatedAtMs) && ageMs < staleAfterMs) {
+      preserved += 1;
+      log(
+        `recovery preserved id=${id} session=${sessionId ?? "none"} ageSeconds=${Math.round(ageMs / 1_000)} retryAfterSeconds=${Math.ceil((staleAfterMs - ageMs) / 1_000)}`,
+      );
+      continue;
     }
 
     updateStatus(id, "pending", {
@@ -770,7 +783,7 @@ function recoverMappedOutputs() {
     );
   }
 
-  return { recovered, reset };
+  return { preserved, recovered, reset };
 }
 
 function promote(id, sessionId) {
@@ -959,10 +972,11 @@ function generate(item, args, activeChildren) {
           });
           return;
         } catch (error) {
-          if (!pendingError && code === 0) {
+          if (!pendingError) {
             error.codexResponse = responses.join("\n\n");
             error.codexDiagnostics = diagnostics.join("\n\n");
             error.imageCreated = true;
+            error.recoverableImage = true;
             error.sessionId = sessionId;
             rejectGeneration(error);
             return;
@@ -1024,7 +1038,7 @@ async function main() {
   logProdCopyAge();
   prepareQueueDbForConcurrentWrites();
   log(`queue initial ${getQueueStatusSummary()}`);
-  const recovery = recoverMappedOutputs();
+  const recovery = recoverMappedOutputs(args.timeoutMs);
   log(`queue afterRecovery ${getQueueStatusSummary()}`);
   const activeChildren = new Map();
   const runStartedAt = Date.now();
@@ -1131,20 +1145,21 @@ async function main() {
       completed += 1;
       recordMetrics(error?.durationMs, error?.codexUsage);
 
+      const status = error?.recoverableImage ? "processing" : "failed";
       try {
-        updateStatus(item.id, "failed", { lastError: message });
+        updateStatus(item.id, status, { lastError: message });
       } catch (databaseError) {
         const databaseMessage =
           databaseError instanceof Error
             ? databaseError.message
             : String(databaseError);
         log(
-          `status update failed id=${item.id} intendedStatus=failed error=${databaseMessage}`,
+          `status update failed id=${item.id} intendedStatus=${status} error=${databaseMessage}`,
         );
       }
 
       log(
-        `thread finished id=${item.id} session=${error?.sessionId ?? "unknown"} image=${error?.noImage ? "no" : error?.imageCreated ? "yes" : "unknown"} promoted=no status=failed durationSeconds=${Number.isFinite(error?.durationMs) ? (error.durationMs / 1_000).toFixed(1) : "unknown"} ${formatUsage(error?.codexUsage)} error=${message}`,
+        `thread finished id=${item.id} session=${error?.sessionId ?? "unknown"} image=${error?.noImage ? "no" : error?.imageCreated ? "yes" : "unknown"} promoted=no status=${status} durationSeconds=${Number.isFinite(error?.durationMs) ? (error.durationMs / 1_000).toFixed(1) : "unknown"} ${formatUsage(error?.codexUsage)} error=${message}`,
       );
       if (error?.noImage) {
         logLines(
@@ -1225,7 +1240,7 @@ async function main() {
   }
   log(`queue finish ${getQueueStatusSummary()}`);
   log(
-    `worker finished attempted=${schedulerResult.attempted} completed=${completed} promoted=${promoted} recovered=${recovery.recovered} recoveryReset=${recovery.reset} failed=${failed} interrupted=${interrupted} stopReason=${schedulerResult.stopReason ?? "complete"} successRate=${completed === 0 ? "0.0" : ((promoted / completed) * 100).toFixed(1)}% runLog=${RUN_LOG_PATH} eventsLog=${RUN_EVENTS_PATH}`,
+    `worker finished attempted=${schedulerResult.attempted} completed=${completed} promoted=${promoted} recovered=${recovery.recovered} recoveryPreserved=${recovery.preserved} recoveryReset=${recovery.reset} failed=${failed} interrupted=${interrupted} stopReason=${schedulerResult.stopReason ?? "complete"} successRate=${completed === 0 ? "0.0" : ((promoted / completed) * 100).toFixed(1)}% runLog=${RUN_LOG_PATH} eventsLog=${RUN_EVENTS_PATH}`,
   );
   removeWorkerState();
   process.removeListener("exit", removeWorkerState);

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs
@@ -29,6 +29,14 @@ const RUN_LOG_DIR = path.join(REVIEW_ROOT, "codex-native-runs");
 const RUN_LOG_PATH = path.join(RUN_LOG_DIR, `${RUN_ID}.log`);
 const RUN_EVENTS_PATH = path.join(RUN_LOG_DIR, `${RUN_ID}.events.jsonl`);
 const WORKER_LOCK_PATH = path.join(REVIEW_ROOT, "codex-native-worker.lock");
+const WORKER_COMMAND_PATH = path.join(
+  REVIEW_ROOT,
+  "codex-native-worker-command.json",
+);
+const WORKER_STATE_PATH = path.join(
+  REVIEW_ROOT,
+  "codex-native-worker-state.json",
+);
 const CODEX_IMAGE_HOME = path.resolve(
   process.env.CODEX_IMAGE_HOME || path.join(REVIEW_ROOT, "codex-image-home"),
 );
@@ -43,7 +51,6 @@ const DEFAULT_EFFORT = process.env.CODEX_IMAGE_AGENT_EFFORT || "high";
 const NODE_SQLITE_ARGS = ["--disable-warning=ExperimentalWarning"];
 const USAGE_CHECK_DISABLED = process.env.CODEX_USAGE_CHECK_DISABLED === "1";
 const CLEAN_CODEX_FLAGS = [
-  "--ephemeral",
   "--ignore-user-config",
   "--ignore-rules",
   "-c",
@@ -107,13 +114,18 @@ function readPositiveInteger(name, fallback = null) {
 function parseArgs() {
   const id = readOption("--id");
   const limit = readPositiveInteger("--limit", id ? 1 : null);
+  const concurrency = readPositiveInteger("--concurrency", 10);
 
   if (!limit) {
     throw new Error("Pass --limit <count> or --id <queue-id>");
   }
 
   return {
-    concurrency: readPositiveInteger("--concurrency", 10),
+    backlogRefillSize: readPositiveInteger(
+      "--backlog-refill-size",
+      concurrency * 2,
+    ),
+    concurrency,
     effort: readOption("--effort") || DEFAULT_EFFORT,
     id,
     limit,
@@ -516,21 +528,6 @@ function findGeneratedPng(sessionId) {
   );
 }
 
-function removeGeneratedSession(sessionId) {
-  const sessionPath = path.resolve(GENERATED_IMAGES_ROOT, sessionId);
-  if (path.dirname(sessionPath) !== GENERATED_IMAGES_ROOT) {
-    log(`generated cleanup skipped invalid session=${sessionId}`);
-    return;
-  }
-
-  try {
-    fs.rmSync(sessionPath, { recursive: true, force: true });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    log(`generated cleanup failed session=${sessionId} error=${message}`);
-  }
-}
-
 function createGenerationError(
   message,
   response,
@@ -603,15 +600,8 @@ function getClaimableIds({ id, limit }, excludedIds = new Set()) {
         `
           SELECT "id", "status", "updatedAt"
           FROM "v2_image_review_queue"
-          WHERE "status" IN ('pending', 'failed', 'rejected')
-          ORDER BY
-            CASE "status"
-              WHEN 'failed' THEN 0
-              WHEN 'rejected' THEN 1
-              ELSE 2
-            END,
-            "updatedAt" ASC,
-            "id" ASC
+          WHERE "status" = 'pending'
+          ORDER BY "updatedAt" ASC, "id" ASC
         `,
       )
       .all();
@@ -625,24 +615,56 @@ function getClaimableIds({ id, limit }, excludedIds = new Set()) {
   }
 }
 
-function queueSourceRows(mode, limit = null) {
+function queueSourceRows(mode, limit = null, onSpawn = () => {}) {
   log(`queue refill mode=${mode} requested=${limit ?? "all"}`);
   const scriptArgs = [BACKLOG_SCRIPT, "--mode", mode];
   if (limit !== null) scriptArgs.push("--limit", String(limit));
 
-  const output = execFileSync(
-    process.execPath,
-    [...NODE_SQLITE_ARGS, ...scriptArgs],
-    {
-      encoding: "utf8",
-      env: process.env,
-      maxBuffer: 10 * 1024 * 1024,
-    },
-  );
-  if (output.trim()) logLines(`queue ${mode}`, output);
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [...NODE_SQLITE_ARGS, ...scriptArgs],
+      {
+        detached: process.platform !== "win32",
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
 
-  const selected = Number(output.match(/\bselected=(\d+)/)?.[1] ?? Number.NaN);
-  return { selected: Number.isFinite(selected) ? selected : 0 };
+    onSpawn(child);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout = `${stdout}${chunk}`.slice(-10 * 1024 * 1024);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr = `${stderr}${chunk}`.slice(-1 * 1024 * 1024);
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (stdout.trim()) logLines(`queue ${mode}`, stdout);
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+
+      reject(
+        new Error(
+          `Queue ${mode} exited code=${code ?? "none"} signal=${signal ?? "none"}${
+            stderr.trim() ? ` stderr=${stderr.trim()}` : ""
+          }`,
+        ),
+      );
+    });
+  });
+}
+
+function writeJsonAtomic(filePath, value) {
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`);
+  fs.renameSync(temporaryPath, filePath);
 }
 
 function getQueueStatusSummary() {
@@ -667,7 +689,7 @@ function getQueueStatusSummary() {
   }
 }
 
-function recoverMappedOutputs(staleAfterMs) {
+function recoverMappedOutputs() {
   const database = openQueueDb();
   let rows;
 
@@ -676,7 +698,7 @@ function recoverMappedOutputs(staleAfterMs) {
     rows = database
       .prepare(
         `
-          SELECT "id", "codexNativeAgentId", "updatedAt"
+          SELECT "id", "codexNativeAgentId"
           FROM "v2_image_review_queue"
           WHERE "status" = 'processing'
         `,
@@ -687,7 +709,6 @@ function recoverMappedOutputs(staleAfterMs) {
   }
 
   let recovered = 0;
-  let preserved = 0;
   let reset = 0;
 
   for (const row of rows) {
@@ -705,7 +726,6 @@ function recoverMappedOutputs(staleAfterMs) {
       } else {
         try {
           promote(id, sessionId);
-          removeGeneratedSession(sessionId);
           recovered += 1;
           log(
             `recovered id=${id} session=${sessionId} image=yes source=${imagePath}`,
@@ -717,19 +737,8 @@ function recoverMappedOutputs(staleAfterMs) {
           log(
             `recovery promotion failed id=${id} session=${sessionId} error=${message}`,
           );
-          continue;
         }
       }
-    }
-
-    const updatedAtMs = Date.parse(String(row.updatedAt));
-    const ageMs = Date.now() - updatedAtMs;
-    if (Number.isFinite(updatedAtMs) && ageMs < staleAfterMs) {
-      preserved += 1;
-      log(
-        `recovery preserved id=${id} session=${sessionId ?? "none"} ageSeconds=${Math.round(ageMs / 1_000)} retryAfterSeconds=${Math.ceil((staleAfterMs - ageMs) / 1_000)}`,
-      );
-      continue;
     }
 
     updateStatus(id, "pending", {
@@ -743,7 +752,7 @@ function recoverMappedOutputs(staleAfterMs) {
     );
   }
 
-  return { preserved, recovered, reset };
+  return { recovered, reset };
 }
 
 function promote(id, sessionId) {
@@ -893,40 +902,19 @@ function generate(item, args, activeChildren) {
       activeChildren.delete(item.id);
       if (stdoutBuffer) consumeLine(stdoutBuffer);
 
-      if (pendingError) {
-        pendingError.codexResponse = responses.join("\n\n");
-        pendingError.codexDiagnostics = diagnostics.join("\n\n");
-        pendingError.imageCreated = Boolean(
-          sessionId && findGeneratedPng(sessionId),
-        );
-        pendingError.sessionId = sessionId;
-        rejectGeneration(pendingError);
-        return;
-      }
-
-      if (code !== 0) {
-        const imageCreated = Boolean(sessionId && findGeneratedPng(sessionId));
-        const error = createGenerationError(
-          `Codex exited code=${code} signal=${signal ?? "none"}${
-            stderr.trim() ? ` stderr=${stderr.trim()}` : ""
-          }`,
-          responses.join("\n\n"),
-          {
-            diagnostics: diagnostics.join("\n\n"),
-            noImage: !imageCreated,
-            sessionId,
-          },
-        );
-        error.imageCreated = imageCreated;
-        error.recoverableImage = imageCreated && signal === null;
-        rejectGeneration(error);
-        return;
-      }
-
       if (sessionId) {
         const imagePath = findGeneratedPng(sessionId);
 
         if (!imagePath) {
+          if (pendingError) {
+            pendingError.codexResponse = responses.join("\n\n");
+            pendingError.codexDiagnostics = diagnostics.join("\n\n");
+            pendingError.noImage = true;
+            pendingError.sessionId = sessionId;
+            rejectGeneration(pendingError);
+            return;
+          }
+
           rejectGeneration(
             createGenerationError(
               `Codex session ${sessionId} completed without a generated PNG (exit=${code ?? "none"} signal=${signal ?? "none"})`,
@@ -943,16 +931,10 @@ function generate(item, args, activeChildren) {
 
         try {
           promote(item.id, sessionId);
-          const promotedImagePath = path.join(
-            REVIEW_ROOT,
-            "edited",
-            `${item.id}.png`,
-          );
-          removeGeneratedSession(sessionId);
           resolve({
             durationMs: Date.now() - startedAt,
             id: item.id,
-            imagePath: promotedImagePath,
+            imagePath,
             response: responses.join("\n\n"),
             sessionId,
             usage,
@@ -963,12 +945,36 @@ function generate(item, args, activeChildren) {
             error.codexResponse = responses.join("\n\n");
             error.codexDiagnostics = diagnostics.join("\n\n");
             error.imageCreated = true;
-            error.recoverableImage = true;
             error.sessionId = sessionId;
             rejectGeneration(error);
             return;
           }
         }
+      }
+
+      if (pendingError) {
+        pendingError.codexResponse = responses.join("\n\n");
+        pendingError.codexDiagnostics = diagnostics.join("\n\n");
+        pendingError.sessionId = sessionId;
+        rejectGeneration(pendingError);
+        return;
+      }
+
+      if (code !== 0) {
+        rejectGeneration(
+          createGenerationError(
+            `Codex exited code=${code} signal=${signal ?? "none"}${
+              stderr.trim() ? ` stderr=${stderr.trim()}` : ""
+            }`,
+            responses.join("\n\n"),
+            {
+              diagnostics: diagnostics.join("\n\n"),
+              noImage: true,
+              sessionId,
+            },
+          ),
+        );
+        return;
       }
 
       if (!sessionId) {
@@ -992,6 +998,7 @@ async function main() {
   prepareCodexImageHome();
   const releaseWorkerLock = acquireWorkerLock();
   process.once("exit", releaseWorkerLock);
+  fs.rmSync(WORKER_COMMAND_PATH, { force: true });
   log(`run=${RUN_ID} log=${RUN_LOG_PATH} events=${RUN_EVENTS_PATH}`);
   log(
     `paths reviewRoot=${REVIEW_ROOT} queueDb=${REVIEW_DB_PATH} originals=${ORIGINALS_DIR} codexHome=${CODEX_IMAGE_HOME} generated=${GENERATED_IMAGES_ROOT}`,
@@ -999,9 +1006,10 @@ async function main() {
   logProdCopyAge();
   prepareQueueDbForConcurrentWrites();
   log(`queue initial ${getQueueStatusSummary()}`);
-  const recovery = recoverMappedOutputs(args.timeoutMs);
+  const recovery = recoverMappedOutputs();
   log(`queue afterRecovery ${getQueueStatusSummary()}`);
   const activeChildren = new Map();
+  const activeTasks = new Set();
   const attemptedIds = new Set();
   const runStartedAt = Date.now();
   const durationsMs = [];
@@ -1012,13 +1020,48 @@ async function main() {
     reasoningOutputTokens: 0,
   };
   let usageSamples = 0;
-  let catchupChecked = false;
-  let stopping = false;
+  let desiredConcurrency = args.concurrency;
+  let draining = false;
+  let forceStopping = false;
   let stopSignal = null;
+  let stopReason = null;
   let completed = 0;
   let promoted = 0;
   let failed = 0;
   let interrupted = 0;
+  let catchupStarted = Boolean(args.id);
+  let catchupComplete = Boolean(args.id);
+  let backlogExhausted = false;
+  let refillChild = null;
+  let refillMode = null;
+  let refillPromise = null;
+  let fatalError = null;
+
+  const writeWorkerState = () => {
+    writeJsonAtomic(WORKER_STATE_PATH, {
+      active: activeChildren.size,
+      attempted: attemptedIds.size,
+      completed,
+      desiredConcurrency,
+      draining,
+      failed,
+      limit: args.limit,
+      pid: process.pid,
+      promoted,
+      refillMode,
+      runId: RUN_ID,
+      status: draining ? "draining" : "running",
+      updatedAt: new Date().toISOString(),
+    });
+  };
+
+  const removeWorkerState = () => {
+    try {
+      const state = JSON.parse(fs.readFileSync(WORKER_STATE_PATH, "utf8"));
+      if (state.runId === RUN_ID) fs.rmSync(WORKER_STATE_PATH, { force: true });
+    } catch {}
+  };
+  process.once("exit", removeWorkerState);
 
   const recordMetrics = (durationMs, usage) => {
     if (Number.isFinite(durationMs)) durationsMs.push(durationMs);
@@ -1035,165 +1078,281 @@ async function main() {
     const successPercent =
       completed === 0 ? "0.0" : ((promoted / completed) * 100).toFixed(1);
     log(
-      `progress completed=${completed}/${args.limit} (${completionPercent}%) success=${promoted}/${completed} (${successPercent}%) failed=${failed} active=${activeChildren.size}`,
+      `progress completed=${completed}/${args.limit} (${completionPercent}%) success=${promoted}/${completed} (${successPercent}%) failed=${failed} active=${activeChildren.size} target=${desiredConcurrency}`,
     );
+    writeWorkerState();
   };
 
-  const stop = (signal) => {
-    if (stopping) return;
-    stopping = true;
+  const requestDrain = (reason) => {
+    if (draining) return;
+    draining = true;
+    stopReason = reason;
+    log(`draining reason=${reason} active=${activeChildren.size}`);
+    if (refillChild) terminate(refillChild);
+    writeWorkerState();
+  };
+
+  const forceStop = (signal) => {
+    if (forceStopping) return;
+    forceStopping = true;
+    draining = true;
     stopSignal = signal;
-    log(`stopping signal=${signal} active=${activeChildren.size}`);
+    stopReason ??= signal;
+    log(`force stopping signal=${signal} active=${activeChildren.size}`);
+    if (refillChild) terminate(refillChild);
     for (const child of activeChildren.values()) terminate(child);
+    writeWorkerState();
   };
 
-  process.once("SIGINT", () => stop("SIGINT"));
-  process.once("SIGTERM", () => stop("SIGTERM"));
+  const handleSignal = (signal) => {
+    if (draining) {
+      forceStop(signal);
+      return;
+    }
+    requestDrain(signal);
+  };
+
+  const handleSigint = () => handleSignal("SIGINT");
+  const handleSigterm = () => handleSignal("SIGTERM");
+  process.on("SIGINT", handleSigint);
+  process.on("SIGTERM", handleSigterm);
 
   log(
-    `worker started limit=${args.limit} concurrency=${args.concurrency} model=${args.model} effort=${args.effort} timeoutMinutes=${Math.round(args.timeoutMs / 60_000)} usageIntervalMinutes=${args.usageIntervalMs / 60_000} sessionMode=isolated-image-only`,
+    `worker started limit=${args.limit} backlogRefillSize=${args.backlogRefillSize} concurrency=${args.concurrency} model=${args.model} effort=${args.effort} timeoutMinutes=${Math.round(args.timeoutMs / 60_000)} usageIntervalMinutes=${args.usageIntervalMs / 60_000} scheduler=rolling sessionMode=isolated-image-only`,
   );
+  writeWorkerState();
   const usageMonitor = createUsageMonitor(args.usageIntervalMs);
   await usageMonitor.sample("start");
   usageMonitor.start();
 
-  const runBatch = async (ids) => {
-    let nextIndex = 0;
+  const processItem = async (item) => {
+    try {
+      const result = await generate(item, args, activeChildren);
+      promoted += 1;
+      completed += 1;
+      recordMetrics(result.durationMs, result.usage);
+      log(
+        `thread finished id=${item.id} session=${result.sessionId} image=yes promoted=yes status=review durationSeconds=${(result.durationMs / 1_000).toFixed(1)} ${formatUsage(result.usage)} output=${result.imagePath}`,
+      );
+      logProgress();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
 
-    const runSlot = async () => {
-      while (!stopping) {
-        const id = ids[nextIndex];
-        nextIndex += 1;
-        if (!id) return;
-
-        const item = claimNextPendingItem(id);
-        if (!item) {
-          log(`skipped id=${id} reason=not-claimable`);
-          continue;
-        }
-
+      if (forceStopping) {
+        interrupted += 1;
+        const interruption = `Worker interrupted by ${stopSignal ?? "signal"}`;
         try {
-          const result = await generate(item, args, activeChildren);
-          promoted += 1;
-          completed += 1;
-          recordMetrics(result.durationMs, result.usage);
+          updateStatus(item.id, "pending", { lastError: interruption });
+        } catch (databaseError) {
+          const databaseMessage =
+            databaseError instanceof Error
+              ? databaseError.message
+              : String(databaseError);
           log(
-            `thread finished id=${item.id} session=${result.sessionId} image=yes promoted=yes status=review durationSeconds=${(result.durationMs / 1_000).toFixed(1)} ${formatUsage(result.usage)} output=${result.imagePath}`,
+            `status update failed id=${item.id} intendedStatus=pending error=${databaseMessage}`,
           );
-          logProgress();
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
+        }
+        log(
+          `thread interrupted id=${item.id} session=${error?.sessionId ?? "unknown"} signal=${stopSignal ?? "unknown"} status=pending`,
+        );
+        return;
+      }
 
-          if (stopping) {
-            interrupted += 1;
-            const interruption = `Worker interrupted by ${stopSignal ?? "signal"}`;
-            try {
-              updateStatus(item.id, "pending", { lastError: interruption });
-            } catch (databaseError) {
-              const databaseMessage =
-                databaseError instanceof Error
-                  ? databaseError.message
-                  : String(databaseError);
-              log(
-                `status update failed id=${item.id} intendedStatus=pending error=${databaseMessage}`,
-              );
-            }
-            log(
-              `thread interrupted id=${item.id} session=${error?.sessionId ?? "unknown"} signal=${stopSignal ?? "unknown"} status=pending`,
-            );
-            continue;
-          }
+      failed += 1;
+      completed += 1;
+      recordMetrics(error?.durationMs, error?.codexUsage);
 
-          const status = error?.recoverableImage ? "processing" : "failed";
-          failed += 1;
-          completed += 1;
-          recordMetrics(error?.durationMs, error?.codexUsage);
+      try {
+        updateStatus(item.id, "failed", { lastError: message });
+      } catch (databaseError) {
+        const databaseMessage =
+          databaseError instanceof Error
+            ? databaseError.message
+            : String(databaseError);
+        log(
+          `status update failed id=${item.id} intendedStatus=failed error=${databaseMessage}`,
+        );
+      }
 
-          try {
-            const statusOptions = { lastError: message };
-            if (error?.imageCreated) {
-              statusOptions.codexNativeAgentId = error.sessionId;
-            }
-            updateStatus(item.id, status, statusOptions);
-          } catch (databaseError) {
-            const databaseMessage =
-              databaseError instanceof Error
-                ? databaseError.message
-                : String(databaseError);
-            log(
-              `status update failed id=${item.id} intendedStatus=${status} error=${databaseMessage}`,
-            );
-          }
-
-          log(
-            `thread finished id=${item.id} session=${error?.sessionId ?? "unknown"} image=${error?.noImage ? "no" : error?.imageCreated ? "yes" : "unknown"} promoted=no status=${status} durationSeconds=${Number.isFinite(error?.durationMs) ? (error.durationMs / 1_000).toFixed(1) : "unknown"} ${formatUsage(error?.codexUsage)} error=${message}`,
-          );
-          if (error?.noImage) {
-            logLines(
-              `no-image response id=${item.id}`,
-              error.codexResponse || "(no textual response captured)",
-            );
-            if (error.codexDiagnostics) {
-              logLines(
-                `no-image diagnostic id=${item.id}`,
-                error.codexDiagnostics,
-              );
-            }
-          }
-          logProgress();
+      log(
+        `thread finished id=${item.id} session=${error?.sessionId ?? "unknown"} image=${error?.noImage ? "no" : error?.imageCreated ? "yes" : "unknown"} promoted=no status=failed durationSeconds=${Number.isFinite(error?.durationMs) ? (error.durationMs / 1_000).toFixed(1) : "unknown"} ${formatUsage(error?.codexUsage)} error=${message}`,
+      );
+      if (error?.noImage) {
+        logLines(
+          `no-image response id=${item.id}`,
+          error.codexResponse || "(no textual response captured)",
+        );
+        if (error.codexDiagnostics) {
+          logLines(`no-image diagnostic id=${item.id}`, error.codexDiagnostics);
         }
       }
-    };
-
-    await Promise.all(
-      Array.from({ length: Math.min(args.concurrency, ids.length) }, runSlot),
-    );
+      logProgress();
+    }
   };
 
-  while (!stopping && attemptedIds.size < args.limit) {
-    const remaining = args.limit - attemptedIds.size;
-    let ids = getClaimableIds({ ...args, limit: remaining }, attemptedIds);
+  const startAvailable = () => {
+    if (draining || attemptedIds.size >= args.limit) return;
 
-    if (ids.length === 0 && !args.id && !catchupChecked) {
-      catchupChecked = true;
-      try {
-        queueSourceRows("catchup");
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        log(`catchup check stopped error=${message}`);
-        process.exitCode = 1;
-        break;
+    const slots = Math.min(
+      desiredConcurrency - activeTasks.size,
+      args.limit - attemptedIds.size,
+    );
+    if (slots <= 0) return;
+
+    const ids = getClaimableIds({ ...args, limit: slots }, attemptedIds);
+    for (const id of ids) {
+      const item = claimNextPendingItem(id);
+      if (!item) {
+        log(`skipped id=${id} reason=not-claimable`);
+        continue;
       }
-      ids = getClaimableIds({ ...args, limit: remaining }, attemptedIds);
-    }
 
-    if (ids.length === 0 && !args.id && catchupChecked) {
-      let refillSelected = 0;
-      do {
-        try {
-          ({ selected: refillSelected } = queueSourceRows(
-            "backlog",
-            remaining,
-          ));
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          log(`backlog refill stopped error=${message}`);
-          process.exitCode = 1;
-          break;
+      attemptedIds.add(id);
+      let task;
+      task = processItem(item).finally(() => {
+        activeTasks.delete(task);
+        writeWorkerState();
+      });
+      activeTasks.add(task);
+    }
+    writeWorkerState();
+  };
+
+  const beginRefill = (mode, limit) => {
+    if (refillPromise || draining || limit < 1) return;
+    refillMode = mode;
+    if (mode === "catchup") catchupStarted = true;
+    writeWorkerState();
+
+    refillPromise = queueSourceRows(mode, limit, (child) => {
+      refillChild = child;
+    })
+      .then((output) => {
+        if (mode === "catchup") catchupComplete = true;
+        if (mode === "backlog" && /\bselected=0\b/.test(output)) {
+          backlogExhausted = true;
         }
-        ids = getClaimableIds({ ...args, limit: remaining }, attemptedIds);
-      } while (ids.length === 0 && refillSelected > 0);
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        if (draining) {
+          log(`queue refill interrupted mode=${mode}`);
+          return;
+        }
+
+        fatalError = error;
+        process.exitCode = 1;
+        log(`${mode} refill stopped error=${message}`);
+        requestDrain(`${mode} refill failed`);
+      })
+      .finally(() => {
+        refillChild = null;
+        refillMode = null;
+        refillPromise = null;
+        writeWorkerState();
+      });
+  };
+
+  const maybeRefill = () => {
+    if (args.id || draining || refillPromise) return;
+    const remaining = args.limit - attemptedIds.size;
+    if (remaining <= 0) return;
+
+    const pending = getClaimableIds(
+      { ...args, id: null, limit: remaining },
+      attemptedIds,
+    ).length;
+    if (!catchupStarted) {
+      beginRefill("catchup", remaining);
+      return;
+    }
+    if (!catchupComplete || backlogExhausted) return;
+
+    const lowWater = Math.min(remaining, desiredConcurrency * 2);
+    if (pending >= lowWater) return;
+    const refillSize = Math.min(
+      remaining - pending,
+      Math.max(args.backlogRefillSize, desiredConcurrency * 3),
+    );
+    beginRefill("backlog", refillSize);
+  };
+
+  const applyControlCommand = () => {
+    if (!fs.existsSync(WORKER_COMMAND_PATH)) return;
+
+    let command;
+    try {
+      command = JSON.parse(fs.readFileSync(WORKER_COMMAND_PATH, "utf8"));
+      fs.rmSync(WORKER_COMMAND_PATH, { force: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`control command ignored error=${message}`);
+      return;
     }
 
-    if (ids.length === 0) {
-      log("no claimable queue rows");
-      break;
+    if (command.runId !== RUN_ID) {
+      log(
+        `control command ignored reason=run-mismatch command=${command.runId}`,
+      );
+      return;
     }
+    if (command.command === "drain") {
+      requestDrain("control command");
+      return;
+    }
+    if (
+      command.command === "concurrency" &&
+      Number.isInteger(command.value) &&
+      command.value > 0
+    ) {
+      const previous = desiredConcurrency;
+      desiredConcurrency = command.value;
+      log(
+        `concurrency changed previous=${previous} desired=${desiredConcurrency} active=${activeChildren.size}`,
+      );
+      writeWorkerState();
+      return;
+    }
+    log(`control command ignored reason=invalid command=${command.command}`);
+  };
 
-    for (const id of ids) attemptedIds.add(id);
-    await runBatch(ids);
+  const waitForActivity = async () => {
+    const waits = [new Promise((resolve) => setTimeout(resolve, 250))];
+    waits.push(...activeTasks);
+    if (refillPromise) waits.push(refillPromise);
+    await Promise.race(waits);
+  };
+
+  while (true) {
+    applyControlCommand();
+    startAvailable();
+    maybeRefill();
+
+    if (!draining && attemptedIds.size >= args.limit) {
+      requestDrain("limit reached");
+    }
+    if (
+      !draining &&
+      args.id &&
+      attemptedIds.size === 0 &&
+      activeTasks.size === 0
+    ) {
+      requestDrain("queue item is not claimable");
+    }
+    if (
+      !draining &&
+      backlogExhausted &&
+      !refillPromise &&
+      activeTasks.size === 0 &&
+      getClaimableIds({ ...args, id: null, limit: 1 }, attemptedIds).length ===
+        0
+    ) {
+      requestDrain("source backlog exhausted");
+    }
+    if (draining && activeTasks.size === 0 && !refillPromise) break;
+    if (fatalError && activeTasks.size === 0 && !refillPromise) break;
+
+    await waitForActivity();
   }
 
   await usageMonitor.finish();
@@ -1220,11 +1379,14 @@ async function main() {
   }
   log(`queue finish ${getQueueStatusSummary()}`);
   log(
-    `worker finished attempted=${attemptedIds.size} completed=${completed} promoted=${promoted} recovered=${recovery.recovered} recoveryPreserved=${recovery.preserved} recoveryReset=${recovery.reset} failed=${failed} interrupted=${interrupted} successRate=${completed === 0 ? "0.0" : ((promoted / completed) * 100).toFixed(1)}% runLog=${RUN_LOG_PATH} eventsLog=${RUN_EVENTS_PATH}`,
+    `worker finished attempted=${attemptedIds.size} completed=${completed} promoted=${promoted} recovered=${recovery.recovered} recoveryReset=${recovery.reset} failed=${failed} interrupted=${interrupted} stopReason=${stopReason ?? "complete"} successRate=${completed === 0 ? "0.0" : ((promoted / completed) * 100).toFixed(1)}% runLog=${RUN_LOG_PATH} eventsLog=${RUN_EVENTS_PATH}`,
   );
+  process.removeListener("SIGINT", handleSigint);
+  process.removeListener("SIGTERM", handleSigterm);
+  removeWorkerState();
+  process.removeListener("exit", removeWorkerState);
   releaseWorkerLock();
   process.removeListener("exit", releaseWorkerLock);
-  if (failed > 0 && !stopping) process.exitCode = 1;
 }
 
 await main();

--- a/apps/main/scripts/image-processing/v2-ahs-image-review/server.mjs
+++ b/apps/main/scripts/image-processing/v2-ahs-image-review/server.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 import http from "node:http";
 import { fileURLToPath } from "node:url";
 import {
+  approveAllReviewItems,
   approveReviewItems,
   getCounts,
   getEditedItems,
@@ -134,18 +135,32 @@ const server = http.createServer(async (request, response) => {
   }
 
   if (request.method === "POST" && requestUrl.pathname === "/api/approve-all") {
+    const updated = approveAllReviewItems();
+    console.log(`[v2-image-review] approved all review items count=${updated}`);
+    sendJson(response, {
+      ok: true,
+      updated,
+      counts: getCounts(),
+    });
+    return;
+  }
+
+  if (
+    request.method === "POST" &&
+    requestUrl.pathname === "/api/approve-page"
+  ) {
     const body = await readJsonBody(request);
     const ids = Array.isArray(body.ids)
       ? body.ids.filter((id) => typeof id === "string")
       : [];
 
     if (ids.length === 0) {
-      sendJson(response, { error: "Missing review ids" }, 400);
+      sendJson(response, { error: "Missing review item ids" }, 400);
       return;
     }
 
     const updated = approveReviewItems(ids);
-    console.log(`[v2-image-review] approved all review items count=${updated}`);
+    console.log(`[v2-image-review] approved review page count=${updated}`);
     sendJson(response, {
       ok: true,
       updated,

--- a/apps/main/tests/codex-native-image-mapping.test.ts
+++ b/apps/main/tests/codex-native-image-mapping.test.ts
@@ -1,0 +1,204 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+const appRoot = process.cwd();
+const scriptRoot = path.join(
+  appRoot,
+  "scripts/image-processing/v2-ahs-image-review",
+);
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const temporaryRoot of temporaryRoots.splice(0)) {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+describe("Codex-native image agent mapping", () => {
+  it("refuses to promote an empty generated image", () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "codex-image-empty-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+
+    const dataRoot = path.join(temporaryRoot, "data");
+    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+    const generatedRoot = path.join(temporaryRoot, "generated");
+    const databasePath = path.join(reviewRoot, "review.sqlite");
+    const originalPath = path.join(dataRoot, "v2-ahs-images", "cr-empty.jpg");
+    const emptyOutput = path.join(generatedRoot, "agent-empty", "result.png");
+
+    fs.mkdirSync(path.dirname(originalPath), { recursive: true });
+    fs.mkdirSync(path.dirname(emptyOutput), { recursive: true });
+    fs.mkdirSync(reviewRoot, { recursive: true });
+    fs.writeFileSync(originalPath, "original");
+    fs.writeFileSync(emptyOutput, "");
+
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE "v2_image_review_queue" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "postTitle" TEXT,
+        "originalPath" TEXT NOT NULL,
+        "editedPath" TEXT,
+        "status" TEXT NOT NULL,
+        "attempts" INTEGER NOT NULL DEFAULT 0,
+        "lastError" TEXT,
+        "promptVersion" TEXT,
+        "codexNativeAgentId" TEXT,
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        `INSERT INTO "v2_image_review_queue" VALUES (?, ?, ?, NULL, 'processing', 1, NULL, NULL, ?, ?, ?)`,
+      )
+      .run(
+        "cr-empty",
+        "Empty cultivar",
+        originalPath,
+        "agent-empty",
+        "now",
+        "now",
+      );
+    database.close();
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(scriptRoot, "promote-codex-native-batch.mjs"),
+        "--pair",
+        "cr-empty=agent-empty",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
+          CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
+        },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("No non-empty generated PNG found");
+    expect(fs.existsSync(path.join(reviewRoot, "edited", "cr-empty.png"))).toBe(
+      false,
+    );
+  });
+
+  it("refuses a mismatched agent before promoting the recorded output", () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "codex-image-mapping-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+
+    const dataRoot = path.join(temporaryRoot, "data");
+    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+    const generatedRoot = path.join(temporaryRoot, "generated");
+    const databasePath = path.join(reviewRoot, "review.sqlite");
+    const originalPath = path.join(dataRoot, "v2-ahs-images", "cr-test.jpg");
+    const correctOutput = path.join(
+      generatedRoot,
+      "agent-correct",
+      "result.png",
+    );
+    const wrongOutput = path.join(generatedRoot, "agent-wrong", "result.png");
+
+    fs.mkdirSync(path.dirname(originalPath), { recursive: true });
+    fs.mkdirSync(path.dirname(correctOutput), { recursive: true });
+    fs.mkdirSync(path.dirname(wrongOutput), { recursive: true });
+    fs.mkdirSync(reviewRoot, { recursive: true });
+    fs.writeFileSync(originalPath, "original");
+    fs.writeFileSync(correctOutput, "correct-output");
+    fs.writeFileSync(wrongOutput, "wrong-output");
+
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE "v2_image_review_queue" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "postTitle" TEXT,
+        "originalPath" TEXT NOT NULL,
+        "editedPath" TEXT,
+        "status" TEXT NOT NULL,
+        "attempts" INTEGER NOT NULL DEFAULT 0,
+        "lastError" TEXT,
+        "promptVersion" TEXT,
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        `INSERT INTO "v2_image_review_queue" VALUES (?, ?, ?, NULL, 'pending', 0, NULL, NULL, ?, ?)`,
+      )
+      .run("cr-test", "Test cultivar", originalPath, "now", "now");
+    database.close();
+
+    const env = {
+      ...process.env,
+      V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
+      CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
+    };
+
+    execFileSync(
+      process.execPath,
+      [
+        path.join(scriptRoot, "assign-codex-native-agent.mjs"),
+        "--pair",
+        "cr-test=agent-correct",
+      ],
+      { env },
+    );
+
+    const mismatch = spawnSync(
+      process.execPath,
+      [
+        path.join(scriptRoot, "promote-codex-native-batch.mjs"),
+        "--pair",
+        "cr-test=agent-wrong",
+      ],
+      { env, encoding: "utf8" },
+    );
+
+    expect(mismatch.status).toBe(1);
+    expect(mismatch.stdout).toContain("agent-mismatch");
+    expect(fs.existsSync(path.join(reviewRoot, "edited", "cr-test.png"))).toBe(
+      false,
+    );
+
+    execFileSync(
+      process.execPath,
+      [
+        path.join(scriptRoot, "promote-codex-native-batch.mjs"),
+        "--pair",
+        "cr-test=agent-correct",
+      ],
+      { env },
+    );
+
+    expect(
+      fs.readFileSync(path.join(reviewRoot, "edited", "cr-test.png"), "utf8"),
+    ).toBe("correct-output");
+
+    const verifiedDatabase = new DatabaseSync(databasePath, {
+      readOnly: true,
+    });
+    const row = verifiedDatabase
+      .prepare(
+        `SELECT "status", "codexNativeAgentId" FROM "v2_image_review_queue" WHERE "id" = ?`,
+      )
+      .get("cr-test");
+    verifiedDatabase.close();
+
+    expect(row).toEqual({
+      status: "review",
+      codexNativeAgentId: "agent-correct",
+    });
+  });
+});

--- a/apps/main/tests/codex-native-worker.test.ts
+++ b/apps/main/tests/codex-native-worker.test.ts
@@ -14,8 +14,8 @@ const temporaryRoots: string[] = [];
 
 function createWorkerEnv(
   temporaryRoot: string,
-  overrides: NodeJS.ProcessEnv = {},
-) {
+  overrides: Partial<NodeJS.ProcessEnv> = {},
+): NodeJS.ProcessEnv {
   const authPath = path.join(temporaryRoot, "codex-auth.json");
   fs.writeFileSync(authPath, "{}");
 
@@ -23,7 +23,7 @@ function createWorkerEnv(
     ...process.env,
     CODEX_AUTH_PATH: authPath,
     ...overrides,
-  };
+  } as NodeJS.ProcessEnv;
 }
 
 afterEach(() => {

--- a/apps/main/tests/codex-native-worker.test.ts
+++ b/apps/main/tests/codex-native-worker.test.ts
@@ -1,9 +1,12 @@
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  createQueueDatabase,
+  createWorkerFixture,
+} from "./helpers/codex-native-worker-fixture";
 
 const appRoot = process.cwd();
 const scriptRoot = path.join(
@@ -34,14 +37,10 @@ afterEach(() => {
 
 describe("Codex-native image worker", () => {
   it("refuses to recover queue rows while another worker is running", () => {
-    const temporaryRoot = fs.mkdtempSync(
-      path.join(os.tmpdir(), "codex-native-worker-lock-"),
+    const { dataRoot, reviewRoot, temporaryRoot } = createWorkerFixture(
+      "codex-native-worker-lock-",
     );
     temporaryRoots.push(temporaryRoot);
-
-    const dataRoot = path.join(temporaryRoot, "data");
-    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
-    fs.mkdirSync(reviewRoot, { recursive: true });
     fs.writeFileSync(
       path.join(reviewRoot, "codex-native-worker.lock"),
       JSON.stringify({
@@ -73,21 +72,17 @@ describe("Codex-native image worker", () => {
   });
 
   it("keeps concurrent queue rows mapped and promotes without lock failures", () => {
-    const temporaryRoot = fs.mkdtempSync(
-      path.join(os.tmpdir(), "codex-native-worker-"),
-    );
+    const {
+      dataRoot,
+      databasePath,
+      fakeCodexPath,
+      generatedRoot,
+      originalsRoot,
+      reviewRoot,
+      temporaryRoot,
+    } = createWorkerFixture("codex-native-worker-");
     temporaryRoots.push(temporaryRoot);
-
-    const dataRoot = path.join(temporaryRoot, "data");
-    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
-    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
-    const generatedRoot = path.join(temporaryRoot, "generated");
-    const databasePath = path.join(reviewRoot, "review.sqlite");
-    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
     const relativeDataRoot = path.relative(appRoot, dataRoot);
-
-    fs.mkdirSync(reviewRoot, { recursive: true });
-    fs.mkdirSync(originalsRoot, { recursive: true });
     const ids = Array.from({ length: 9 }, (_, index) => `item-${index + 1}`);
     for (const id of ids) {
       fs.writeFileSync(path.join(originalsRoot, `${id}.jpg`), `${id}-source`);
@@ -160,22 +155,7 @@ console.log(JSON.stringify({
     );
     fs.chmodSync(fakeCodexPath, 0o755);
 
-    const database = new DatabaseSync(databasePath);
-    database.exec(`
-      CREATE TABLE "v2_image_review_queue" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "postTitle" TEXT,
-        "originalPath" TEXT NOT NULL,
-        "editedPath" TEXT,
-        "status" TEXT NOT NULL,
-        "attempts" INTEGER NOT NULL DEFAULT 0,
-        "lastError" TEXT,
-        "promptVersion" TEXT,
-        "codexNativeAgentId" TEXT,
-        "createdAt" TEXT NOT NULL,
-        "updatedAt" TEXT NOT NULL
-      );
-    `);
+    const database = createQueueDatabase(databasePath);
     const insert = database.prepare(`
       INSERT INTO "v2_image_review_queue" (
         "id", "postTitle", "originalPath", "status", "codexNativeAgentId",
@@ -314,21 +294,17 @@ console.log(JSON.stringify({
   });
 
   it("reports total account usage from startup through completion", () => {
-    const temporaryRoot = fs.mkdtempSync(
-      path.join(os.tmpdir(), "codex-native-worker-usage-"),
-    );
+    const {
+      dataRoot,
+      databasePath,
+      fakeCodexPath,
+      generatedRoot,
+      originalsRoot,
+      reviewRoot,
+      temporaryRoot,
+    } = createWorkerFixture("codex-native-worker-usage-");
     temporaryRoots.push(temporaryRoot);
-
-    const dataRoot = path.join(temporaryRoot, "data");
-    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
-    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
-    const generatedRoot = path.join(temporaryRoot, "generated");
-    const databasePath = path.join(reviewRoot, "review.sqlite");
-    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
     const usageCounterPath = path.join(temporaryRoot, "usage-counter");
-
-    fs.mkdirSync(reviewRoot, { recursive: true });
-    fs.mkdirSync(originalsRoot, { recursive: true });
     fs.writeFileSync(path.join(originalsRoot, "usage.jpg"), "source");
     fs.writeFileSync(
       fakeCodexPath,
@@ -393,22 +369,7 @@ if (process.argv.includes("app-server")) {
     );
     fs.chmodSync(fakeCodexPath, 0o755);
 
-    const database = new DatabaseSync(databasePath);
-    database.exec(`
-      CREATE TABLE "v2_image_review_queue" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "postTitle" TEXT,
-        "originalPath" TEXT NOT NULL,
-        "editedPath" TEXT,
-        "status" TEXT NOT NULL,
-        "attempts" INTEGER NOT NULL DEFAULT 0,
-        "lastError" TEXT,
-        "promptVersion" TEXT,
-        "codexNativeAgentId" TEXT,
-        "createdAt" TEXT NOT NULL,
-        "updatedAt" TEXT NOT NULL
-      );
-    `);
+    const database = createQueueDatabase(databasePath);
     database
       .prepare(
         `
@@ -465,22 +426,18 @@ if (process.argv.includes("app-server")) {
   });
 
   it("prefetches catchup and backlog work while the queue stays active", () => {
-    const temporaryRoot = fs.mkdtempSync(
-      path.join(os.tmpdir(), "codex-native-backlog-worker-"),
-    );
+    const {
+      dataRoot,
+      databasePath,
+      fakeBacklogPath,
+      fakeCodexPath,
+      generatedRoot,
+      originalsRoot,
+      reviewRoot,
+      temporaryRoot,
+    } = createWorkerFixture("codex-native-backlog-worker-");
     temporaryRoots.push(temporaryRoot);
-
-    const dataRoot = path.join(temporaryRoot, "data");
-    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
-    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
-    const generatedRoot = path.join(temporaryRoot, "generated");
-    const databasePath = path.join(reviewRoot, "review.sqlite");
     const prodDatabasePath = path.join(temporaryRoot, "prod.sqlite");
-    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
-    const fakeBacklogPath = path.join(temporaryRoot, "fake-backlog.mjs");
-
-    fs.mkdirSync(reviewRoot, { recursive: true });
-    fs.mkdirSync(originalsRoot, { recursive: true });
     fs.writeFileSync(path.join(originalsRoot, "linked.jpg"), "linked-source");
     fs.writeFileSync(path.join(originalsRoot, "failed.jpg"), "failed-source");
     fs.writeFileSync(path.join(originalsRoot, "catchup.jpg"), "catchup-source");
@@ -550,22 +507,7 @@ database.close();
     );
     fs.chmodSync(fakeBacklogPath, 0o755);
 
-    const database = new DatabaseSync(databasePath);
-    database.exec(`
-      CREATE TABLE "v2_image_review_queue" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "postTitle" TEXT,
-        "originalPath" TEXT NOT NULL,
-        "editedPath" TEXT,
-        "status" TEXT NOT NULL,
-        "attempts" INTEGER NOT NULL DEFAULT 0,
-        "lastError" TEXT,
-        "promptVersion" TEXT,
-        "codexNativeAgentId" TEXT,
-        "createdAt" TEXT NOT NULL,
-        "updatedAt" TEXT NOT NULL
-      );
-    `);
+    const database = createQueueDatabase(databasePath);
     database
       .prepare(
         `
@@ -661,19 +603,15 @@ database.close();
   });
 
   it("summarizes a no-image failure without failing the batch", () => {
-    const temporaryRoot = fs.mkdtempSync(
-      path.join(os.tmpdir(), "codex-native-no-image-"),
-    );
+    const {
+      dataRoot,
+      databasePath,
+      fakeCodexPath,
+      originalsRoot,
+      reviewRoot,
+      temporaryRoot,
+    } = createWorkerFixture("codex-native-no-image-");
     temporaryRoots.push(temporaryRoot);
-
-    const dataRoot = path.join(temporaryRoot, "data");
-    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
-    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
-    const databasePath = path.join(reviewRoot, "review.sqlite");
-    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
-
-    fs.mkdirSync(reviewRoot, { recursive: true });
-    fs.mkdirSync(originalsRoot, { recursive: true });
     fs.writeFileSync(path.join(originalsRoot, "no-image.jpg"), "source");
     fs.writeFileSync(
       fakeCodexPath,
@@ -687,21 +625,8 @@ console.log(JSON.stringify({
     );
     fs.chmodSync(fakeCodexPath, 0o755);
 
-    const database = new DatabaseSync(databasePath);
+    const database = createQueueDatabase(databasePath);
     database.exec(`
-      CREATE TABLE "v2_image_review_queue" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "postTitle" TEXT,
-        "originalPath" TEXT NOT NULL,
-        "editedPath" TEXT,
-        "status" TEXT NOT NULL,
-        "attempts" INTEGER NOT NULL DEFAULT 0,
-        "lastError" TEXT,
-        "promptVersion" TEXT,
-        "codexNativeAgentId" TEXT,
-        "createdAt" TEXT NOT NULL,
-        "updatedAt" TEXT NOT NULL
-      );
       INSERT INTO "v2_image_review_queue" (
         "id", "postTitle", "originalPath", "status", "createdAt", "updatedAt"
       ) VALUES (
@@ -769,22 +694,18 @@ console.log(JSON.stringify({
   });
 
   it("changes concurrency live and drains without interrupting active work", async () => {
-    const temporaryRoot = fs.mkdtempSync(
-      path.join(os.tmpdir(), "codex-native-control-"),
-    );
+    const {
+      dataRoot,
+      databasePath,
+      fakeBacklogPath,
+      fakeCodexPath,
+      generatedRoot,
+      originalsRoot,
+      reviewRoot,
+      temporaryRoot,
+    } = createWorkerFixture("codex-native-control-");
     temporaryRoots.push(temporaryRoot);
-
-    const dataRoot = path.join(temporaryRoot, "data");
-    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
-    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
-    const generatedRoot = path.join(temporaryRoot, "generated");
-    const databasePath = path.join(reviewRoot, "review.sqlite");
-    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
-    const fakeBacklogPath = path.join(temporaryRoot, "fake-backlog.mjs");
     const statePath = path.join(reviewRoot, "codex-native-worker-state.json");
-
-    fs.mkdirSync(reviewRoot, { recursive: true });
-    fs.mkdirSync(originalsRoot, { recursive: true });
     for (let index = 1; index <= 8; index += 1) {
       fs.writeFileSync(
         path.join(originalsRoot, `control-${index}.jpg`),
@@ -817,22 +738,7 @@ console.log(\`[v2-image-queue] mode=\${mode} selected=0\`);
     );
     fs.chmodSync(fakeBacklogPath, 0o755);
 
-    const database = new DatabaseSync(databasePath);
-    database.exec(`
-      CREATE TABLE "v2_image_review_queue" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "postTitle" TEXT,
-        "originalPath" TEXT NOT NULL,
-        "editedPath" TEXT,
-        "status" TEXT NOT NULL,
-        "attempts" INTEGER NOT NULL DEFAULT 0,
-        "lastError" TEXT,
-        "promptVersion" TEXT,
-        "codexNativeAgentId" TEXT,
-        "createdAt" TEXT NOT NULL,
-        "updatedAt" TEXT NOT NULL
-      );
-    `);
+    const database = createQueueDatabase(databasePath);
     const insert = database.prepare(`
       INSERT INTO "v2_image_review_queue" (
         "id", "postTitle", "originalPath", "status", "createdAt", "updatedAt"
@@ -945,19 +851,15 @@ console.log(\`[v2-image-queue] mode=\${mode} selected=0\`);
   });
 
   it("returns an interrupted thread to pending without counting a failure", async () => {
-    const temporaryRoot = fs.mkdtempSync(
-      path.join(os.tmpdir(), "codex-native-interrupted-"),
-    );
+    const {
+      dataRoot,
+      databasePath,
+      fakeCodexPath,
+      originalsRoot,
+      reviewRoot,
+      temporaryRoot,
+    } = createWorkerFixture("codex-native-interrupted-");
     temporaryRoots.push(temporaryRoot);
-
-    const dataRoot = path.join(temporaryRoot, "data");
-    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
-    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
-    const databasePath = path.join(reviewRoot, "review.sqlite");
-    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
-
-    fs.mkdirSync(reviewRoot, { recursive: true });
-    fs.mkdirSync(originalsRoot, { recursive: true });
     fs.writeFileSync(path.join(originalsRoot, "interrupted.jpg"), "source");
     fs.writeFileSync(
       fakeCodexPath,
@@ -968,22 +870,7 @@ setInterval(() => {}, 1_000);
     );
     fs.chmodSync(fakeCodexPath, 0o755);
 
-    const database = new DatabaseSync(databasePath);
-    database.exec(`
-      CREATE TABLE "v2_image_review_queue" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "postTitle" TEXT,
-        "originalPath" TEXT NOT NULL,
-        "editedPath" TEXT,
-        "status" TEXT NOT NULL,
-        "attempts" INTEGER NOT NULL DEFAULT 0,
-        "lastError" TEXT,
-        "promptVersion" TEXT,
-        "codexNativeAgentId" TEXT,
-        "createdAt" TEXT NOT NULL,
-        "updatedAt" TEXT NOT NULL
-      );
-    `);
+    const database = createQueueDatabase(databasePath);
     database
       .prepare(
         `

--- a/apps/main/tests/codex-native-worker.test.ts
+++ b/apps/main/tests/codex-native-worker.test.ts
@@ -203,6 +203,23 @@ console.log(JSON.stringify({
         "2026-01-04",
         "2026-01-04",
       );
+    const freshTimestamp = new Date().toISOString();
+    database
+      .prepare(
+        `
+          INSERT INTO "v2_image_review_queue" (
+            "id", "postTitle", "originalPath", "status", "codexNativeAgentId",
+            "createdAt", "updatedAt"
+          ) VALUES (?, ?, ?, 'processing', 'session-fresh', ?, ?)
+        `,
+      )
+      .run(
+        "fresh-processing",
+        "Fresh Processing",
+        path.join(originalsRoot, "item-1.jpg"),
+        freshTimestamp,
+        freshTimestamp,
+      );
     database.close();
 
     execFileSync(
@@ -249,7 +266,12 @@ console.log(JSON.stringify({
       .all();
     verifiedDatabase.close();
 
-    expect(rows).toHaveLength(11);
+    expect(rows).toHaveLength(12);
+    expect(rows).toContainEqual({
+      id: "fresh-processing",
+      status: "processing",
+      codexNativeAgentId: "session-fresh",
+    });
     expect(rows).toContainEqual({
       id: "recovered",
       status: "review",
@@ -283,9 +305,11 @@ console.log(JSON.stringify({
     expect(runLog).toContain(
       "usageSamples=10 tokensInput=1000 tokensCached=800 tokensOutput=100 tokensReasoning=50",
     );
-    expect(runLog).toContain("queue initial pending=9 processing=2");
-    expect(runLog).toContain("queue afterRecovery pending=10 review=1");
-    expect(runLog).toContain("queue finish review=11");
+    expect(runLog).toContain("queue initial pending=9 processing=3");
+    expect(runLog).toContain(
+      "queue afterRecovery pending=10 processing=1 review=1",
+    );
+    expect(runLog).toContain("queue finish processing=1 review=11");
     expect(runLog).toContain(`paths reviewRoot=${reviewRoot}`);
     expect(runLog).toContain(
       `codexHome=${path.join(reviewRoot, "codex-image-home")}`,

--- a/apps/main/tests/codex-native-worker.test.ts
+++ b/apps/main/tests/codex-native-worker.test.ts
@@ -12,6 +12,20 @@ const scriptRoot = path.join(
 );
 const temporaryRoots: string[] = [];
 
+function createWorkerEnv(
+  temporaryRoot: string,
+  overrides: NodeJS.ProcessEnv = {},
+) {
+  const authPath = path.join(temporaryRoot, "codex-auth.json");
+  fs.writeFileSync(authPath, "{}");
+
+  return {
+    ...process.env,
+    CODEX_AUTH_PATH: authPath,
+    ...overrides,
+  };
+}
+
 afterEach(() => {
   for (const temporaryRoot of temporaryRoots.splice(0)) {
     fs.rmSync(temporaryRoot, { recursive: true, force: true });
@@ -42,11 +56,10 @@ describe("Codex-native image worker", () => {
       [path.join(scriptRoot, "run-codex-native-worker.mjs"), "--limit", "1"],
       {
         encoding: "utf8",
-        env: {
-          ...process.env,
+        env: createWorkerEnv(temporaryRoot, {
           CODEX_USAGE_CHECK_DISABLED: "1",
           V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
-        },
+        }),
       },
     );
 
@@ -224,13 +237,12 @@ console.log(JSON.stringify({
         "1",
       ],
       {
-        env: {
-          ...process.env,
+        env: createWorkerEnv(temporaryRoot, {
           CODEX_BIN: fakeCodexPath,
           CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
           CODEX_USAGE_CHECK_DISABLED: "1",
           V2_AHS_IMAGE_REVIEW_DATA_ROOT: relativeDataRoot,
-        },
+        }),
       },
     );
 
@@ -424,12 +436,11 @@ if (process.argv.includes("app-server")) {
         "1",
       ],
       {
-        env: {
-          ...process.env,
+        env: createWorkerEnv(temporaryRoot, {
           CODEX_BIN: fakeCodexPath,
           CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
           V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
-        },
+        }),
       },
     );
 
@@ -608,15 +619,14 @@ database.close();
         "1",
       ],
       {
-        env: {
-          ...process.env,
+        env: createWorkerEnv(temporaryRoot, {
           CODEX_BACKLOG_SCRIPT: fakeBacklogPath,
           CODEX_BIN: fakeCodexPath,
           CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
           CODEX_USAGE_CHECK_DISABLED: "1",
           V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
           V2_AHS_PROD_COPY_DB_PATH: prodDatabasePath,
-        },
+        }),
       },
     );
 
@@ -712,12 +722,11 @@ console.log(JSON.stringify({
       ],
       {
         encoding: "utf8",
-        env: {
-          ...process.env,
+        env: createWorkerEnv(temporaryRoot, {
           CODEX_BIN: fakeCodexPath,
           CODEX_USAGE_CHECK_DISABLED: "1",
           V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
-        },
+        }),
       },
     );
 
@@ -840,14 +849,13 @@ console.log(\`[v2-image-queue] mode=\${mode} selected=0\`);
     }
     database.close();
 
-    const env = {
-      ...process.env,
+    const env = createWorkerEnv(temporaryRoot, {
       CODEX_BACKLOG_SCRIPT: fakeBacklogPath,
       CODEX_BIN: fakeCodexPath,
       CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
       CODEX_USAGE_CHECK_DISABLED: "1",
       V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
-    };
+    });
     const worker = spawn(
       process.execPath,
       [
@@ -1003,12 +1011,11 @@ setInterval(() => {}, 1_000);
         "1",
       ],
       {
-        env: {
-          ...process.env,
+        env: createWorkerEnv(temporaryRoot, {
           CODEX_BIN: fakeCodexPath,
           CODEX_USAGE_CHECK_DISABLED: "1",
           V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
-        },
+        }),
         stdio: ["ignore", "pipe", "pipe"],
       },
     );

--- a/apps/main/tests/codex-native-worker.test.ts
+++ b/apps/main/tests/codex-native-worker.test.ts
@@ -1,0 +1,1072 @@
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+const appRoot = process.cwd();
+const scriptRoot = path.join(
+  appRoot,
+  "scripts/image-processing/v2-ahs-image-review",
+);
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const temporaryRoot of temporaryRoots.splice(0)) {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+describe("Codex-native image worker", () => {
+  it("refuses to recover queue rows while another worker is running", () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "codex-native-worker-lock-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+
+    const dataRoot = path.join(temporaryRoot, "data");
+    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+    fs.mkdirSync(reviewRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(reviewRoot, "codex-native-worker.lock"),
+      JSON.stringify({
+        pid: process.pid,
+        runId: "active-test-worker",
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [path.join(scriptRoot, "run-codex-native-worker.mjs"), "--limit", "1"],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_USAGE_CHECK_DISABLED: "1",
+          V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
+        },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      `Another image worker is already running pid=${process.pid} run=active-test-worker`,
+    );
+    expect(
+      fs.existsSync(path.join(reviewRoot, "codex-native-worker.lock")),
+    ).toBe(true);
+  });
+
+  it("keeps concurrent queue rows mapped and promotes without lock failures", () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "codex-native-worker-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+
+    const dataRoot = path.join(temporaryRoot, "data");
+    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
+    const generatedRoot = path.join(temporaryRoot, "generated");
+    const databasePath = path.join(reviewRoot, "review.sqlite");
+    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
+    const relativeDataRoot = path.relative(appRoot, dataRoot);
+
+    fs.mkdirSync(reviewRoot, { recursive: true });
+    fs.mkdirSync(originalsRoot, { recursive: true });
+    const ids = Array.from({ length: 9 }, (_, index) => `item-${index + 1}`);
+    for (const id of ids) {
+      fs.writeFileSync(path.join(originalsRoot, `${id}.jpg`), `${id}-source`);
+    }
+    fs.writeFileSync(
+      path.join(originalsRoot, "stranded.jpg"),
+      "stranded-source",
+    );
+    fs.mkdirSync(path.join(generatedRoot, "session-recovered"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(generatedRoot, "session-recovered", "result.png"),
+      "recovered-output",
+    );
+    fs.writeFileSync(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const imageIndex = process.argv.indexOf("-i");
+const sourcePath = process.argv[imageIndex + 1];
+const id = path.parse(sourcePath).name;
+const sessionId = \`session-\${id}\`;
+const disabledFeatures = process.argv.flatMap((arg, index, args) =>
+  arg === "--disable" ? [args[index + 1]] : [],
+);
+for (const requiredArg of ["--ignore-user-config", "--ignore-rules"]) {
+  if (!process.argv.includes(requiredArg)) {
+    throw new Error(\`Missing clean-session argument: \${requiredArg}\`);
+  }
+}
+for (const config of [
+  "skills.bundled.enabled=false",
+  "skills.include_instructions=false",
+]) {
+  if (!process.argv.includes(config)) {
+    throw new Error(\`Missing clean-session config: \${config}\`);
+  }
+}
+for (const feature of ["apps", "chronicle", "memories", "plugins"]) {
+  if (!disabledFeatures.includes(feature)) {
+    throw new Error(\`Feature was not disabled: \${feature}\`);
+  }
+}
+const imageGenerationIndex = process.argv.indexOf("--enable");
+if (process.argv[imageGenerationIndex + 1] !== "image_generation") {
+  throw new Error("Image generation was not explicitly enabled");
+}
+const dataRoot = path.resolve(process.env.V2_AHS_IMAGE_REVIEW_DATA_ROOT);
+if (!process.env.CODEX_HOME?.startsWith(dataRoot)) {
+  throw new Error("Codex home is not inside the shared image-processing root");
+}
+console.log(JSON.stringify({ type: "thread.started", thread_id: sessionId }));
+await new Promise((resolve) => setTimeout(resolve, 20));
+const outputDir = path.join(process.env.CODEX_GENERATED_IMAGES_ROOT, sessionId);
+fs.mkdirSync(outputDir, { recursive: true });
+fs.writeFileSync(path.join(outputDir, "result.png"), \`\${id}-output\`);
+console.log(JSON.stringify({
+  type: "turn.completed",
+  usage: {
+    input_tokens: 100,
+    cached_input_tokens: 80,
+    output_tokens: 10,
+    reasoning_output_tokens: 5,
+  },
+}));
+`,
+    );
+    fs.chmodSync(fakeCodexPath, 0o755);
+
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE "v2_image_review_queue" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "postTitle" TEXT,
+        "originalPath" TEXT NOT NULL,
+        "editedPath" TEXT,
+        "status" TEXT NOT NULL,
+        "attempts" INTEGER NOT NULL DEFAULT 0,
+        "lastError" TEXT,
+        "promptVersion" TEXT,
+        "codexNativeAgentId" TEXT,
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL
+      );
+    `);
+    const insert = database.prepare(`
+      INSERT INTO "v2_image_review_queue" (
+        "id", "postTitle", "originalPath", "status", "codexNativeAgentId",
+        "createdAt", "updatedAt"
+      ) VALUES (?, ?, ?, 'pending', NULL, ?, ?)
+    `);
+    for (const [index, id] of ids.entries()) {
+      insert.run(
+        id,
+        id,
+        path.join(originalsRoot, `${id}.jpg`),
+        `2026-01-${String(index + 1).padStart(2, "0")}`,
+        `2026-01-${String(index + 1).padStart(2, "0")}`,
+      );
+    }
+    database
+      .prepare(
+        `
+          INSERT INTO "v2_image_review_queue" (
+            "id", "postTitle", "originalPath", "status", "codexNativeAgentId",
+            "createdAt", "updatedAt"
+          ) VALUES (?, ?, ?, 'processing', 'session-recovered', ?, ?)
+        `,
+      )
+      .run(
+        "recovered",
+        "Recovered",
+        path.join(originalsRoot, "item-1.jpg"),
+        "2026-01-03",
+        "2026-01-03",
+      );
+    database
+      .prepare(
+        `
+          INSERT INTO "v2_image_review_queue" (
+            "id", "postTitle", "originalPath", "status", "codexNativeAgentId",
+            "createdAt", "updatedAt"
+          ) VALUES (?, ?, ?, 'processing', NULL, ?, ?)
+        `,
+      )
+      .run(
+        "stranded",
+        "Stranded",
+        path.join(originalsRoot, "stranded.jpg"),
+        "2026-01-04",
+        "2026-01-04",
+      );
+    database.close();
+
+    execFileSync(
+      process.execPath,
+      [
+        path.join(scriptRoot, "run-codex-native-worker.mjs"),
+        "--limit",
+        "10",
+        "--concurrency",
+        "10",
+        "--timeout-minutes",
+        "1",
+      ],
+      {
+        env: {
+          ...process.env,
+          CODEX_BIN: fakeCodexPath,
+          CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
+          CODEX_USAGE_CHECK_DISABLED: "1",
+          V2_AHS_IMAGE_REVIEW_DATA_ROOT: relativeDataRoot,
+        },
+      },
+    );
+
+    for (const id of ids) {
+      expect(
+        fs.readFileSync(path.join(reviewRoot, "edited", `${id}.png`), "utf8"),
+      ).toBe(`${id}-output`);
+    }
+    expect(
+      fs.readFileSync(path.join(reviewRoot, "edited", "recovered.png"), "utf8"),
+    ).toBe("recovered-output");
+
+    const verifiedDatabase = new DatabaseSync(databasePath, {
+      readOnly: true,
+    });
+    const rows = verifiedDatabase
+      .prepare(
+        `
+          SELECT "id", "status", "codexNativeAgentId"
+          FROM "v2_image_review_queue"
+          ORDER BY "id"
+        `,
+      )
+      .all();
+    verifiedDatabase.close();
+
+    expect(rows).toHaveLength(11);
+    expect(rows).toContainEqual({
+      id: "recovered",
+      status: "review",
+      codexNativeAgentId: "session-recovered",
+    });
+    expect(rows).toContainEqual({
+      id: "stranded",
+      status: "review",
+      codexNativeAgentId: "session-stranded",
+    });
+    for (const id of ids) {
+      expect(rows).toContainEqual({
+        id,
+        status: "review",
+        codexNativeAgentId: `session-${id}`,
+      });
+    }
+
+    const runFiles = fs.readdirSync(path.join(reviewRoot, "codex-native-runs"));
+    const runLog = fs.readFileSync(
+      path.join(
+        reviewRoot,
+        "codex-native-runs",
+        runFiles.find((file) => file.endsWith(".log"))!,
+      ),
+      "utf8",
+    );
+    expect(runLog).toContain("success=10/10 (100.0%)");
+    expect(runLog).toContain("worker finished attempted=10 completed=10");
+    expect(runLog).toContain("promoted=yes status=review");
+    expect(runLog).toContain(
+      "usageSamples=10 tokensInput=1000 tokensCached=800 tokensOutput=100 tokensReasoning=50",
+    );
+    expect(runLog).toContain("queue initial pending=9 processing=2");
+    expect(runLog).toContain("queue afterRecovery pending=10 review=1");
+    expect(runLog).toContain("queue finish review=11");
+    expect(runLog).toContain(`paths reviewRoot=${reviewRoot}`);
+    expect(runLog).toContain(
+      `codexHome=${path.join(reviewRoot, "codex-image-home")}`,
+    );
+    expect(runFiles.some((file) => file.endsWith(".events.jsonl"))).toBe(true);
+  });
+
+  it("reports total account usage from startup through completion", () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "codex-native-worker-usage-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+
+    const dataRoot = path.join(temporaryRoot, "data");
+    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
+    const generatedRoot = path.join(temporaryRoot, "generated");
+    const databasePath = path.join(reviewRoot, "review.sqlite");
+    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
+    const usageCounterPath = path.join(temporaryRoot, "usage-counter");
+
+    fs.mkdirSync(reviewRoot, { recursive: true });
+    fs.mkdirSync(originalsRoot, { recursive: true });
+    fs.writeFileSync(path.join(originalsRoot, "usage.jpg"), "source");
+    fs.writeFileSync(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+
+if (process.argv.includes("app-server")) {
+  const counterPath = ${JSON.stringify(usageCounterPath)};
+  const sampleIndex = fs.existsSync(counterPath)
+    ? Number(fs.readFileSync(counterPath, "utf8"))
+    : 0;
+  fs.writeFileSync(counterPath, String(sampleIndex + 1));
+  const usedPercent = sampleIndex === 0 ? 10 : 13;
+  const lifetimeTokens = sampleIndex === 0 ? 1_000 : 1_300;
+  const input = readline.createInterface({ input: process.stdin });
+  input.on("line", (line) => {
+    const request = JSON.parse(line);
+    if (request.id === 1) {
+      console.log(JSON.stringify({ id: 1, result: {} }));
+    } else if (request.id === 2) {
+      console.log(JSON.stringify({
+        id: 2,
+        result: {
+          rateLimits: {
+            primary: {
+              usedPercent,
+              windowDurationMins: 10_080,
+              resetsAt: 1_800_000_000,
+            },
+          },
+          rateLimitResetCredits: { availableCount: 3 },
+        },
+      }));
+    } else if (request.id === 3) {
+      console.log(JSON.stringify({
+        id: 3,
+        result: { summary: { lifetimeTokens } },
+      }));
+    }
+  });
+} else {
+  const imageIndex = process.argv.indexOf("-i");
+  const id = path.parse(process.argv[imageIndex + 1]).name;
+  const sessionId = \`session-\${id}\`;
+  console.log(JSON.stringify({ type: "thread.started", thread_id: sessionId }));
+  const outputDir = path.join(process.env.CODEX_GENERATED_IMAGES_ROOT, sessionId);
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, "result.png"), "output");
+  console.log(JSON.stringify({
+    type: "turn.completed",
+    usage: {
+      input_tokens: 100,
+      cached_input_tokens: 80,
+      output_tokens: 10,
+      reasoning_output_tokens: 5,
+    },
+  }));
+}
+`,
+    );
+    fs.chmodSync(fakeCodexPath, 0o755);
+
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE "v2_image_review_queue" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "postTitle" TEXT,
+        "originalPath" TEXT NOT NULL,
+        "editedPath" TEXT,
+        "status" TEXT NOT NULL,
+        "attempts" INTEGER NOT NULL DEFAULT 0,
+        "lastError" TEXT,
+        "promptVersion" TEXT,
+        "codexNativeAgentId" TEXT,
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        `
+          INSERT INTO "v2_image_review_queue" (
+            "id", "postTitle", "originalPath", "status", "createdAt", "updatedAt"
+          ) VALUES (?, ?, ?, 'pending', ?, ?)
+        `,
+      )
+      .run(
+        "usage",
+        "Usage",
+        path.join(originalsRoot, "usage.jpg"),
+        "2026-01-01",
+        "2026-01-01",
+      );
+    database.close();
+
+    execFileSync(
+      process.execPath,
+      [
+        path.join(scriptRoot, "run-codex-native-worker.mjs"),
+        "--id",
+        "usage",
+        "--timeout-minutes",
+        "1",
+      ],
+      {
+        env: {
+          ...process.env,
+          CODEX_BIN: fakeCodexPath,
+          CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
+          V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
+        },
+      },
+    );
+
+    const runDirectory = path.join(reviewRoot, "codex-native-runs");
+    const runLog = fs.readFileSync(
+      path.join(
+        runDirectory,
+        fs.readdirSync(runDirectory).find((file) => file.endsWith(".log"))!,
+      ),
+      "utf8",
+    );
+    expect(runLog).toContain(
+      "codex usage label=start usedPercent=10 remainingPercent=90",
+    );
+    expect(runLog).toContain(
+      "codex usage label=finish usedPercent=13 remainingPercent=87",
+    );
+    expect(runLog).toContain(
+      "codex usage run baselineLabel=start baselineUsedPercent=10 finishUsedPercent=13 accountWideDeltaUsedPercent=3",
+    );
+    expect(runLog).toContain("accountWideDeltaTokens=300");
+  });
+
+  it("prefetches catchup and backlog work while the queue stays active", () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "codex-native-backlog-worker-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+
+    const dataRoot = path.join(temporaryRoot, "data");
+    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
+    const generatedRoot = path.join(temporaryRoot, "generated");
+    const databasePath = path.join(reviewRoot, "review.sqlite");
+    const prodDatabasePath = path.join(temporaryRoot, "prod.sqlite");
+    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
+    const fakeBacklogPath = path.join(temporaryRoot, "fake-backlog.mjs");
+
+    fs.mkdirSync(reviewRoot, { recursive: true });
+    fs.mkdirSync(originalsRoot, { recursive: true });
+    fs.writeFileSync(path.join(originalsRoot, "linked.jpg"), "linked-source");
+    fs.writeFileSync(path.join(originalsRoot, "failed.jpg"), "failed-source");
+    fs.writeFileSync(path.join(originalsRoot, "catchup.jpg"), "catchup-source");
+    fs.writeFileSync(path.join(originalsRoot, "backlog.jpg"), "backlog-source");
+
+    fs.writeFileSync(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const imageIndex = process.argv.indexOf("-i");
+const id = path.parse(process.argv[imageIndex + 1]).name;
+const sessionId = \`session-\${id}\`;
+console.log(JSON.stringify({ type: "thread.started", thread_id: sessionId }));
+await new Promise((resolve) => setTimeout(resolve, id === "linked" ? 300 : 20));
+const outputDir = path.join(process.env.CODEX_GENERATED_IMAGES_ROOT, sessionId);
+fs.mkdirSync(outputDir, { recursive: true });
+fs.writeFileSync(path.join(outputDir, "result.png"), \`\${id}-output\`);
+`,
+    );
+    fs.chmodSync(fakeCodexPath, 0o755);
+
+    fs.writeFileSync(
+      fakeBacklogPath,
+      `#!/usr/bin/env node
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+const reviewRoot = path.join(
+  process.env.V2_AHS_IMAGE_REVIEW_DATA_ROOT,
+  "v2-ahs-image-review",
+);
+const database = new DatabaseSync(path.join(reviewRoot, "review.sqlite"));
+const modeIndex = process.argv.indexOf("--mode");
+const mode = process.argv[modeIndex + 1];
+const linked = database
+  .prepare('SELECT "status" FROM "v2_image_review_queue" WHERE "id" = ?')
+  .get("linked");
+if (!['processing', 'review'].includes(linked?.status)) {
+  throw new Error("Source discovery ran before the existing queue started");
+}
+if (mode === "backlog") {
+  const catchup = database
+    .prepare('SELECT "status" FROM "v2_image_review_queue" WHERE "id" = ?')
+    .get("catchup");
+  if (!['processing', 'review'].includes(catchup?.status)) {
+    throw new Error("Backlog selected before catchup started");
+  }
+}
+const id = mode === "catchup" ? "catchup" : "backlog";
+const now = new Date().toISOString();
+database.prepare(\`
+  INSERT INTO "v2_image_review_queue" (
+    "id", "postTitle", "originalPath", "status", "attempts",
+    "createdAt", "updatedAt"
+  ) VALUES (?, ?, ?, 'pending', 0, ?, ?)
+\`).run(
+  id,
+  id === "catchup" ? "Catchup" : "Backlog",
+  path.join(process.env.V2_AHS_IMAGE_REVIEW_DATA_ROOT, "v2-ahs-images", \`\${id}.jpg\`),
+  now,
+  now,
+);
+database.close();
+`,
+    );
+    fs.chmodSync(fakeBacklogPath, 0o755);
+
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE "v2_image_review_queue" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "postTitle" TEXT,
+        "originalPath" TEXT NOT NULL,
+        "editedPath" TEXT,
+        "status" TEXT NOT NULL,
+        "attempts" INTEGER NOT NULL DEFAULT 0,
+        "lastError" TEXT,
+        "promptVersion" TEXT,
+        "codexNativeAgentId" TEXT,
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        `
+          INSERT INTO "v2_image_review_queue" (
+            "id", "postTitle", "originalPath", "status", "attempts",
+            "createdAt", "updatedAt"
+          ) VALUES (?, ?, ?, 'pending', 0, ?, ?)
+        `,
+      )
+      .run(
+        "linked",
+        "Linked",
+        path.join(originalsRoot, "linked.jpg"),
+        "2026-01-01",
+        "2026-01-01",
+      );
+    database
+      .prepare(
+        `
+          INSERT INTO "v2_image_review_queue" (
+            "id", "postTitle", "originalPath", "status", "attempts",
+            "createdAt", "updatedAt"
+          ) VALUES (?, ?, ?, 'failed', 1, ?, ?)
+        `,
+      )
+      .run(
+        "failed",
+        "Failed",
+        path.join(originalsRoot, "failed.jpg"),
+        "2026-01-01",
+        "2026-01-01",
+      );
+    database.close();
+
+    const prodDatabase = new DatabaseSync(prodDatabasePath);
+    prodDatabase.exec(`
+      CREATE TABLE "Listing" ("cultivarReferenceId" TEXT);
+      INSERT INTO "Listing" VALUES ('linked');
+    `);
+    prodDatabase.close();
+
+    execFileSync(
+      process.execPath,
+      [
+        path.join(scriptRoot, "run-codex-native-worker.mjs"),
+        "--limit",
+        "3",
+        "--concurrency",
+        "2",
+        "--timeout-minutes",
+        "1",
+      ],
+      {
+        env: {
+          ...process.env,
+          CODEX_BACKLOG_SCRIPT: fakeBacklogPath,
+          CODEX_BIN: fakeCodexPath,
+          CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
+          CODEX_USAGE_CHECK_DISABLED: "1",
+          V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
+          V2_AHS_PROD_COPY_DB_PATH: prodDatabasePath,
+        },
+      },
+    );
+
+    const verifiedDatabase = new DatabaseSync(databasePath, {
+      readOnly: true,
+    });
+    const rows = verifiedDatabase
+      .prepare(
+        `SELECT "id", "status" FROM "v2_image_review_queue" ORDER BY "id"`,
+      )
+      .all();
+    verifiedDatabase.close();
+
+    expect(rows).toEqual([
+      { id: "backlog", status: "review" },
+      { id: "catchup", status: "review" },
+      { id: "failed", status: "failed" },
+      { id: "linked", status: "review" },
+    ]);
+
+    const runDirectory = path.join(reviewRoot, "codex-native-runs");
+    const runLog = fs.readFileSync(
+      path.join(
+        runDirectory,
+        fs.readdirSync(runDirectory).find((file) => file.endsWith(".log"))!,
+      ),
+      "utf8",
+    );
+    expect(runLog.indexOf("started id=catchup")).toBeLessThan(
+      runLog.indexOf("thread finished id=linked"),
+    );
+  });
+
+  it("summarizes a no-image failure without failing the batch", () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "codex-native-no-image-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+
+    const dataRoot = path.join(temporaryRoot, "data");
+    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
+    const databasePath = path.join(reviewRoot, "review.sqlite");
+    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
+
+    fs.mkdirSync(reviewRoot, { recursive: true });
+    fs.mkdirSync(originalsRoot, { recursive: true });
+    fs.writeFileSync(path.join(originalsRoot, "no-image.jpg"), "source");
+    fs.writeFileSync(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "thread.started", thread_id: "session-no-image" }));
+console.log(JSON.stringify({
+  type: "item.completed",
+  item: { type: "agent_message", text: "I could not create this image." }
+}));
+`,
+    );
+    fs.chmodSync(fakeCodexPath, 0o755);
+
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE "v2_image_review_queue" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "postTitle" TEXT,
+        "originalPath" TEXT NOT NULL,
+        "editedPath" TEXT,
+        "status" TEXT NOT NULL,
+        "attempts" INTEGER NOT NULL DEFAULT 0,
+        "lastError" TEXT,
+        "promptVersion" TEXT,
+        "codexNativeAgentId" TEXT,
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL
+      );
+      INSERT INTO "v2_image_review_queue" (
+        "id", "postTitle", "originalPath", "status", "createdAt", "updatedAt"
+      ) VALUES (
+        'no-image', 'No Image', '${path.join(originalsRoot, "no-image.jpg")}',
+        'pending', '2026-01-01', '2026-01-01'
+      );
+    `);
+    database.close();
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(scriptRoot, "run-codex-native-worker.mjs"),
+        "--id",
+        "no-image",
+        "--timeout-minutes",
+        "1",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_BIN: fakeCodexPath,
+          CODEX_USAGE_CHECK_DISABLED: "1",
+          V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const runDirectory = path.join(reviewRoot, "codex-native-runs");
+    const runFiles = fs.readdirSync(runDirectory);
+    const runLog = fs.readFileSync(
+      path.join(runDirectory, runFiles.find((file) => file.endsWith(".log"))!),
+      "utf8",
+    );
+    expect(runLog).toContain("image=no");
+    expect(runLog).toContain(
+      "no-image response id=no-image: I could not create this image.",
+    );
+    expect(runLog).toContain("success=0/1 (0.0%)");
+    expect(runLog).toContain(
+      "worker finished attempted=1 completed=1 promoted=0",
+    );
+    expect(runLog).toContain(
+      "failed=1 interrupted=0 stopReason=limit reached successRate=0.0%",
+    );
+
+    const events = fs
+      .readFileSync(
+        path.join(
+          runDirectory,
+          runFiles.find((file) => file.endsWith(".events.jsonl"))!,
+        ),
+        "utf8",
+      )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        queueId: "no-image",
+        event: expect.objectContaining({ type: "item.completed" }),
+      }),
+    );
+  });
+
+  it("changes concurrency live and drains without interrupting active work", async () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "codex-native-control-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+
+    const dataRoot = path.join(temporaryRoot, "data");
+    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
+    const generatedRoot = path.join(temporaryRoot, "generated");
+    const databasePath = path.join(reviewRoot, "review.sqlite");
+    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
+    const fakeBacklogPath = path.join(temporaryRoot, "fake-backlog.mjs");
+    const statePath = path.join(reviewRoot, "codex-native-worker-state.json");
+
+    fs.mkdirSync(reviewRoot, { recursive: true });
+    fs.mkdirSync(originalsRoot, { recursive: true });
+    for (let index = 1; index <= 8; index += 1) {
+      fs.writeFileSync(
+        path.join(originalsRoot, `control-${index}.jpg`),
+        "source",
+      );
+    }
+    fs.writeFileSync(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const imageIndex = process.argv.indexOf("-i");
+const id = path.parse(process.argv[imageIndex + 1]).name;
+const sessionId = \`session-\${id}\`;
+console.log(JSON.stringify({ type: "thread.started", thread_id: sessionId }));
+await new Promise((resolve) => setTimeout(resolve, 1_500));
+const outputDir = path.join(process.env.CODEX_GENERATED_IMAGES_ROOT, sessionId);
+fs.mkdirSync(outputDir, { recursive: true });
+fs.writeFileSync(path.join(outputDir, "result.png"), "output");
+`,
+    );
+    fs.chmodSync(fakeCodexPath, 0o755);
+    fs.writeFileSync(
+      fakeBacklogPath,
+      `#!/usr/bin/env node
+const mode = process.argv[process.argv.indexOf("--mode") + 1];
+console.log(\`[v2-image-queue] mode=\${mode} selected=0\`);
+`,
+    );
+    fs.chmodSync(fakeBacklogPath, 0o755);
+
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE "v2_image_review_queue" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "postTitle" TEXT,
+        "originalPath" TEXT NOT NULL,
+        "editedPath" TEXT,
+        "status" TEXT NOT NULL,
+        "attempts" INTEGER NOT NULL DEFAULT 0,
+        "lastError" TEXT,
+        "promptVersion" TEXT,
+        "codexNativeAgentId" TEXT,
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL
+      );
+    `);
+    const insert = database.prepare(`
+      INSERT INTO "v2_image_review_queue" (
+        "id", "postTitle", "originalPath", "status", "createdAt", "updatedAt"
+      ) VALUES (?, ?, ?, 'pending', ?, ?)
+    `);
+    for (let index = 1; index <= 8; index += 1) {
+      insert.run(
+        `control-${index}`,
+        `Control ${index}`,
+        path.join(originalsRoot, `control-${index}.jpg`),
+        `2026-01-0${index}`,
+        `2026-01-0${index}`,
+      );
+    }
+    database.close();
+
+    const env = {
+      ...process.env,
+      CODEX_BACKLOG_SCRIPT: fakeBacklogPath,
+      CODEX_BIN: fakeCodexPath,
+      CODEX_GENERATED_IMAGES_ROOT: generatedRoot,
+      CODEX_USAGE_CHECK_DISABLED: "1",
+      V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
+    };
+    const worker = spawn(
+      process.execPath,
+      [
+        path.join(scriptRoot, "run-codex-native-worker.mjs"),
+        "--limit",
+        "8",
+        "--concurrency",
+        "1",
+        "--timeout-minutes",
+        "1",
+      ],
+      { env, stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    const waitForState = async (predicate: (state: any) => boolean) => {
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        if (fs.existsSync(statePath)) {
+          const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+          if (predicate(state)) return state;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      throw new Error("Timed out waiting for worker state");
+    };
+
+    await waitForState(
+      (state) => state.desiredConcurrency === 1 && state.active === 1,
+    );
+    execFileSync(
+      process.execPath,
+      [
+        path.join(scriptRoot, "control-codex-native-worker.mjs"),
+        "concurrency",
+        "3",
+      ],
+      { env },
+    );
+    await waitForState(
+      (state) => state.desiredConcurrency === 3 && state.active === 3,
+    );
+    execFileSync(
+      process.execPath,
+      [path.join(scriptRoot, "control-codex-native-worker.mjs"), "drain"],
+      { env },
+    );
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        worker.kill("SIGKILL");
+        reject(new Error("Timed out waiting for worker drain"));
+      }, 10_000);
+      worker.once("error", reject);
+      worker.once("close", (code) => {
+        clearTimeout(timeout);
+        resolve(code);
+      });
+    });
+    expect(exitCode).toBe(0);
+
+    const verifiedDatabase = new DatabaseSync(databasePath, { readOnly: true });
+    const statuses = verifiedDatabase
+      .prepare(
+        `SELECT "status", COUNT(*) AS "count" FROM "v2_image_review_queue" GROUP BY "status" ORDER BY "status"`,
+      )
+      .all();
+    verifiedDatabase.close();
+    expect(statuses).toEqual([
+      { status: "pending", count: 5 },
+      { status: "review", count: 3 },
+    ]);
+
+    const runDirectory = path.join(reviewRoot, "codex-native-runs");
+    const runLog = fs.readFileSync(
+      path.join(
+        runDirectory,
+        fs.readdirSync(runDirectory).find((file) => file.endsWith(".log"))!,
+      ),
+      "utf8",
+    );
+    expect(runLog).toContain(
+      "concurrency changed previous=1 desired=3 active=1",
+    );
+    expect(runLog).toContain("draining reason=control command active=3");
+    expect(runLog).toContain("promoted=3");
+    expect(runLog).toContain("interrupted=0");
+  });
+
+  it("returns an interrupted thread to pending without counting a failure", async () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "codex-native-interrupted-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+
+    const dataRoot = path.join(temporaryRoot, "data");
+    const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+    const originalsRoot = path.join(dataRoot, "v2-ahs-images");
+    const databasePath = path.join(reviewRoot, "review.sqlite");
+    const fakeCodexPath = path.join(temporaryRoot, "fake-codex.mjs");
+
+    fs.mkdirSync(reviewRoot, { recursive: true });
+    fs.mkdirSync(originalsRoot, { recursive: true });
+    fs.writeFileSync(path.join(originalsRoot, "interrupted.jpg"), "source");
+    fs.writeFileSync(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "thread.started", thread_id: "session-interrupted" }));
+setInterval(() => {}, 1_000);
+`,
+    );
+    fs.chmodSync(fakeCodexPath, 0o755);
+
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE "v2_image_review_queue" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "postTitle" TEXT,
+        "originalPath" TEXT NOT NULL,
+        "editedPath" TEXT,
+        "status" TEXT NOT NULL,
+        "attempts" INTEGER NOT NULL DEFAULT 0,
+        "lastError" TEXT,
+        "promptVersion" TEXT,
+        "codexNativeAgentId" TEXT,
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        `
+          INSERT INTO "v2_image_review_queue" (
+            "id", "postTitle", "originalPath", "status", "createdAt", "updatedAt"
+          ) VALUES (?, ?, ?, 'pending', ?, ?)
+        `,
+      )
+      .run(
+        "interrupted",
+        "Interrupted",
+        path.join(originalsRoot, "interrupted.jpg"),
+        "2026-01-01",
+        "2026-01-01",
+      );
+    database.close();
+
+    const worker = spawn(
+      process.execPath,
+      [
+        path.join(scriptRoot, "run-codex-native-worker.mjs"),
+        "--id",
+        "interrupted",
+        "--timeout-minutes",
+        "1",
+      ],
+      {
+        env: {
+          ...process.env,
+          CODEX_BIN: fakeCodexPath,
+          CODEX_USAGE_CHECK_DISABLED: "1",
+          V2_AHS_IMAGE_REVIEW_DATA_ROOT: dataRoot,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    let stdout = "";
+    let sentInterrupt = false;
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        worker.kill("SIGKILL");
+        reject(new Error("Timed out waiting to interrupt worker"));
+      }, 10_000);
+
+      worker.stdout.setEncoding("utf8");
+      worker.stdout.on("data", (chunk) => {
+        stdout += chunk;
+        if (!sentInterrupt && stdout.includes("assigned id=interrupted")) {
+          sentInterrupt = true;
+          worker.kill("SIGINT");
+        }
+      });
+      worker.once("error", reject);
+      worker.once("close", (code) => {
+        clearTimeout(timeout);
+        resolve(code);
+      });
+    });
+
+    expect(exitCode).toBe(0);
+
+    const verifiedDatabase = new DatabaseSync(databasePath, { readOnly: true });
+    const row = verifiedDatabase
+      .prepare(
+        `
+          SELECT "status", "lastError", "codexNativeAgentId"
+          FROM "v2_image_review_queue"
+          WHERE "id" = 'interrupted'
+        `,
+      )
+      .get();
+    verifiedDatabase.close();
+
+    expect(row).toEqual({
+      status: "pending",
+      lastError: "Worker interrupted by SIGINT",
+      codexNativeAgentId: null,
+    });
+
+    const runDirectory = path.join(reviewRoot, "codex-native-runs");
+    const runLogPath = fs
+      .readdirSync(runDirectory)
+      .map((file) => path.join(runDirectory, file))
+      .find((file) => file.endsWith(".log"))!;
+    const runLog = fs.readFileSync(runLogPath, "utf8");
+    expect(runLog).toContain("stopping signal=SIGINT active=1");
+    expect(runLog).toContain(
+      "thread interrupted id=interrupted session=session-interrupted signal=SIGINT status=pending",
+    );
+    expect(runLog).toContain("failed=0 interrupted=1");
+    expect(runLog).not.toContain("no-image response id=interrupted");
+  });
+});

--- a/apps/main/tests/generated-cultivar-image-backlog.test.ts
+++ b/apps/main/tests/generated-cultivar-image-backlog.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  findLinkedCultivarIds,
+  selectBacklogRows,
+  selectCatchupRows,
+} from "../scripts/image-processing/v2-ahs-image-review/queue-backlog-source-images";
+
+const databases: DatabaseSync[] = [];
+
+function createDatabase() {
+  const database = new DatabaseSync(":memory:");
+  databases.push(database);
+  database.exec(`
+    CREATE TABLE "CultivarReference" (
+      "id" TEXT PRIMARY KEY,
+      "ahsId" TEXT,
+      "v2AhsCultivarId" TEXT,
+      "normalizedName" TEXT
+    );
+    CREATE TABLE "V2AhsCultivar" (
+      "id" TEXT PRIMARY KEY,
+      "post_title" TEXT,
+      "image_url" TEXT
+    );
+    CREATE TABLE "AhsListing" (
+      "id" TEXT PRIMARY KEY,
+      "name" TEXT,
+      "ahsImageUrl" TEXT
+    );
+    CREATE TABLE "Listing" ("cultivarReferenceId" TEXT);
+    CREATE TABLE "ImageAsset" (
+      "cultivarReferenceId" TEXT,
+      "kind" TEXT,
+      "status" TEXT
+    );
+  `);
+  return database;
+}
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+describe("generated cultivar image backlog selection", () => {
+  it("identifies only claimable cultivars linked to listings", () => {
+    const database = createDatabase();
+    database.exec(`
+      INSERT INTO "CultivarReference" VALUES
+        ('cr-backlog', NULL, NULL, 'backlog'),
+        ('cr-linked', NULL, NULL, 'linked');
+      INSERT INTO "Listing" VALUES ('cr-linked');
+    `);
+
+    expect(
+      findLinkedCultivarIds(database, ["cr-backlog", "cr-linked"]),
+    ).toEqual(["cr-linked"]);
+    expect(findLinkedCultivarIds(database, ["cr-backlog"])).toEqual([]);
+  });
+
+  it("takes the next alphabetical non-linked cultivars without ready assets or queue history", () => {
+    const database = createDatabase();
+    database.exec(`
+      INSERT INTO "V2AhsCultivar" VALUES
+        ('v2-alpha', 'Alpha Display', 'https://example.com/alpha.jpg'),
+        ('v2-beta', 'Beta Display', 'https://example.com/beta.jpg'),
+        ('v2-gamma', 'Gamma Display', 'https://example.com/gamma.jpg'),
+        ('v2-zebra', 'Zebra Display', 'https://example.com/zebra.jpg');
+      INSERT INTO "AhsListing" VALUES
+        ('ahs-legacy', 'Legacy Display', 'https://example.com/legacy.jpg');
+      INSERT INTO "CultivarReference" VALUES
+        ('cr-alpha', NULL, 'v2-alpha', 'alpha'),
+        ('cr-beta', NULL, 'v2-beta', 'beta'),
+        ('cr-gamma', NULL, 'v2-gamma', 'gamma'),
+        ('cr-history', 'ahs-legacy', NULL, 'aardvark'),
+        ('cr-no-source', NULL, NULL, 'delta'),
+        ('cr-zebra', NULL, 'v2-zebra', 'zebra');
+      INSERT INTO "Listing" VALUES ('cr-beta');
+      INSERT INTO "ImageAsset" VALUES ('cr-gamma', 'cultivar', 'ready');
+    `);
+
+    const rows = selectBacklogRows(database, new Set(["cr-history"]), 2);
+
+    expect(rows).toEqual([
+      {
+        id: "cr-alpha",
+        imageUrl: "https://example.com/alpha.jpg",
+        postTitle: "Alpha Display",
+        sourceKind: "v2",
+      },
+      {
+        id: "cr-zebra",
+        imageUrl: "https://example.com/zebra.jpg",
+        postTitle: "Zebra Display",
+        sourceKind: "v2",
+      },
+    ]);
+  });
+
+  it("selects every newly linked cultivar before backlog work", () => {
+    const database = createDatabase();
+    database.exec(`
+      INSERT INTO "V2AhsCultivar" VALUES
+        ('v2-new', 'New Linked', 'https://example.com/new.jpg'),
+        ('v2-local', 'Already Local', 'https://example.com/local.jpg'),
+        ('v2-ready', 'Already Ready', 'https://example.com/ready.jpg');
+      INSERT INTO "CultivarReference" VALUES
+        ('cr-new', NULL, 'v2-new', 'new linked'),
+        ('cr-local', NULL, 'v2-local', 'already local'),
+        ('cr-ready', NULL, 'v2-ready', 'already ready');
+      INSERT INTO "Listing" VALUES
+        ('cr-new'),
+        ('cr-local'),
+        ('cr-ready');
+      INSERT INTO "ImageAsset" VALUES ('cr-ready', 'cultivar', 'ready');
+    `);
+
+    expect(selectCatchupRows(database, new Set(["cr-local"]))).toEqual([
+      {
+        id: "cr-new",
+        imageUrl: "https://example.com/new.jpg",
+        postTitle: "New Linked",
+        sourceKind: "v2",
+      },
+    ]);
+  });
+});

--- a/apps/main/tests/helpers/codex-native-worker-fixture.ts
+++ b/apps/main/tests/helpers/codex-native-worker-fixture.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+export function createWorkerFixture(prefix: string) {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dataRoot = path.join(temporaryRoot, "data");
+  const reviewRoot = path.join(dataRoot, "v2-ahs-image-review");
+  const originalsRoot = path.join(dataRoot, "v2-ahs-images");
+
+  fs.mkdirSync(reviewRoot, { recursive: true });
+  fs.mkdirSync(originalsRoot, { recursive: true });
+
+  return {
+    dataRoot,
+    databasePath: path.join(reviewRoot, "review.sqlite"),
+    fakeBacklogPath: path.join(temporaryRoot, "fake-backlog.mjs"),
+    fakeCodexPath: path.join(temporaryRoot, "fake-codex.mjs"),
+    generatedRoot: path.join(temporaryRoot, "generated"),
+    originalsRoot,
+    reviewRoot,
+    temporaryRoot,
+  };
+}
+
+export function createQueueDatabase(databasePath: string) {
+  const database = new DatabaseSync(databasePath);
+  database.exec(`
+    CREATE TABLE "v2_image_review_queue" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "postTitle" TEXT,
+      "originalPath" TEXT NOT NULL,
+      "editedPath" TEXT,
+      "status" TEXT NOT NULL,
+      "attempts" INTEGER NOT NULL DEFAULT 0,
+      "lastError" TEXT,
+      "promptVersion" TEXT,
+      "codexNativeAgentId" TEXT,
+      "createdAt" TEXT NOT NULL,
+      "updatedAt" TEXT NOT NULL
+    );
+  `);
+  return database;
+}

--- a/apps/main/tests/image-review-bulk-approval.test.ts
+++ b/apps/main/tests/image-review-bulk-approval.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  delete process.env.V2_AHS_IMAGE_REVIEW_DATA_ROOT;
+  for (const temporaryRoot of temporaryRoots.splice(0)) {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+describe("image review bulk approval", () => {
+  it("approves only the requested review rows", async () => {
+    const temporaryRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "image-review-bulk-approval-"),
+    );
+    temporaryRoots.push(temporaryRoot);
+    process.env.V2_AHS_IMAGE_REVIEW_DATA_ROOT = temporaryRoot;
+
+    const moduleUrl = pathToFileURL(
+      path.join(
+        process.cwd(),
+        "scripts/image-processing/v2-ahs-image-review/review-db.mjs",
+      ),
+    );
+    moduleUrl.searchParams.set("test", String(Date.now()));
+    const reviewDb = await import(moduleUrl.href);
+    const database = reviewDb.openQueueDb();
+    reviewDb.ensureSchema(database);
+
+    const insert = database.prepare(`
+      INSERT INTO "v2_image_review_queue" (
+        "id", "postTitle", "originalPath", "editedPath", "status",
+        "createdAt", "updatedAt"
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+    for (const [id, status] of [
+      ["review-1", "review"],
+      ["review-2", "review"],
+      ["pending-1", "pending"],
+      ["processing-1", "processing"],
+      ["approved-1", "approved"],
+    ]) {
+      insert.run(
+        id,
+        id,
+        `/originals/${id}.jpg`,
+        status === "review" ? `/edited/${id}.png` : null,
+        status,
+        "2026-01-01",
+        "2026-01-01",
+      );
+    }
+    database.close();
+
+    expect(
+      reviewDb.approveReviewItems(["review-1", "pending-1", "missing"]),
+    ).toBe(1);
+    expect(reviewDb.getCounts()).toMatchObject({
+      approved: 2,
+      pending: 1,
+      processing: 1,
+      review: 1,
+    });
+
+    expect(reviewDb.approveAllReviewItems()).toBe(1);
+    expect(reviewDb.getCounts()).toMatchObject({
+      approved: 3,
+      pending: 1,
+      processing: 1,
+      review: 0,
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "db:seed:prepare": "TURBO_CACHE_DIR=.turbo turbo run db:seed:prepare --filter=@daylily-catalog/main",
     "db:seed:sync": "TURBO_CACHE_DIR=.turbo turbo run db:seed:sync --filter=@daylily-catalog/main",
     "images:generate": "pnpm --filter @daylily-catalog/main images:generate",
+    "images:control": "pnpm --filter @daylily-catalog/main images:control",
     "migrate:generate": "TURBO_CACHE_DIR=.turbo turbo run migrate:generate --filter=@daylily-catalog/main",
     "browser-tools-server": "TURBO_CACHE_DIR=.turbo turbo run browser-tools-server --filter=@daylily-catalog/main",
     "profile:queries": "TURBO_CACHE_DIR=.turbo turbo run profile:queries --filter=@daylily-catalog/main"


### PR DESCRIPTION
## Description

Improve the local generated-cultivar image workflow. The worker now keeps its concurrency pool full, supports live concurrency changes and graceful drain, records durable queue-to-session mappings, prefetches catch-up/backlog sources, and gives the review UI dense batch approval controls.

This PR changes local operator tooling only. It does not change production application reads or writes. Runtime images, SQLite databases, logs, generated candidates, and local snapshots are not included.

## Files

- `package.json`: add root image generation and control commands.
- `apps/main/package.json`: add app-level image generation and control commands.
- `apps/main/docs/generated-cultivar-image-catchup.md`: document the current catch-up, backlog, review, import, and cleanup flow.
- `apps/main/scripts/image-processing/v2-ahs-image-review/README.md`: document the local runtime root and primary commands.
- `apps/main/scripts/image-processing/v2-ahs-image-review/codex-native-image-generation.md`: document autonomous generation, observability, recovery, and runtime controls.
- `apps/main/scripts/image-processing/v2-ahs-image-review/run-codex-native-worker.mjs`: use a rolling concurrency pool, source prefetch, run logs, usage snapshots, live scaling, and graceful drain.
- `apps/main/scripts/image-processing/v2-ahs-image-review/control-codex-native-worker.mjs`: add status, concurrency, and drain commands for a running worker.
- `apps/main/scripts/image-processing/v2-ahs-image-review/queue-backlog-source-images.ts`: make backlog selection durable and compatible with rolling refills.
- `apps/main/scripts/image-processing/v2-ahs-image-review/review-db.mjs`: add concurrent queue support, durable Codex session mapping, and batch approval operations.
- `apps/main/scripts/image-processing/v2-ahs-image-review/promote-codex-native-result.mjs`: promote only the result mapped to the claimed queue row.
- `apps/main/scripts/image-processing/v2-ahs-image-review/promote-codex-native-batch.mjs`: align batch promotion with the durable mapping flow.
- `apps/main/scripts/image-processing/v2-ahs-image-review/app.mjs`: support the dense paged review workflow and batch actions.
- `apps/main/scripts/image-processing/v2-ahs-image-review/index.html`: provide the compact side-by-side review grid and confirmation UI.
- `apps/main/scripts/image-processing/v2-ahs-image-review/server.mjs`: expose page and all-review approval endpoints.
- `apps/main/tests/codex-native-image-mapping.test.ts`: cover queue-to-session result mapping.
- `apps/main/tests/codex-native-worker.test.ts`: cover concurrency, refill, observability, failures, scaling, and drain behavior.
- `apps/main/tests/generated-cultivar-image-backlog.test.ts`: cover backlog selection and exclusions.
- `apps/main/tests/image-review-bulk-approval.test.ts`: cover page and all-review approval behavior.

## Verification

- `vitest`: 4 focused files, 13 tests passed.
- `prettier --check`: all PR files passed.
- `git diff --check`: passed.
- Real smoke run: concurrency changed from 2 to 3, then drained with 8/8 images promoted, 0 failures, and 0 interruptions.
