### PR TITLE
Defer membership pricing until growers are ready to publish

### DIFF
--- a/apps/main/src/app/start-membership/page.tsx
+++ b/apps/main/src/app/start-membership/page.tsx
@@ -8,17 +8,10 @@ import {
   SellerLandingViewTracker,
 } from "./_components/seller-landing-actions";
 import { PRO_FEATURES, METADATA_CONFIG } from "@/config/constants";
-import {
-  getSubscriptionPriceCopy,
-  SUBSCRIPTION_CONFIG,
-} from "@/config/subscription-config";
+import { SUBSCRIPTION_CONFIG } from "@/config/subscription-config";
 import { IMAGES } from "@/lib/constants/images";
 import { getCanonicalBaseUrl } from "@/lib/utils/getBaseUrl";
 import { serializeJsonLd } from "@/lib/utils/json-ld";
-import {
-  getMembershipPriceDisplay,
-  type MembershipPriceDisplay,
-} from "@/server/stripe/get-membership-price-display";
 import { UsedByWave } from "@/components/used-by-wave";
 import { LaurelRatingBadge } from "@/components/laurel-rating-badge";
 import {
@@ -113,8 +106,8 @@ const FAQ_ITEMS = [
       "No. Daylily Catalog does not process buyer payments. You handle the sale directly.",
   },
   {
-    question: SUBSCRIPTION_CONFIG.COPY.MARKETING.TRIAL_FAQ_QUESTION,
-    answer: SUBSCRIPTION_CONFIG.COPY.MARKETING.TRIAL_FAQ_ANSWER,
+    question: SUBSCRIPTION_CONFIG.COPY.MARKETING.MEMBERSHIP_FAQ_QUESTION,
+    answer: SUBSCRIPTION_CONFIG.COPY.MARKETING.MEMBERSHIP_FAQ_ANSWER,
   },
   {
     question: "Can I build my catalog before publishing?",
@@ -146,10 +139,9 @@ function createFaqSchema(baseUrl: string) {
   };
 }
 
-export default async function StartMembershipPage() {
+export default function StartMembershipPage() {
   const baseUrl = getCanonicalBaseUrl();
   const faqSchema = createFaqSchema(baseUrl);
-  const membershipPriceDisplay = await getMembershipPriceDisplay();
 
   return (
     <div className="min-h-svh overflow-hidden">
@@ -160,7 +152,7 @@ export default async function StartMembershipPage() {
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(faqSchema) }}
       />
 
-      <StartMembershipHero membershipPriceDisplay={membershipPriceDisplay} />
+      <StartMembershipHero />
 
       <GrowerTestimonialsSection />
 
@@ -177,13 +169,7 @@ export default async function StartMembershipPage() {
   );
 }
 
-function StartMembershipHero({
-  membershipPriceDisplay,
-}: {
-  membershipPriceDisplay: MembershipPriceDisplay;
-}) {
-  const priceCopy = getSubscriptionPriceCopy(membershipPriceDisplay);
-
+function StartMembershipHero() {
   return (
     <MarketingHero>
       <MarketingHeroContent
@@ -203,9 +189,8 @@ function StartMembershipHero({
           </h1>
 
           <p className="mt-6 max-w-[34rem] text-xl leading-8 font-medium text-pretty text-[#dfe9dc] lg:mt-4 lg:text-lg lg:leading-7">
-            Add photos, prices, availability, notes, and contact info. Build and
-            preview your catalog first.{" "}
-            {SUBSCRIPTION_CONFIG.COPY.MARKETING.HERO_TRIAL}
+            Add photos, prices, availability, notes, and contact info.{" "}
+            {SUBSCRIPTION_CONFIG.COPY.MARKETING.HERO}
           </p>
 
           <div className="mt-8 flex flex-col gap-4 lg:mt-5 lg:flex-row lg:gap-5">
@@ -230,17 +215,17 @@ function StartMembershipHero({
         </div>
 
         <div
-          id="pricing"
+          id="membership"
           className="border-y border-white/28 py-6 text-white backdrop-blur-[2px] lg:border-y-0 lg:border-l lg:py-1 lg:pl-10"
         >
           <p className="text-sm font-bold tracking-[0.18em] text-[#f4c477] uppercase">
             Grower membership
           </p>
-          <p className="mt-4 text-6xl leading-none font-bold tracking-tight text-white">
-            {priceCopy.recurringPrice}
-          </p>
+          <h2 className="mt-4 text-4xl leading-tight font-semibold tracking-normal text-white lg:text-5xl">
+            Publish when you are ready
+          </h2>
           <p className="mt-3 max-w-lg text-lg leading-7 text-[#dfe9dc]">
-            {SUBSCRIPTION_CONFIG.COPY.MARKETING.TRIAL_PRICE}
+            {SUBSCRIPTION_CONFIG.COPY.MARKETING.VALUE_PANEL}
           </p>
 
           <div className="mt-6 grid gap-4 border-t border-white/22 pt-5">

--- a/apps/main/src/app/start-membership/page.tsx
+++ b/apps/main/src/app/start-membership/page.tsx
@@ -215,7 +215,7 @@ function StartMembershipHero() {
         </div>
 
         <div
-          id="membership"
+          id="pricing"
           className="border-y border-white/28 py-6 text-white backdrop-blur-[2px] lg:border-y-0 lg:border-l lg:py-1 lg:pl-10"
         >
           <p className="text-sm font-bold tracking-[0.18em] text-[#f4c477] uppercase">

--- a/apps/main/src/config/subscription-config.ts
+++ b/apps/main/src/config/subscription-config.ts
@@ -109,15 +109,16 @@ export const SUBSCRIPTION_CONFIG = {
     },
     MARKETING: {
       FINAL_CTA:
-        "Build and preview your catalog, start your trial, then open your dashboard.",
-      HERO_TRIAL: `Start a ${TRIAL_DURATION} trial before your dashboard opens.`,
-      HOW_IT_WORKS_TITLE: "Build first. Start your trial when ready.",
+        "Build and preview your catalog. Choose a paid membership when you are ready to publish.",
+      HERO: "Build and preview your catalog first. Choose a membership when you are ready to publish.",
+      HOW_IT_WORKS_TITLE: "Build first. Publish when you are ready.",
+      MEMBERSHIP_FAQ_ANSWER:
+        "Build and preview your catalog for free. Choose a paid membership when you are ready to publish it.",
+      MEMBERSHIP_FAQ_QUESTION: "When do I choose a membership?",
       PUBLISH_STEP:
-        "Start your trial, choose your public URL, and import the ready listings.",
-      TRIAL_FAQ_ANSWER:
-        "The trial starts at checkout, before your dashboard opens.",
-      TRIAL_FAQ_QUESTION: "When does my free trial start?",
-      TRIAL_PRICE: `Start your ${TRIAL_DURATION} trial before your paid dashboard opens.`,
+        "Choose a paid membership, select your public URL, and import the ready listings.",
+      VALUE_PANEL:
+        "Build and preview first. Choose a paid membership only when you are ready to publish your catalog.",
     },
     STATUS: {
       ACTIVE_DESCRIPTION:

--- a/apps/main/tests/atlas/onboarding-membership.atlas.ts
+++ b/apps/main/tests/atlas/onboarding-membership.atlas.ts
@@ -60,6 +60,22 @@ test("Membership offer", async ({ page }) => {
       name: "Your whole daylily catalog. One link buyers can browse.",
     }),
   ).toBeVisible();
+  await expect(
+    page.getByRole("heading", {
+      exact: true,
+      name: "Publish when you are ready",
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Build and preview your catalog first. Choose a membership when you are ready to publish.",
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Create your catalog" }).first(),
+  ).toHaveAttribute("href", "/catalog-importer");
+  await expect(page.locator("body")).not.toContainText(/\btrial\b/i);
+  await expect(page.locator("body")).not.toContainText(/\$\s*\d/);
   await captureAtlasState(page, "onboarding-membership-offer");
 });
 

--- a/apps/main/tests/subscription-config.test.ts
+++ b/apps/main/tests/subscription-config.test.ts
@@ -73,4 +73,44 @@ describe("subscription offer configuration", () => {
 
     expect(violations).toEqual([]);
   });
+
+  it("keeps the start-membership page focused on previewing before purchase", () => {
+    const pageSource = readFileSync(
+      path.join(
+        process.cwd(),
+        "src",
+        "app",
+        "start-membership",
+        "page.tsx",
+      ),
+      "utf8",
+    );
+    const marketingCopy = Object.values(
+      SUBSCRIPTION_CONFIG.COPY.MARKETING,
+    ).join(" ");
+
+    expect(SUBSCRIPTION_CONFIG.COPY.MARKETING).toMatchObject({
+      HERO:
+        "Build and preview your catalog first. Choose a membership when you are ready to publish.",
+      MEMBERSHIP_FAQ_ANSWER:
+        "Build and preview your catalog for free. Choose a paid membership when you are ready to publish it.",
+      MEMBERSHIP_FAQ_QUESTION: "When do I choose a membership?",
+    });
+    expect(SUBSCRIPTION_CONFIG.PATHS.NEW_USER_ONBOARDING).toBe(
+      "/catalog-importer",
+    );
+    expect(pageSource).toContain("<SellerLandingOnboardingCta");
+    expect(pageSource).toContain("Publish when you are ready");
+    expect(pageSource).not.toMatch(/\btrial\b/i);
+    expect(pageSource).not.toMatch(/\$\s*\d/);
+    expect(marketingCopy).not.toMatch(/\btrial\b/i);
+    expect(marketingCopy).not.toMatch(/[$€£]\s*\d/);
+    expect(marketingCopy).not.toMatch(/\/(?:mo|month|yr|year)\b/i);
+    expect(marketingCopy).not.toMatch(
+      /\b(?:annual|monthly|per month|per year|yearly)\b/i,
+    );
+    expect(pageSource).not.toContain("getMembershipPriceDisplay");
+    expect(pageSource).not.toContain("membershipPriceDisplay");
+    expect(pageSource).not.toContain("getSubscriptionPriceCopy");
+  });
 });


### PR DESCRIPTION
## Summary

- Keep the current `/start-membership` hero layout, but replace the price presentation with a preview-first value panel.
- Tell growers to build and preview a catalog before they choose a paid membership.
- Remove price, interval, and trial language from this marketing page.
- Preserve all calls to action, routes, the `#pricing` anchor, checkout behavior, the existing trial, importer paywall behavior, dashboard behavior, and analytics.

## Files

- `apps/main/src/app/start-membership/page.tsx`: Remove the Stripe price fetch and display prop. Add the value panel and update hero, process, FAQ, and final call-to-action copy. Preserve `id="pricing"` and the existing CTA targets.
- `apps/main/src/config/subscription-config.ts`: Replace marketing-only trial copy with preview-first membership copy. Remove obsolete marketing trial entries.
- `apps/main/tests/subscription-config.test.ts`: Add a focused contract for the new copy, the absence of price and trial language, the removed price fetch, and the existing catalog importer target.
- `apps/main/tests/atlas/onboarding-membership.atlas.ts`: Strengthen only the existing Membership offer state with the preview-first copy, importer link, and no-price/no-trial assertions.

## Verification

- Focused marketing/importer Vitest suites: 6 files, 37 tests passed.
- Current focused rerun: 3 files, 23 tests passed.
- Atlas metadata tests: 17 tests passed.
- `node apps/main/scripts/run-integration-local.mjs tests/integration/catalog-importer-checkout-provider-boundaries.integration.ts`: 2 tests passed.
- `pnpm main test:e2e -- --retries=0 tests/e2e/catalog-importer-onboarding.e2e.ts`: 1 test passed.
- Origin/main Atlas baseline: `onboarding-membership`, 5 states passed.
- PR Atlas rerun: `onboarding-membership`, 5 states passed.
- Visible Chrome after walkthrough: home CTA to `/start-membership`, loaded page media, membership FAQ, and `/catalog-importer` CTA verified. The live Next development-tools menu listed no issue entries, and Chrome reported no warning or error logs.
- `pnpm main lint`: passed with 0 errors and one unrelated existing `react-hooks/exhaustive-deps` warning in `dashboard-db-provider.tsx:450`.
- `pnpm typecheck`: passed.
- `git diff --check`: passed.

## Verification notes

The first full-app integration attempt in the active worktree hit the host Watchpack limit: `EMFILE: too many open files, watch`. The same command and PR state passed in the isolated worktree with no competing watcher on that path.

The clean origin/main Atlas capture is the retained visual baseline. The initial visible-Chrome baseline capture loaded lazy example-card media too late, and the initial saved development-tools image was taken after the server stopped, so both invalid PNGs were excluded instead of being presented as clean evidence. The browser control log still records the baseline walkthrough. The final after Chrome capture has all affected media loaded and a readable live development-tools menu.