### PR TITLE
Include listing context in buyer inquiries

### DIFF
--- a/apps/main/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/_components/public-listing-page-actions.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/_components/public-listing-page-actions.tsx
@@ -84,9 +84,13 @@ export function usePublicListingContactTracker({
 
 export function PublicListingContactButton({
   listingId,
+  listingTitle,
+  listingPrice,
   sellerId,
   sellerName,
 }: Pick<PublicListingPageActionsProps, "listingId" | "sellerId"> & {
+  listingTitle: string;
+  listingPrice: number | null;
   sellerName?: string;
 }) {
   const trackContactClick = usePublicListingContactTracker({
@@ -100,6 +104,14 @@ export function PublicListingContactButton({
       userName={sellerName}
       showTopButton
       onContactClick={trackContactClick}
+      inquiryItem={{
+        id: listingId,
+        listingId,
+        title: listingTitle,
+        price: listingPrice,
+        quantity: 1,
+        userId: sellerId,
+      }}
     />
   );
 }

--- a/apps/main/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/page.tsx
+++ b/apps/main/src/app/(public)/[userSlugOrId]/[listingSlugOrId]/page.tsx
@@ -232,6 +232,8 @@ export default async function PublicListingPage({ params }: PageProps) {
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
         <PublicListingContactButton
           listingId={listing.id}
+          listingTitle={listing.title}
+          listingPrice={listing.price}
           sellerId={listing.userId}
           sellerName={listing.sellerTitle ?? undefined}
         />

--- a/apps/main/src/components/contact-form.tsx
+++ b/apps/main/src/components/contact-form.tsx
@@ -43,24 +43,40 @@ import {
 
 interface ContactFormProps {
   userId: string;
+  inquiryItem?: CartItem;
   onSubmitSuccess?: () => void;
 }
 
-export function ContactForm({ userId, onSubmitSuccess }: ContactFormProps) {
+export function ContactForm({
+  userId,
+  inquiryItem,
+  onSubmitSuccess,
+}: ContactFormProps) {
   return (
     <TRPCReactProvider>
-      <ContactFormContent userId={userId} onSubmitSuccess={onSubmitSuccess} />
+      <ContactFormContent
+        userId={userId}
+        inquiryItem={inquiryItem}
+        onSubmitSuccess={onSubmitSuccess}
+      />
     </TRPCReactProvider>
   );
 }
 
-function ContactFormContent({ userId, onSubmitSuccess }: ContactFormProps) {
+function ContactFormContent({
+  userId,
+  inquiryItem,
+  onSubmitSuccess,
+}: ContactFormProps) {
   const { items, updateQuantity, removeItem, clearCart, total } =
     useCart(userId);
+  const hasInquiryItem = Boolean(
+    inquiryItem && !items.some((item) => item.id === inquiryItem.id),
+  );
   const { customerInfo, updateCustomerInfo } = useCustomerInfo();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showClearCartDialog, setShowClearCartDialog] = useState(false);
-  const hasItems = items.length > 0;
+  const hasItems = hasInquiryItem || items.length > 0;
 
   const sendMessage = api.public.sendMessage.useMutation({
     onSuccess: () => {
@@ -120,12 +136,12 @@ function ContactFormContent({ userId, onSubmitSuccess }: ContactFormProps) {
 
   // Update form when cart items change
   useEffect(() => {
-    form.setValue("hasItems", items.length > 0, {
+    form.setValue("hasItems", hasItems, {
       shouldDirty: false,
       shouldTouch: false,
       shouldValidate: true,
     });
-  }, [items.length, form]);
+  }, [hasItems, form]);
 
   const onSubmit = (data: ContactFormWithCartData) => {
     setIsSubmitting(true);
@@ -136,29 +152,14 @@ function ContactFormContent({ userId, onSubmitSuccess }: ContactFormProps) {
       name: data.name ?? "",
     });
 
-    // Format cart items for the message
-    let formattedMessage = data.message ?? "";
-
-    if (items.length > 0) {
-      formattedMessage += "\n\n--- Cart Items ---\n";
-      items.forEach((item) => {
-        formattedMessage += `\n${item.quantity}x ${item.title}`;
-        if (item.price) {
-          formattedMessage += ` (${formatPrice(item.price)} each)`;
-        }
-      });
-      formattedMessage += `\n\nSubtotal: ${formatPrice(total)}`;
-      formattedMessage +=
-        "\n\nNote: Final pricing, shipping, and handling may vary at the discretion of the seller.";
-    }
-
     // Send the message
     sendMessage.mutate({
       userId: data.userId,
       customerEmail: data.email,
       customerName: data.name ?? "",
-      message: formattedMessage,
-      items: items,
+      message: data.message ?? "",
+      items,
+      inquiryItem: hasInquiryItem ? inquiryItem : undefined,
     });
   };
 
@@ -227,6 +228,18 @@ function ContactFormContent({ userId, onSubmitSuccess }: ContactFormProps) {
                 </FormItem>
               )}
             />
+
+            {hasInquiryItem && inquiryItem && (
+              <div className="border-border rounded-md border p-4">
+                <h3 className="mb-2 font-medium">About this listing</h3>
+                <p>{inquiryItem.title}</p>
+                <p className="text-muted-foreground text-sm">
+                  {inquiryItem.price === null
+                    ? "Price not provided"
+                    : formatPrice(inquiryItem.price)}
+                </p>
+              </div>
+            )}
 
             {items.length > 0 && (
               <div className="border-border rounded-md border p-4">

--- a/apps/main/src/components/floating-cart-button.tsx
+++ b/apps/main/src/components/floating-cart-button.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { ShoppingCart, MessageCircle } from "lucide-react";
 import { ContactForm } from "@/components/contact-form";
+import { type CartItem } from "@/types";
 import { useState } from "react";
 
 interface FloatingCartButtonProps {
@@ -18,6 +19,7 @@ interface FloatingCartButtonProps {
   userName?: string;
   showTopButton?: boolean;
   onContactClick?: () => void;
+  inquiryItem?: CartItem;
 }
 
 export function FloatingCartButton({
@@ -25,9 +27,11 @@ export function FloatingCartButton({
   userName,
   showTopButton = false,
   onContactClick,
+  inquiryItem,
 }: FloatingCartButtonProps) {
   const { itemCount } = useCart(userId);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [includeInquiryItem, setIncludeInquiryItem] = useState(false);
 
   return (
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
@@ -36,6 +40,7 @@ export function FloatingCartButton({
           type="button"
           className="w-full sm:w-auto"
           onClick={() => {
+            setIncludeInquiryItem(true);
             onContactClick?.();
             setIsDialogOpen(true);
           }}
@@ -54,7 +59,10 @@ export function FloatingCartButton({
           type="button"
           className="fixed right-4 bottom-[calc(2.5rem+env(safe-area-inset-bottom))] z-50 flex items-center gap-2 rounded-full shadow-md"
           variant="default"
-          onClick={onContactClick}
+          onClick={() => {
+            setIncludeInquiryItem(false);
+            onContactClick?.();
+          }}
           aria-label={
             itemCount > 0
               ? `Contact seller and view cart (${itemCount} ${itemCount === 1 ? "item" : "items"})`
@@ -84,6 +92,7 @@ export function FloatingCartButton({
         </DialogDescription>
         <ContactForm
           userId={userId}
+          inquiryItem={includeInquiryItem ? inquiryItem : undefined}
           onSubmitSuccess={() => setIsDialogOpen(false)}
         />
       </DialogContent>

--- a/apps/main/src/server/api/routers/public.ts
+++ b/apps/main/src/server/api/routers/public.ts
@@ -30,6 +30,7 @@ const publicInquiryInputSchema = z.object({
   customerName: z.string().max(120).optional(),
   message: z.string().max(5000),
   items: z.array(publicInquiryCartItemSchema).max(25).optional(),
+  inquiryItem: publicInquiryCartItemSchema.optional(),
 });
 
 export const publicRouter = createTRPCRouter({

--- a/apps/main/src/server/services/public-inquiry.ts
+++ b/apps/main/src/server/services/public-inquiry.ts
@@ -14,6 +14,7 @@ export interface SendPublicInquiryInput {
   customerName?: string;
   message: string;
   items?: CartItem[];
+  inquiryItem?: CartItem;
 }
 
 export interface SendPublicInquiryOptions {
@@ -32,7 +33,7 @@ interface PublicInquiryContext {
   sellerNameForSellerEmail: string;
   sellerNameForCustomerEmail: string;
   sellerSubjectName: string;
-  subtotal: number;
+  subtotal: string;
 }
 
 function getSesClient() {
@@ -79,14 +80,15 @@ function formatCartItems(items: CartItem[] | undefined) {
     return {
       hasCartItems: false,
       formattedItems: "(No items selected)",
-      subtotal: 0,
+      subtotal: "$0.00",
     };
   }
 
-  const subtotal = items.reduce(
-    (sum, item) => sum + (item.price ?? 0) * item.quantity,
-    0,
-  );
+  const subtotal = items.some((item) => item.price === null)
+    ? "Price not provided"
+    : `$${items
+        .reduce((sum, item) => sum + (item.price ?? 0) * item.quantity, 0)
+        .toFixed(2)}`;
   const formattedItems = items
     .map(
       (item) =>
@@ -104,20 +106,23 @@ function formatCartItems(items: CartItem[] | undefined) {
 }
 
 async function resolveCartItems(input: SendPublicInquiryInput) {
-  if (!input.items?.length) {
-    return { items: input.items, hadOmittedItems: false };
+  const requestedItems = input.inquiryItem
+    ? [input.inquiryItem, ...(input.items ?? [])]
+    : input.items;
+  if (!requestedItems?.length) {
+    return { items: requestedItems, hadOmittedItems: false };
   }
 
   const listings = await db.listing.findMany({
     where: {
-      id: { in: [...new Set(input.items.map((item) => item.listingId))] },
+      id: { in: [...new Set(requestedItems.map((item) => item.listingId))] },
       userId: input.userId,
       ...isPublished(),
     },
     select: { id: true, title: true, price: true },
   });
   const listingById = new Map(listings.map((listing) => [listing.id, listing]));
-  const items = input.items.flatMap((item) => {
+  const items = requestedItems.flatMap((item) => {
     const listing = listingById.get(item.listingId);
     return listing
       ? [{ ...item, title: listing.title, price: listing.price }]
@@ -131,7 +136,7 @@ async function resolveCartItems(input: SendPublicInquiryInput) {
     });
   }
 
-  return { items, hadOmittedItems: items.length !== input.items.length };
+  return { items, hadOmittedItems: items.length !== requestedItems.length };
 }
 
 async function loadPublicInquiryContext(
@@ -213,7 +218,7 @@ ${
     ? `Customer's Selected Items:
 ${context.formattedItems}${context.hadOmittedItems ? "\n\nOne or more unavailable items were omitted." : ""}
 
-Subtotal: $${context.subtotal.toFixed(2)}
+Subtotal: ${context.subtotal}
 Note: Final pricing, shipping, and handling are at your discretion.`
     : "No items were selected."
 }
@@ -253,7 +258,7 @@ ${
     ? `Items you're interested in:
 ${context.formattedItems}${context.hadOmittedItems ? "\n\nOne or more unavailable items were omitted." : ""}
 
-Subtotal: $${context.subtotal.toFixed(2)}
+Subtotal: ${context.subtotal}
 (Note: Final pricing, shipping, and handling may vary at the discretion of the seller.)`
     : ""
 }

--- a/apps/main/tests/integration/buyer-inquiry-email.integration.ts
+++ b/apps/main/tests/integration/buyer-inquiry-email.integration.ts
@@ -65,4 +65,10 @@ test("buyer inquiry sends the seller and buyer emails", async ({
       }),
     ]),
   );
+
+  for (const email of emails) {
+    expect(email.text).toContain("Existing Bloom");
+    expect(email.text).toContain("Subtotal: Price not provided");
+    expect(email.text).not.toContain("No items selected");
+  }
 });


### PR DESCRIPTION
## Summary

- Include the current listing when a buyer opens Contact Seller from a listing page.
- Keep cart-only inquiries unchanged and avoid duplicate listing rows.
- Show `Price not provided` for inquiries about listings without a price.

## Root cause

The listing-page contact button opened the generic cart form without passing the current listing. A buyer could submit a listing-specific message while the email reported that no items were selected.

## Files

- Listing page actions: pass the listing ID, title, and price to the contact dialog.
- Contact form and button: include listing context only from the listing-page button.
- Public inquiry router and service: validate the listing against current database data and format nullable prices.
- Integration test: verify both captured emails include the unpriced listing.

## Validation

- `pnpm exec vitest run tests/contact-form.test.tsx tests/floating-cart-button.test.tsx tests/public-inquiry.test.ts tests/public-router-send-message.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with one pre-existing dashboard hook warning)
- `WATCHPACK_POLLING=true INTEGRATION_PORT=3223 node apps/main/scripts/run-integration-local.mjs tests/integration/buyer-inquiry-email.integration.ts`
- Codex review: no actionable findings after fixes
