### PR TITLE
Render crawlable cultivar search results

### DIFF
--- a/apps/main/src/app/(public)/cultivars/_components/cultivar-search-page-client.tsx
+++ b/apps/main/src/app/(public)/cultivars/_components/cultivar-search-page-client.tsx
@@ -1429,6 +1429,15 @@ export function CultivarSearchPageClient({
   initialResponse?: CultivarSearchResponse;
   initialState: InitialCultivarSearchState;
 }) {
+  const initialResponseMatchesState = Boolean(
+    initialResponse &&
+      initialState.q === "" &&
+      (!initialState.sort || initialState.sort === "name") &&
+      Object.entries(getInitialFilters(initialState)).every(
+        ([key, value]) =>
+          value === EMPTY_FILTERS[key as keyof CultivarSearchFilters],
+      ),
+  );
   const [query, setQuery] = useState(initialState.q);
   const [debouncedQuery, setDebouncedQuery] = useState(initialState.q);
   const [filters, setFilters] = useState(() => getInitialFilters(initialState));
@@ -1454,8 +1463,8 @@ export function CultivarSearchPageClient({
   const historyEntryIdRef = useRef<string | null>(null);
   const pendingScrollRestorationRef =
     useRef<CultivarSearchReturnSnapshot | null>(null);
-  const skipNextFetchRef = useRef(Boolean(initialResponse));
-  const hasPresentedSearchStateRef = useRef(Boolean(initialResponse));
+  const skipNextFetchRef = useRef(initialResponseMatchesState);
+  const hasPresentedSearchStateRef = useRef(initialResponseMatchesState);
   const initialResponseCapturedRef = useRef(false);
   const retryPendingRef = useRef(false);
 
@@ -1556,7 +1565,12 @@ export function CultivarSearchPageClient({
   );
 
   useEffect(() => {
-    if (!initialResponse || initialResponseCapturedRef.current) return;
+    if (
+      !initialResponseMatchesState ||
+      !initialResponse ||
+      initialResponseCapturedRef.current
+    )
+      return;
     initialResponseCapturedRef.current = true;
     const requestParams = buildRequestParams(0);
 
@@ -1574,7 +1588,7 @@ export function CultivarSearchPageClient({
       resultsReturned: initialResponse.results.length,
       visibleResultCount: initialResponse.results.length,
     });
-  }, [buildRequestParams, initialResponse]);
+  }, [buildRequestParams, initialResponse, initialResponseMatchesState]);
 
   useEffect(() => {
     if (!restorationChecked) return;

--- a/apps/main/src/app/(public)/cultivars/_components/cultivar-search-page-client.tsx
+++ b/apps/main/src/app/(public)/cultivars/_components/cultivar-search-page-client.tsx
@@ -182,7 +182,7 @@ interface CultivarSearchResult {
   };
 }
 
-interface CultivarSearchResponse {
+export interface CultivarSearchResponse {
   pagination: {
     hasMore: boolean;
     limit: number;
@@ -1423,8 +1423,10 @@ function ResultsSkeleton() {
 }
 
 export function CultivarSearchPageClient({
+  initialResponse,
   initialState,
 }: {
+  initialResponse?: CultivarSearchResponse;
   initialState: InitialCultivarSearchState;
 }) {
   const [query, setQuery] = useState(initialState.q);
@@ -1437,9 +1439,13 @@ export function CultivarSearchPageClient({
     isCultivarSort(initialState.sort) ? initialState.sort : "name",
   );
   const [advanced, setAdvanced] = useState(initialState.advanced ?? false);
-  const [results, setResults] = useState<CultivarSearchResult[]>([]);
-  const [nextOffset, setNextOffset] = useState<number | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [results, setResults] = useState<CultivarSearchResult[]>(
+    () => initialResponse?.results ?? [],
+  );
+  const [nextOffset, setNextOffset] = useState<number | null>(
+    initialResponse?.pagination.nextOffset ?? null,
+  );
+  const [loading, setLoading] = useState(!initialResponse);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [retryKey, setRetryKey] = useState(0);
@@ -1448,8 +1454,9 @@ export function CultivarSearchPageClient({
   const historyEntryIdRef = useRef<string | null>(null);
   const pendingScrollRestorationRef =
     useRef<CultivarSearchReturnSnapshot | null>(null);
-  const skipNextFetchRef = useRef(false);
-  const hasPresentedSearchStateRef = useRef(false);
+  const skipNextFetchRef = useRef(Boolean(initialResponse));
+  const hasPresentedSearchStateRef = useRef(Boolean(initialResponse));
+  const initialResponseCapturedRef = useRef(false);
   const retryPendingRef = useRef(false);
 
   useEffect(() => {
@@ -1547,6 +1554,27 @@ export function CultivarSearchPageClient({
     },
     [requestFilters.hasListings, shareParams, sort],
   );
+
+  useEffect(() => {
+    if (!initialResponse || initialResponseCapturedRef.current) return;
+    initialResponseCapturedRef.current = true;
+    const requestParams = buildRequestParams(0);
+
+    captureSearchResultsViewed({
+      clientDurationMs: 0,
+      hasMore: initialResponse.pagination.hasMore,
+      outcome: initialResponse.results.length > 0 ? "results" : "empty",
+      params: requestParams,
+      requestKind: "initial",
+      responseTelemetry: {
+        httpStatus: 200,
+        requestId: undefined,
+        serverDurationMs: undefined,
+      },
+      resultsReturned: initialResponse.results.length,
+      visibleResultCount: initialResponse.results.length,
+    });
+  }, [buildRequestParams, initialResponse]);
 
   useEffect(() => {
     if (!restorationChecked) return;

--- a/apps/main/src/app/(public)/cultivars/page.tsx
+++ b/apps/main/src/app/(public)/cultivars/page.tsx
@@ -1,5 +1,6 @@
 // eslint-disable react/no-danger -- intentional static JSON-LD injection.
 import { type Metadata } from "next";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { MainContent } from "@/app/(public)/_components/main-content";
 import { buildPublicPageMetadata } from "@/app/(public)/_seo/public-seo";
@@ -9,6 +10,10 @@ import { IMAGES } from "@/lib/constants/images";
 import { reportError } from "@/lib/error-utils";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { serializeJsonLd } from "@/lib/utils/json-ld";
+import {
+  getRequestId,
+  logSearchRequest,
+} from "@/server/search/cultivar-search-request-telemetry";
 import {
   CultivarSearchPageClient,
   type CultivarSearchResponse,
@@ -34,6 +39,16 @@ function getFirstSearchParam(
 async function getInitialSearchResponse(
   baseUrl: string,
 ): Promise<CultivarSearchResponse | undefined> {
+  const startedAt = performance.now();
+  const requestId = getRequestId(await headers());
+  const searchParams = new URLSearchParams({
+    hasListings: "true",
+    limit: String(INITIAL_RESULT_LIMIT),
+    mode: "summary",
+    offset: "0",
+    sort: "name",
+  });
+
   try {
     const { searchCultivars } = await import("@/server/search/cultivar-search");
     const results = await searchCultivars({
@@ -47,6 +62,18 @@ async function getInitialSearchResponse(
       sort: "name",
     });
     const hasMore = results.length > INITIAL_RESULT_LIMIT;
+    const responseResults = results.slice(0, INITIAL_RESULT_LIMIT);
+
+    logSearchRequest({
+      durationMs: performance.now() - startedAt,
+      hasMore,
+      httpStatus: 200,
+      mode: "summary",
+      requestId,
+      resultsReturned: responseResults.length,
+      searchParams,
+      status: "success",
+    });
 
     return {
       pagination: {
@@ -54,13 +81,29 @@ async function getInitialSearchResponse(
         limit: INITIAL_RESULT_LIMIT,
         nextOffset: hasMore ? INITIAL_RESULT_LIMIT : null,
       },
-      results: results.slice(0, INITIAL_RESULT_LIMIT),
+      results: responseResults,
     };
   } catch (error) {
+    const indexUnavailable =
+      error instanceof Error &&
+      error.name === "PublicSearchIndexUnavailableError";
+    logSearchRequest({
+      durationMs: performance.now() - startedAt,
+      errorName: indexUnavailable
+        ? undefined
+        : error instanceof Error
+          ? error.name
+          : "UnknownError",
+      httpStatus: indexUnavailable ? 503 : 500,
+      mode: "summary",
+      requestId,
+      searchParams,
+      status: indexUnavailable ? "index_unavailable" : "error",
+    });
     reportError({
       error,
       level: "warning",
-      context: { source: "cultivar-search-initial-results" },
+      context: { requestId, source: "cultivar-search-initial-results" },
     });
     return undefined;
   }
@@ -114,10 +157,7 @@ export default async function CultivarsPage({
   const rawSearchParams = (await searchParams) ?? {};
   const baseUrl = getCanonicalBaseUrl();
   const pageUrl = `${baseUrl}/cultivars`;
-  const initialResponse =
-    Object.keys(rawSearchParams).length === 0
-      ? await getInitialSearchResponse(baseUrl)
-      : undefined;
+  const initialResponse = await getInitialSearchResponse(baseUrl);
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/apps/main/src/app/(public)/cultivars/page.tsx
+++ b/apps/main/src/app/(public)/cultivars/page.tsx
@@ -6,12 +6,18 @@ import { buildPublicPageMetadata } from "@/app/(public)/_seo/public-seo";
 import { METADATA_CONFIG } from "@/config/constants";
 import { isPublicCultivarSearchEnabled } from "@/config/feature-flags";
 import { IMAGES } from "@/lib/constants/images";
+import { reportError } from "@/lib/error-utils";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { serializeJsonLd } from "@/lib/utils/json-ld";
-import { CultivarSearchPageClient } from "./_components/cultivar-search-page-client";
+import {
+  CultivarSearchPageClient,
+  type CultivarSearchResponse,
+} from "./_components/cultivar-search-page-client";
 import { hasAdvancedCultivarSearchState } from "./_lib/cultivar-search-url";
 
 export const dynamic = "force-dynamic";
+
+const INITIAL_RESULT_LIMIT = 24;
 
 interface CultivarsPageProps {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
@@ -23,6 +29,41 @@ function getFirstSearchParam(
 ) {
   const value = params[key];
   return Array.isArray(value) ? value[0] : value;
+}
+
+async function getInitialSearchResponse(
+  baseUrl: string,
+): Promise<CultivarSearchResponse | undefined> {
+  try {
+    const { searchCultivars } = await import("@/server/search/cultivar-search");
+    const results = await searchCultivars({
+      baseUrl,
+      hasListings: true,
+      includeParentageTrees: false,
+      limit: INITIAL_RESULT_LIMIT + 1,
+      listingLimit: 0,
+      offset: 0,
+      prefixLastToken: true,
+      sort: "name",
+    });
+    const hasMore = results.length > INITIAL_RESULT_LIMIT;
+
+    return {
+      pagination: {
+        hasMore,
+        limit: INITIAL_RESULT_LIMIT,
+        nextOffset: hasMore ? INITIAL_RESULT_LIMIT : null,
+      },
+      results: results.slice(0, INITIAL_RESULT_LIMIT),
+    };
+  } catch (error) {
+    reportError({
+      error,
+      level: "warning",
+      context: { source: "cultivar-search-initial-results" },
+    });
+    return undefined;
+  }
 }
 
 export async function generateMetadata({
@@ -73,6 +114,10 @@ export default async function CultivarsPage({
   const rawSearchParams = (await searchParams) ?? {};
   const baseUrl = getCanonicalBaseUrl();
   const pageUrl = `${baseUrl}/cultivars`;
+  const initialResponse =
+    Object.keys(rawSearchParams).length === 0
+      ? await getInitialSearchResponse(baseUrl)
+      : undefined;
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -100,6 +145,7 @@ export default async function CultivarsPage({
       />
 
       <CultivarSearchPageClient
+        initialResponse={initialResponse}
         initialState={{
           advanced:
             getFirstSearchParam(rawSearchParams, "advanced") === "true" ||

--- a/apps/main/src/app/api/v1/cultivars/search/route.ts
+++ b/apps/main/src/app/api/v1/cultivars/search/route.ts
@@ -1,7 +1,5 @@
-import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
 import { getTrustedBaseUrl } from "@/lib/agent-readiness";
-import { getCultivarSearchTelemetryProperties } from "@/lib/analytics/cultivar-search-telemetry";
 import { reportError } from "@/lib/error-utils";
 import { getPublicCloudflareCacheHeaders } from "@/lib/public-cache-policy";
 import {
@@ -10,77 +8,15 @@ import {
   toPublicSearchStatus,
 } from "@/server/search/public-search-api-platform";
 import { searchCultivars } from "@/server/search/cultivar-search";
+import {
+  getRequestId,
+  getTelemetryHeaders,
+  logSearchRequest,
+} from "@/server/search/cultivar-search-request-telemetry";
 import { PublicSearchIndexUnavailableError } from "@/server/search/public-search-index";
 import type { CultivarSearchSort } from "@/server/search/cultivar-search";
 
 export const runtime = "nodejs";
-
-type SearchRequestStatus = "error" | "index_unavailable" | "success";
-
-function roundDurationMs(durationMs: number) {
-  return Math.round(durationMs * 10) / 10;
-}
-
-function getRequestId(request: Request) {
-  return (
-    request.headers.get("cf-ray") ??
-    request.headers.get("x-request-id") ??
-    randomUUID()
-  );
-}
-
-function getTelemetryHeaders(requestId: string, durationMs: number) {
-  return {
-    "X-Cultivar-Search-Duration-Ms": String(roundDurationMs(durationMs)),
-    "X-Cultivar-Search-Request-Id": requestId,
-  };
-}
-
-function logSearchRequest({
-  durationMs,
-  errorName,
-  hasMore,
-  httpStatus,
-  mode,
-  requestId,
-  resultsReturned,
-  searchParams,
-  status,
-}: {
-  durationMs: number;
-  errorName?: string;
-  hasMore?: boolean;
-  httpStatus: number;
-  mode: "full" | "summary";
-  requestId: string;
-  resultsReturned?: number;
-  searchParams: URLSearchParams;
-  status: SearchRequestStatus;
-}) {
-  const payload = JSON.stringify({
-    component: "public-cultivar-search",
-    event: "public_cultivar_search_request",
-    timestamp: new Date().toISOString(),
-    request_id: requestId,
-    status,
-    http_status: httpStatus,
-    duration_ms: roundDurationMs(durationMs),
-    mode,
-    source_surface: mode === "summary" ? "public_page" : "public_api",
-    results_returned: resultsReturned,
-    has_more: hasMore,
-    error_name: errorName,
-    ...getCultivarSearchTelemetryProperties(searchParams),
-  });
-
-  if (status === "success") {
-    console.info(payload);
-  } else if (status === "index_unavailable") {
-    console.warn(payload);
-  } else {
-    console.error(payload);
-  }
-}
 
 function getNumberParam(params: URLSearchParams, key: string) {
   const value = params.get(key);
@@ -127,7 +63,7 @@ export async function GET(request: Request) {
   }
 
   const startedAt = performance.now();
-  const requestId = getRequestId(request);
+  const requestId = getRequestId(request.headers);
   const { searchParams } = new URL(request.url);
   const summaryMode = searchParams.get("mode") === "summary";
   const mode = summaryMode ? "summary" : "full";

--- a/apps/main/src/server/search/cultivar-search-request-telemetry.ts
+++ b/apps/main/src/server/search/cultivar-search-request-telemetry.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "node:crypto";
+import { getCultivarSearchTelemetryProperties } from "@/lib/analytics/cultivar-search-telemetry";
+
+type SearchRequestStatus = "error" | "index_unavailable" | "success";
+
+function roundDurationMs(durationMs: number) {
+  return Math.round(durationMs * 10) / 10;
+}
+
+export function getRequestId(headers: Headers) {
+  return headers.get("cf-ray") ?? headers.get("x-request-id") ?? randomUUID();
+}
+
+export function getTelemetryHeaders(requestId: string, durationMs: number) {
+  return {
+    "X-Cultivar-Search-Duration-Ms": String(roundDurationMs(durationMs)),
+    "X-Cultivar-Search-Request-Id": requestId,
+  };
+}
+
+export function logSearchRequest({
+  durationMs,
+  errorName,
+  hasMore,
+  httpStatus,
+  mode,
+  requestId,
+  resultsReturned,
+  searchParams,
+  status,
+}: {
+  durationMs: number;
+  errorName?: string;
+  hasMore?: boolean;
+  httpStatus: number;
+  mode: "full" | "summary";
+  requestId: string;
+  resultsReturned?: number;
+  searchParams: URLSearchParams;
+  status: SearchRequestStatus;
+}) {
+  const payload = JSON.stringify({
+    component: "public-cultivar-search",
+    event: "public_cultivar_search_request",
+    timestamp: new Date().toISOString(),
+    request_id: requestId,
+    status,
+    http_status: httpStatus,
+    duration_ms: roundDurationMs(durationMs),
+    mode,
+    source_surface: mode === "summary" ? "public_page" : "public_api",
+    results_returned: resultsReturned,
+    has_more: hasMore,
+    error_name: errorName,
+    ...getCultivarSearchTelemetryProperties(searchParams),
+  });
+
+  if (status === "success") {
+    console.info(payload);
+  } else if (status === "index_unavailable") {
+    console.warn(payload);
+  } else {
+    console.error(payload);
+  }
+}

--- a/apps/main/tests/cultivar-search-page-client.test.tsx
+++ b/apps/main/tests/cultivar-search-page-client.test.tsx
@@ -170,6 +170,10 @@ describe("CultivarSearchPageClient", () => {
 
     render(
       <CultivarSearchPageClient
+        initialResponse={searchResponseFor({
+          cultivarReferenceId: "browse-result",
+          name: "Browse Result",
+        })}
         initialState={{
           hasCultivarPhoto: false,
           hasForSaleListings: false,
@@ -306,7 +310,7 @@ describe("CultivarSearchPageClient", () => {
   });
 
   it("uses server-rendered initial results without repeating the search", async () => {
-    window.history.replaceState({}, "", "/cultivars");
+    window.history.replaceState({}, "", "/cultivars?utm_source=newsletter");
 
     render(
       <CultivarSearchPageClient

--- a/apps/main/tests/cultivar-search-page-client.test.tsx
+++ b/apps/main/tests/cultivar-search-page-client.test.tsx
@@ -305,6 +305,43 @@ describe("CultivarSearchPageClient", () => {
     );
   });
 
+  it("uses server-rendered initial results without repeating the search", async () => {
+    window.history.replaceState({}, "", "/cultivars");
+
+    render(
+      <CultivarSearchPageClient
+        initialResponse={searchResponse()}
+        initialState={{
+          hasCultivarPhoto: false,
+          hasForSaleListings: false,
+          hasListings: true,
+          q: "",
+          sort: "name",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Stella de Oro" }),
+    ).toBeVisible();
+    expect(screen.getByRole("link", { name: /Stella de Oro/ })).toHaveAttribute(
+      "href",
+      "/cultivar/stella-de-oro",
+    );
+    await waitFor(() => {
+      expect(capturePosthogEventMock).toHaveBeenCalledWith(
+        "public_cultivar_search_results_viewed",
+        expect.objectContaining({
+          http_status: 200,
+          request_kind: "initial",
+          results_returned: 1,
+          visible_result_count: 1,
+        }),
+      );
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("exposes cultivar-focused advanced filters and sends their values", async () => {
     fetchMock.mockImplementation((url: string) => {
       if (url.includes("/api/v1/cultivars/facets")) {


### PR DESCRIPTION
## Description

Server-render the first cultivar browse page so crawlers receive substantive catalog content and canonical cultivar links in the initial HTML. Hydrate the existing interactive search from that response without a duplicate request when it matches the URL state. Preserve server and client search telemetry.

## Files

- `apps/main/src/app/(public)/cultivars/page.tsx`: loads the first 24 linked cultivars independently of URL parameters, records measured server telemetry, and degrades to the existing client fetch if the search index is unavailable.
- `apps/main/src/app/(public)/cultivars/_components/cultivar-search-page-client.tsx`: accepts the initial response, reuses it for default browse state, and fetches the requested result set when real search or filter state is present.
- `apps/main/src/app/api/v1/cultivars/search/route.ts`: uses the shared request telemetry functions without changing API behavior.
- `apps/main/src/server/search/cultivar-search-request-telemetry.ts`: shares request IDs, durations, status, and search properties between API and server-rendered searches.
- `apps/main/tests/cultivar-search-page-client.test.tsx`: verifies tracking parameters keep the server results without an extra fetch and real search state still requests matching results.

## Verification

- `pnpm main typecheck`
- `pnpm main exec vitest run --maxWorkers=1 tests/cultivar-search-page-client.test.tsx tests/cultivar-search-route.test.ts tests/cultivar-search.integration.test.ts tests/public-surface-cache-safety.test.ts tests/social-sharing-metadata.test.ts` (39 passed)
- `ATLAS_PORT=3227 node apps/main/scripts/run-atlas-flow.mjs cultivar-search --output=apps/main/local/atlas/cultivar-crawlable-verification` (14 passed)
- Raw local `/cultivars` HTML returned HTTP 200 with 24 unique `/cultivar/...` links before hydration.
- Full-app server logs contain `public_cultivar_search_request` with request IDs and measured server durations for SSR queries.
